### PR TITLE
chore: give shelved work a state, and mark the gix abort done

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,9 +72,15 @@ Milestone: [Phase 2](https://github.com/breferrari/vigia/milestone/2)
 | ⬜ | I5 correct with zero interaction | [#6](https://github.com/breferrari/vigia/issues/6) |
 | ⬜ | I6 legible at 40 columns | [#7](https://github.com/breferrari/vigia/issues/7) |
 | ⬜ | I8 terminal restored exactly on exit | [#8](https://github.com/breferrari/vigia/issues/8) |
-| ⬜ | A truncated `.git/index` aborts instead of reporting | [#13](https://github.com/breferrari/vigia/issues/13) |
+| ✅ | A truncated `.git/index` aborts instead of reporting | [#13](https://github.com/breferrari/vigia/issues/13) |
 | ⬜ | I2b re-highlight only changed hunks (`syntect`) | [#4](https://github.com/breferrari/vigia/issues/4) |
 | ⬜ | I3 flat resources over days (soak) | [#5](https://github.com/breferrari/vigia/issues/5) |
+
+**Start with [#9](https://github.com/breferrari/vigia/issues/9), the shell.** The
+other rows render what it draws, so they cannot be tested before it exists. I8 is
+the exception and can go first if preferred: terminal restoration on exit is
+provable against a bare alternate-screen harness, and #13's abort is already
+covered by it.
 
 ## Phase 3 — glanceability
 
@@ -92,6 +98,23 @@ Milestone: [Phase 4](https://github.com/breferrari/vigia/milestone/4)
 | | Task | Issue |
 |---|---|---|
 | ⬜ | `cargo-dist`, crates.io, Homebrew tap | [#12](https://github.com/breferrari/vigia/issues/12) |
+
+## Phase 5 — deferred findings
+
+Milestone: [Phase 5](https://github.com/breferrari/vigia/milestone/5)
+
+Everything on the deferral shelf below has a milestone here, so shelved work is
+still reachable by a milestone-filtered query rather than only readable in prose.
+The shelf carries the *reason*; this table carries the *state*.
+
+| | Task | Issue |
+|---|---|---|
+| ⬜ | A symlink diffs as its target's contents | [#15](https://github.com/breferrari/vigia/issues/15) |
+| ⬜ | The fingerprint cannot see a timestamp-preserving write | [#16](https://github.com/breferrari/vigia/issues/16) |
+| ⬜ | Two paths differing outside UTF-8 collapse onto one cache key | [#17](https://github.com/breferrari/vigia/issues/17) |
+| ⬜ | A frame reads a whole file to discover it is binary | [#18](https://github.com/breferrari/vigia/issues/18) |
+| ⬜ | An idle frame is one `stat` per changed file | [#19](https://github.com/breferrari/vigia/issues/19) |
+| ⬜ | `take-next`: pre-flight the spec against the tracker | [#20](https://github.com/breferrari/vigia/issues/20) |
 
 ---
 


### PR DESCRIPTION
Housekeeping so Phase 2 can be taken cleanly. No code.

All three items were found by an automated drift check now running at session end, not by reading the files.

## What was wrong

**#13 shipped but its row was still unchecked.** The issue closed at 11:36; the Phase 2 table still said `⬜`.

**Shelved findings had a milestone but no table.** #15 through #19 were assigned to Phase 5 and appeared only in the deferral shelf's prose. A work-taking query filters by milestone and would have returned them, but nothing in the plan showed their *state*, so "what is outstanding on the shelf" was unanswerable without opening six issues.

**#20 was in neither.** Milestoned, but absent from the roadmap entirely.

## What changed

A **Phase 5 section**, so the shelf and the tracker agree: the shelf explains why an item moved, the table shows where it stands. Both are needed and they are different questions.

Phase 2 now states **where to start**: the shell, because the other rows render what it draws and cannot be tested before it exists. I8 is named as the exception that can go first, since terminal restoration is provable against a bare alternate-screen harness and #13's abort path is already covered by it.

## Verification

The drift check reports **no drift** against this branch, across all six directions: an invariant with no issue, an issue naming an invariant the spec dropped, an unmilestoned open issue, an open issue absent from the roadmap, a status row disagreeing with its issue, and a roadmap deferring to a milestone that does not exist.
