### PR TITLE
spec: say what it does, not only how well it does it

### DIFF
--- a/.claude/skills/take-next/SKILL.md
+++ b/.claude/skills/take-next/SKILL.md
@@ -116,15 +116,35 @@ task is worse than one session idle.
 
 ## 2. Load the why before touching code
 
-The issue carries acceptance criteria. `SPEC.md` carries the contract. The
-reasoning behind both is outside the repo, through the `vigil` MCP server:
+**Read the repo first.** The issue carries acceptance criteria, `SPEC.md` carries
+the contract, and — unusually for a repo — a great deal of the *reasoning* is here
+too: §10's open questions carry their measurements, the invariant callouts explain
+why they split, and the commit messages argue rather than announce. Most "why did
+we do it this way" questions are answered inside the checkout.
 
-- `search` for the decision you are about to touch
-- `recall` for accumulated constraints, remembering it is empty early and that
-  empty is not evidence of no record
+Then reach outside it, through the `vigil` MCP server, for the three things the
+repo deliberately does **not** hold:
 
-Read before deciding. A choice re-derived from scratch that contradicts a
-recorded one is the single most expensive mistake available here.
+- **What cannot be public.** This repo is public. The competitive read, the market
+  position, the objection this project was started against — none of that belongs
+  in a file anyone can clone, and it is the reason the vault exists at all.
+- **What generalises past this repo.** A `gix` limitation or a measurement trap is
+  true for every Rust project, so it lives where other projects can reach it.
+- **What predates or outlives the code.** Why this is monitor-class rather than
+  review-class was decided before the first commit, and re-deriving it is the most
+  expensive mistake available here.
+
+```
+search   the decision you are about to touch
+recall   accumulated constraints — empty early, and empty is not evidence of none
+```
+
+**Consulting the vault is deliberate, not reflexive.** Reaching for it when the
+answer is in `SPEC.md` wastes a call; reaching for it out of habit while writing a
+*public* commit message loads strategic context that must never land in one. That
+direction is the one with a hook guarding it, because a squash commit merged to a
+public `main` stays reachable by SHA forever. Know which of the three you are
+asking for before you ask.
 
 ## 3. Plan it, in plan mode, before touching code
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,6 +93,14 @@ with: there are 40- and 80-column snapshots already, and what I6 still needs is
 the assertions that make it an invariant rather than a screenshot. A diff line
 does lose its tail at 40 columns today.
 
+**[#6](https://github.com/breferrari/vigia/issues/6) is blocked on a decision, not
+on code.** I5 promises the view follows the newest change untouched, and no follow
+mode exists yet, so what happens when the reader scrolls is undecided — `SPEC.md`
+§11.2 **B1**. Implementing #6 first would settle it accidentally inside a snapshot
+test, which is how a behaviour becomes permanent without anyone choosing it. Rule
+on B1, then take #6. **B2** — which file wins when a batch changes several — is
+the same decision one layer down and lands with it.
+
 ## Phase 3 — glanceability
 
 Milestone: [Phase 3](https://github.com/breferrari/vigia/milestone/3)

--- a/SPEC.md
+++ b/SPEC.md
@@ -323,3 +323,122 @@ tap, prebuilt binaries on GitHub releases.
       thesis; confirm against a week of real use.
 - [ ] Windows: supported target or best-effort? Truecolor needs Win10+, and
       legacy conhost degrades.
+
+## 11. Behaviour
+
+§3 says how well `vigia` does things. Every number in it is defensible and every
+one has a test. Nothing above says **what happens when you press a key, or when
+nothing has changed** — and that gap is why the product reads as a screenshot
+with budgets attached.
+
+Two parts: what the shell already does, recorded because it was decided in code
+first, and what is still undecided.
+
+> [!warning] Behaviour decided in code without a line here is a defect
+> The README says this file is the source of truth, written before the code. That
+> was **not true** for the whole interaction surface on 2026-07-30: the keymap and
+> the treatment of untracked files were both settled in implementation and appear
+> nowhere above. §11.1 repays that, and the rule it leaves behind is the same
+> shape as §3's: **an invariant without a failing test is a wish, and a behaviour
+> without a spec line is an accident.** Neither is caught by `take-next`'s
+> pre-flight, which compares invariant tokens rather than behaviour.
+
+### 11.1 What the shell does today
+
+Back-filled from the implementation on 2026-07-30, not newly decided. Where this
+disagrees with the code, the code is the bug.
+
+**What the diff contains.** Working tree against the index. **Untracked files are
+included** and diff as all-additions — load-bearing rather than incidental, since
+creating new files is among the most common things an agent does, and a tool blind
+to them would miss its own use case. Rename tracking is **on by default**: showing
+a move as an unrelated delete plus add misdescribes what the agent did. Its
+streaming cost is the open question in §10, not a settled trade.
+
+**Keys.**
+
+| Key | Action |
+|---|---|
+| `q`, `Esc`, `Ctrl-C`, `Ctrl-D` | quit |
+| `j`, `↓` | scroll down one row |
+| `k`, `↑` | scroll up one row |
+| `Space`, `PgDn` | page down |
+| `PgUp` | page up |
+| `g`, `Home` | first changed file |
+| `G`, `End` | last changed file |
+| mouse wheel | scroll |
+| terminal resize | redraw, no state change |
+
+**Scroll position is `(file, offset within that file)`, never a row index.** A
+frame that changes something above the viewport therefore does not teleport the
+view. This is a correctness property, not an implementation detail: with a row
+index, an agent writing to a file earlier in the list would yank the reader's
+position on every keystroke it makes.
+
+**CLI.** One optional positional path, defaulting to the working directory. No
+flags today.
+
+### 11.2 Undecided — these gate Phase 2
+
+Each carries a recommendation marked **(proposed)**. None is settled until ruled
+on, and none may contradict §3 — if one does, §3 wins and the recommendation is
+wrong.
+
+**B1 — What happens to follow mode when the reader scrolls.** I5 promises the
+view "auto-follows the newest change and scrolls to it, untouched", and **no
+follow mode exists in the code yet** — `Action` is quit, scroll, page, top,
+bottom, redraw. So the relationship between following and scrolling is genuinely
+open, and [#6](https://github.com/breferrari/vigia/issues/6) will otherwise
+settle it by accident inside a snapshot test.
+
+*(proposed)* `less +F` semantics. Follow is **on** at startup; **any manual
+scroll disengages it**; `G` / `End` re-engages, since "go to the newest thing" is
+already that key. The status bar states which mode is active. Rationale: it is
+the idiom every terminal user already has, disengage-on-scroll is the only rule
+that never fights a reader mid-read, and re-engaging costs a keystroke that
+already exists rather than a new binding.
+
+**B2 — Which file wins when several change at once.** An agent rewriting five
+files in one action is the normal case, not an edge case. "The newest change" is
+ambiguous the moment a batch coalesces.
+
+*(proposed)* Follow the file whose write landed **last** in the settled batch,
+and let §5's visual pulse carry the others. Rationale: it reads "newest"
+literally, it is stable rather than heuristic, and the pulse already exists to
+say "these moved too" without moving the viewport for each.
+
+**B3 — The empty state.** Zero changes is not an edge case; it is the state the
+tool sits in most of the time, and it is the **first** thing anyone sees when
+they open it beside an agent that has not written yet. A blank pane is
+indistinguishable from a hang.
+
+*(proposed)* Name it: repository, branch, "no changes", and an explicit statement
+that it is watching. This screen is the product's first impression and currently
+has no specification at all.
+
+**B4 — Is the file list navigable?** The README mockup shows a file list above
+the diff. Selectable, with the diff jumping to the selection, or a map rather
+than a menu?
+
+*(proposed)* **Not navigable in v1** — one continuous scroll, list as map.
+Rationale: selection implies focus, focus implies a second mode, and modes are
+reviewer-class (§2). The pane is 40 columns beside an agent, not a full-screen
+client.
+
+**B5 — Not a git repository, and submodules.** Neither appears anywhere in this
+spec.
+
+*(proposed)* Not a repository: exit non-zero with one line, **before** entering
+the alternate screen — an error painted inside a TUI that then restores the
+terminal is an error nobody reads. Submodules: out of v1, shown as an opaque
+directory and said so, because recursing into them costs the incremental
+guarantees in I2a.
+
+**B6 — CLI surface and configuration.** No flags exist; §5 theming arrives in
+Phase 3 with nowhere to configure it.
+
+*(proposed)* Hold the CLI at one positional path plus `--version` / `--help`
+through v1, and add flags only when something asks for one. Configuration lands
+**with** theming in Phase 3, not before: a config file with one thing in it
+invites a second thing, and every option is a behaviour that needs a line in this
+section.


### PR DESCRIPTION
Two documents that had stopped being true, in opposite directions.

## `SPEC.md` §11 — Behaviour

Nine invariants, each with an absolute budget and a test that fails when it is
missed, and nothing anywhere saying **what happens when you press a key, or when
nothing has changed**. The spec was a non-functional contract with no functional
half.

### 11.1 — back-filled, not newly decided

Worse than a gap. Two behaviours were settled in code and appear nowhere in the
spec, while the README says this file is written before the code:

- **untracked files are included** and diff as all-additions
  (`worktree.rs`, `UntrackedFiles::Files`) — load-bearing, since creating new
  files is among the most common things an agent does
- **the full keymap** — `q`/`Esc`/`Ctrl-C`/`Ctrl-D`, `j`/`k`, `Space`/`PgUp`/`PgDn`,
  `g`/`G`, wheel, resize

Also recorded: scroll position is `(file, offset within file)`, never a row index
— a correctness property, because with a row index an agent writing above the
viewport would yank the reader's position on every keystroke it makes.

The rule this leaves is the sibling of one §3 already carries: **an invariant
without a failing test is a wish, and a behaviour without a spec line is an
accident.** Note that `take-next`'s new pre-flight catches neither — it compares
invariant tokens and never looks at behaviour.

### 11.2 — six open decisions, none settled

Each has a **(proposed)** answer to argue with, not a ruling.

**B1 blocks [#6](https://github.com/breferrari/vigia/issues/6).** I5 promises the
view follows the newest change untouched, and **no follow mode exists in the code
at all** — `Action` is quit/scroll/page/top/bottom/redraw. So what happens when
the reader scrolls is undecided, and implementing #6 first would fix it forever
inside a snapshot test without anyone choosing it. Proposed: `less +F` semantics.

**B3 is the quiet one.** Zero changes is the state the tool sits in most of the
time, and the first screen anyone sees when they open it beside an agent that has
not written yet. It had no specification whatsoever, and a blank pane is
indistinguishable from a hang.

B2 (which file wins when a batch changes several), B4 (is the file list
navigable), B5 (not-a-repo, submodules), B6 (CLI surface and config) are the rest.

`ROADMAP.md` now says #6 is blocked on a decision rather than on code.

## `take-next` §2 — the opposite error

It said *"the reasoning behind both is outside the repo, through the `vigil` MCP
server."* That is no longer true. §10's open questions carry their measurements,
the invariant callouts explain why they split, and the commit messages argue
rather than announce — most "why is it this way" questions are answered inside
the checkout.

Rewritten to: **read the repo first**, then reach outside it for the three things
the repo deliberately does not hold — what cannot be public, what generalises past
this repo, and what predates the code.

With a caution that was missing entirely: **this repo is public.** Habitually
loading strategic context while writing a commit message points the one direction
that has a hook guarding it, and a squash commit merged to a public `main` stays
reachable by SHA forever.

## Scope of checks

Docs-only (`SPEC.md`, `ROADMAP.md`, `.claude/skills/take-next/SKILL.md`), verified
with the step 5 filter — no Rust touched, so `cargo test`, `cargo bench` and the
budget gates are skipped deliberately. Challenge that if it looks wrong.

Nothing here changes an invariant. If any proposed behaviour contradicts §3, §3
wins and the proposal is wrong.
