### PR TITLE
I8: terminal restored on every exit the process controls

### DIFF
--- a/.claude/skills/take-next/SKILL.md
+++ b/.claude/skills/take-next/SKILL.md
@@ -5,17 +5,13 @@ description: Take the next task from ROADMAP.md and ship it end to end. Use when
 
 # take-next
 
-Take **one** task from `ROADMAP.md` and carry it to done. Not part of a task, not
-three tasks, not a survey of what could be done.
+Take **one** task from `ROADMAP.md` and carry it to done. Not part of a task, not three tasks, not a survey of what could be done.
 
-This is a reconstruction. The original lived in a global skills directory, was
-never version controlled, and was lost in a machine migration. It lives in the
-repo now for that reason. Do not move it out.
+This is a reconstruction. The original lived in a global skills directory, was never version controlled, and was lost in a machine migration. It lives in the repo now for that reason. Do not move it out.
 
 ## 1. Find your place
 
-Do not guess and do not scroll the code looking for where things stopped. One
-command finds the work:
+Do not guess and do not scroll the code looking for where things stopped. One command finds the work:
 
 ```sh
 # The earliest milestone that still HAS open issues, then its issues.
@@ -24,27 +20,17 @@ gh api "repos/{owner}/{repo}/milestones?state=open&sort=due_on&direction=asc" \
 gh issue list --state open --milestone "<that title>"
 ```
 
-**Not "the earliest open milestone".** A finished phase leaves its milestone open
-until someone closes it, so the earliest *open* milestone can be one with zero
-open issues, and the query then returns nothing and the session has no work to
-take. That happened the first time this was tried: Phase 1 was complete, merged,
-and still open, so `take-next` found the plan and then found nothing in it.
+**Not "the earliest open milestone".** A finished phase leaves its milestone open until someone closes it, so the earliest *open* milestone can be one with zero open issues, and the query then returns nothing and the session has no work to take. That happened the first time this was tried: Phase 1 was complete, merged, and still open, so `take-next` found the plan and then found nothing in it.
 
-**If you finish the last issue in a milestone, close the milestone.** It is the
-step that makes the next session's first command work.
+**If you finish the last issue in a milestone, close the milestone.** It is the step that makes the next session's first command work.
 
-`ROADMAP.md` is the plan; the issues are the truth. If they disagree, the issues
-win and the roadmap is stale, so fix the roadmap in the same pass.
+`ROADMAP.md` is the plan; the issues are the truth. If they disagree, the issues win and the roadmap is stale, so fix the roadmap in the same pass.
 
 ### Pre-flight: does the spec still agree with the tracker?
 
-That rule is right and nothing enforced it, so drift was only ever caught by
-someone happening to read both. It went wrong in **both** directions inside one
-hour: an issue described a design the spec had already moved past, and an issue
-sat open after the work it tracked had shipped.
+That rule is right and nothing enforced it, so drift was only ever caught by someone happening to read both. It went wrong in **both** directions inside one hour: an issue described a design the spec had already moved past, and an issue sat open after the work it tracked had shipped.
 
-Run this before taking a task. Three commands gather the state; you do the
-comparing.
+Run this before taking a task. Three commands gather the state; you do the comparing.
 
 ```sh
 git fetch -q origin
@@ -63,14 +49,9 @@ git show origin/main:ROADMAP.md | grep -oE '^\| *(✅|🔨|⬜) *\|.*\[#[0-9]+\]
 Then four comparisons. Any hit is a finding to fix **in this pass**, not a note:
 
 1. **Untracked** — an invariant the spec declares that no issue title names.
-2. **Orphan** — an issue naming an `I<n>` token the spec no longer declares. This
-   is what catches a rename or a split that left the tracker behind.
-3. **State** — a roadmap row marked `✅` whose issue is open, or a row not marked
-   done whose issue is closed.
-4. **Unfiled** — an *open* issue with **no milestone**. This looks least like
-   drift and matters most: the query above filters *by* milestone, so an
-   unmilestoned issue is not deprioritised, it is **invisible** and will never be
-   returned however long it sits. Seven had accumulated before anyone noticed.
+2. **Orphan** — an issue naming an `I<n>` token the spec no longer declares. This is what catches a rename or a split that left the tracker behind.
+3. **State** — a roadmap row marked `✅` whose issue is open, or a row not marked done whose issue is closed.
+4. **Unfiled** — an *open* issue with **no milestone**. This looks least like drift and matters most: the query above filters *by* milestone, so an unmilestoned issue is not deprioritised, it is **invisible** and will never be returned however long it sits. Seven had accumulated before anyone noticed.
 
 > [!warning] Read `SPEC.md` and `ROADMAP.md` from `origin/main`, never the working tree
 > The first run of this check read the checkout, which had a feature branch
@@ -82,86 +63,49 @@ Then four comparisons. Any hit is a finding to fix **in this pass**, not a note:
 > Comparing uncommitted state is occasionally what you want. It has to be asked
 > for out loud, never the default.
 
-Only the first two directions are cheap to eyeball; run all four anyway. A check
-that nags forever gets ignored exactly like one that stays silent, so if a
-finding is a false positive, fix the *check* here rather than learning to skip it.
+Only the first two directions are cheap to eyeball; run all four anyway. A check that nags forever gets ignored exactly like one that stays silent, so if a finding is a false positive, fix the *check* here rather than learning to skip it.
 
-**Two traps if you match these with `jq`, both of which made the first run report
-every invariant as drifting in both directions at once:**
+**Two traps if you match these with `jq`, both of which made the first run report every invariant as drifting in both directions at once:**
 
-- **`\b` does not work.** In a `jq` string, `\b` is the *backspace* character, so
-  `test("\\bI1\\b")` compiles a regex containing two backspaces and matches
-  nothing — silently, and in the "everything is broken" direction. Use an
-  explicit class instead of escaping harder:
+- **`\b` does not work.** In a `jq` string, `\b` is the *backspace* character, so `test("\\bI1\\b")` compiles a regex containing two backspaces and matches nothing — silently, and in the "everything is broken" direction. Use an explicit class instead of escaping harder:
   ```sh
   B='(^|[^A-Za-z0-9])'; A='([^A-Za-z0-9]|$)'
   jq -e --arg i "$inv" --arg b "$B" --arg a "$A" 'any(.[]; .title | test($b+$i+$a))'
   ```
-- **`jq` emits CRLF on Windows.** Its output into a shell loop carries `\r`, so
-  `grep -qxF "$token"` fails against a clean list for every token. Pipe through
-  `tr -d '\r'` before comparing.
+- **`jq` emits CRLF on Windows.** Its output into a shell loop carries `\r`, so `grep -qxF "$token"` fails against a clean list for every token. Pipe through `tr -d '\r'` before comparing.
 
-The two together produce a check that is *100% false positive* while looking like
-a catastrophic finding. Mutate it once before you trust it: point a comparison at
-a token you know is tracked and confirm it comes back **clean**. A drift check
-that cannot report "no drift" has not been tested.
+The two together produce a check that is *100% false positive* while looking like a catastrophic finding. Mutate it once before you trust it: point a comparison at a token you know is tracked and confirm it comes back **clean**. A drift check that cannot report "no drift" has not been tested.
 
-Take the **topmost unstarted task in the earliest open phase**. Do not skip ahead
-to something more interesting. If a later task genuinely blocks the current one,
-say so and take the blocker, but say it out loud first.
+Take the **topmost unstarted task in the earliest open phase**. Do not skip ahead to something more interesting. If a later task genuinely blocks the current one, say so and take the blocker, but say it out loud first.
 
-If a task is already `🔨 in progress`, check `git status` and the open PRs before
-starting anything: another session may be mid-flight, and two sessions on one
-task is worse than one session idle.
+If a task is already `🔨 in progress`, check `git status` and the open PRs before starting anything: another session may be mid-flight, and two sessions on one task is worse than one session idle.
 
 ## 2. Load the why before touching code
 
-**Read the repo first.** The issue carries acceptance criteria, `SPEC.md` carries
-the contract, and — unusually for a repo — a great deal of the *reasoning* is here
-too: §10's open questions carry their measurements, the invariant callouts explain
-why they split, and the commit messages argue rather than announce. Most "why did
-we do it this way" questions are answered inside the checkout.
+**Read the repo first.** The issue carries acceptance criteria, `SPEC.md` carries the contract, and — unusually for a repo — a great deal of the *reasoning* is here too: §10's open questions carry their measurements, the invariant callouts explain why they split, and the commit messages argue rather than announce. Most "why did we do it this way" questions are answered inside the checkout.
 
-Then reach outside it, through the `vigil` MCP server, for the three things the
-repo deliberately does **not** hold:
+Then reach outside it, through the `vigil` MCP server, for the three things the repo deliberately does **not** hold:
 
-- **What cannot be public.** This repo is public. The competitive read, the market
-  position, the objection this project was started against — none of that belongs
-  in a file anyone can clone, and it is the reason the vault exists at all.
-- **What generalises past this repo.** A `gix` limitation or a measurement trap is
-  true for every Rust project, so it lives where other projects can reach it.
-- **What predates or outlives the code.** Why this is monitor-class rather than
-  review-class was decided before the first commit, and re-deriving it is the most
-  expensive mistake available here.
+- **What cannot be public.** This repo is public. The competitive read, the market position, the objection this project was started against — none of that belongs in a file anyone can clone, and it is the reason the vault exists at all.
+- **What generalises past this repo.** A `gix` limitation or a measurement trap is true for every Rust project, so it lives where other projects can reach it.
+- **What predates or outlives the code.** Why this is monitor-class rather than review-class was decided before the first commit, and re-deriving it is the most expensive mistake available here.
 
 ```
 search   the decision you are about to touch
 recall   accumulated constraints — empty early, and empty is not evidence of none
 ```
 
-**Consulting the vault is deliberate, not reflexive.** Reaching for it when the
-answer is in `SPEC.md` wastes a call; reaching for it out of habit while writing a
-*public* commit message loads strategic context that must never land in one. That
-direction is the one with a hook guarding it, because a squash commit merged to a
-public `main` stays reachable by SHA forever. Know which of the three you are
-asking for before you ask.
+**Consulting the vault is deliberate, not reflexive.** Reaching for it when the answer is in `SPEC.md` wastes a call; reaching for it out of habit while writing a *public* commit message loads strategic context that must never land in one. That direction is the one with a hook guarding it, because a squash commit merged to a public `main` stays reachable by SHA forever. Know which of the three you are asking for before you ask.
 
 ## 3. Plan it, in plan mode, before touching code
 
-**Enter plan mode and write the plan. No code before an approved plan.** The plan
-is not ceremony and it is not for you — it is the only artifact the finished work
-can be *audited against*, and code cannot audit itself.
+**Enter plan mode and write the plan. No code before an approved plan.** The plan is not ceremony and it is not for you — it is the only artifact the finished work can be *audited against*, and code cannot audit itself.
 
-Without it the completeness check downstream has nothing to compare to. `/harden`
-carries a plan-fidelity phase that explicitly skips when no written plan exists,
-so a session that skips planning silently disables the one gate designed to catch
-under-delivery. That gate exists because a session once passed five clean audit
-rounds with 501 tests green and had still quietly shipped three promises short.
+Without it the completeness check downstream has nothing to compare to. `/harden` carries a plan-fidelity phase that explicitly skips when no written plan exists, so a session that skips planning silently disables the one gate designed to catch under-delivery. That gate exists because a session once passed five clean audit rounds with 501 tests green and had still quietly shipped three promises short.
 
 ### The plan must be diffable
 
-Length is not the bar; **concreteness** is. Every promise has to be checkable
-later by reading, so write nouns, not intentions:
+Length is not the bar; **concreteness** is. Every promise has to be checkable later by reading, so write nouns, not intentions:
 
 - modules and files touched, function signatures, types
 - error codes emitted, and what emits them
@@ -169,68 +113,38 @@ later by reading, so write nouns, not intentions:
 - any deviation from `SPEC.md`, named upfront with the reason
 - anything explicitly **out** of scope
 
-"Fix the thing" is not a plan. It survives any audit precisely because it promised
-nothing — a plan that cannot be diffed passes the fidelity check while proving
-nothing, which is worse than having no plan at all, because it *looks* gated.
+"Fix the thing" is not a plan. It survives any audit precisely because it promised nothing — a plan that cannot be diffed passes the fidelity check while proving nothing, which is worse than having no plan at all, because it *looks* gated.
 
-Scale it to the diff. A two-line fix gets a short plan; it still names the file,
-the assertion, and the test. A phase gets a long one.
+Scale it to the diff. A two-line fix gets a short plan; it still names the file, the assertion, and the test. A phase gets a long one.
 
 ### The plan has to outlive the session
 
-**Comment it on the issue before implementing.** The issue is the only durable
-surface that exists at planning time — the PR does not exist yet, since there are
-no commits to open it from, so "put it in the PR body" is unexecutable here and
-quietly becomes "keep it in my head". Carry it into the PR body at PR time as
-well, where the reviewer and `/harden`'s fidelity phase will both look for it.
+**Comment it on the issue before implementing.** The issue is the only durable surface that exists at planning time — the PR does not exist yet, since there are no commits to open it from, so "put it in the PR body" is unexecutable here and quietly becomes "keep it in my head". Carry it into the PR body at PR time as well, where the reviewer and `/harden`'s fidelity phase will both look for it.
 
-A plan that lives only in the conversation dies at the next compaction, and
-nobody but this session can ever check the work against it.
+A plan that lives only in the conversation dies at the next compaction, and nobody but this session can ever check the work against it.
 
 ### Deviations
 
-Reality will contradict the plan sometimes; that is normal and not a failure. The
-failure is deviating quietly.
+Reality will contradict the plan sometimes; that is normal and not a failure. The failure is deviating quietly.
 
-**Every deviation is a defect unless its justification was written down at the
-moment it was taken**, naming what the plan got wrong. A reason produced at audit
-time, about a choice made an hour earlier, is rationalisation — the same
-self-serving triage this skill refuses everywhere else, and it has a one-pushback
-half-life. Genuine plan-vs-reality conflicts route through the rule in the next
-section: stop, decide which side is wrong, change *that* one deliberately, in its
-own commit, and say which you changed.
+**Every deviation is a defect unless its justification was written down at the moment it was taken**, naming what the plan got wrong. A reason produced at audit time, about a choice made an hour earlier, is rationalisation — the same self-serving triage this skill refuses everywhere else, and it has a one-pushback half-life. Genuine plan-vs-reality conflicts route through the rule in the next section: stop, decide which side is wrong, change *that* one deliberately, in its own commit, and say which you changed.
 
-At the end of the pass, diff the shipment against the plan and report the result
-(step 6). Any deviation without a contemporaneous justification gets **corrected
-in this session** — not logged, not deferred, not carried into the PR as a note.
+At the end of the pass, diff the shipment against the plan and report the result (step 6). Any deviation without a contemporaneous justification gets **corrected in this session** — not logged, not deferred, not carried into the PR as a note.
 
 ---
 
 ## 4. Ship it
 
-- **The unit is the issue.** One issue, one branch, one PR. Splitting one issue
-  across several PRs fragments review and reads as progress theatre. If the issue
-  is genuinely two things, say so and split the *issue* first.
-- **Never defer a finding into a new issue to get the PR closed.** If work
-  surfaces something inside the scope of the task, fix it here. A new issue is
-  for something genuinely out of scope, and it needs **all three** of a
-  milestone, a `ROADMAP.md` row, and a shelf entry giving the reason it moved.
-  Miss the milestone and the issue is **invisible**, not deprioritised: the query
-  in step 1 filters by milestone and will never return it. Seven accumulated that
-  way before anyone noticed, so file it in one command rather than intending to
-  come back:
+- **The unit is the issue.** One issue, one branch, one PR. Splitting one issue across several PRs fragments review and reads as progress theatre. If the issue is genuinely two things, say so and split the *issue* first.
+- **Never defer a finding into a new issue to get the PR closed.** If work surfaces something inside the scope of the task, fix it here. A new issue is for something genuinely out of scope, and it needs **all three** of a milestone, a `ROADMAP.md` row, and a shelf entry giving the reason it moved. Miss the milestone and the issue is **invisible**, not deprioritised: the query in step 1 filters by milestone and will never return it. Seven accumulated that way before anyone noticed, so file it in one command rather than intending to come back:
 
   ```sh
   gh issue create --title "..." --body-file f.md --milestone "Phase 5 — deferred findings"
   ```
-- **An invariant is not landed until a test fails when it is violated.** Write
-  the failing test first, watch it fail, then make it pass. A test that passes
-  against broken code is worse than no test.
+- **An invariant is not landed until a test fails when it is violated.** Write the failing test first, watch it fail, then make it pass. A test that passes against broken code is worse than no test.
 - **Budgets are tests.** If the task touches the frame path, the budget gate runs.
-- **Do not add a dependency `SPEC.md` does not name.** Propose it into the spec,
-  in its own commit, then use it.
-- If reality contradicts the spec, **stop**. Decide which is wrong, change that
-  one deliberately, in its own commit, and say which you changed.
+- **Do not add a dependency `SPEC.md` does not name.** Propose it into the spec, in its own commit, then use it.
+- If reality contradicts the spec, **stop**. Decide which is wrong, change that one deliberately, in its own commit, and say which you changed.
 
 ## 5. Scope the checks to the diff
 
@@ -242,95 +156,58 @@ git diff --name-only <base>..HEAD | grep -vE '\.md$|^\.github/ISSUE|^LICENSE'
 
 Empty means docs-only: skip `cargo test`, `cargo bench` and the budget gates.
 
-**Caveats, because this is where corner-cutting hides:** `Cargo.toml`,
-`Cargo.lock`, `*.yml` and anything under `.github/workflows` are **never** docs,
-even when changed alongside markdown. A README tweak plus a "tiny" manifest edit
-is a code diff. Log the scope decision in the PR body so a reviewer can challenge
-it.
+**Caveats, because this is where corner-cutting hides:** `Cargo.toml`, `Cargo.lock`, `*.yml` and anything under `.github/workflows` are **never** docs, even when changed alongside markdown. A README tweak plus a "tiny" manifest edit is a code diff. Log the scope decision in the PR body so a reviewer can challenge it.
 
 ## 6. Prove it, then say so honestly
 
 - `cargo test` green, and name the count
 - budget gates green, and quote the numbers against the budgets
-- state failures plainly; a green summary over a skipped check is a lie with good
-  manners
+- state failures plainly; a green summary over a skipped check is a lie with good manners
 
 ### Then diff the shipment against the plan
 
-Tests prove the code does what it does. They cannot prove it does what step 3
-**said** it would — the plan lives outside the code, so no test run reaches it.
-This is a completeness check, done by reading both sides.
+Tests prove the code does what it does. They cannot prove it does what step 3 **said** it would — the plan lives outside the code, so no test run reaches it. This is a completeness check, done by reading both sides.
 
-Walk every promise the plan made — each module, signature, type, error code,
-named test, declared scope boundary — and mark it delivered or not. Then report
-the result out loud, including when it is clean.
+Walk every promise the plan made — each module, signature, type, error code, named test, declared scope boundary — and mark it delivered or not. Then report the result out loud, including when it is clean.
 
-Three shapes to look for, because these are the three that actually shipped once
-behind five clean audit rounds and 501 green tests:
+Three shapes to look for, because these are the three that actually shipped once behind five clean audit rounds and 501 green tests:
 
-- **Quietly narrowed** — the plan promised per-file `+N/−M` counts, the shipment
-  showed paths only.
+- **Quietly narrowed** — the plan promised per-file `+N/−M` counts, the shipment showed paths only.
 - **Quietly collapsed** — a three-value discriminated union became two.
-- **Promised and absent** — an error code defined in the plan, never emitted,
-  leaving dead code where it should have been.
+- **Promised and absent** — an error code defined in the plan, never emitted, leaving dead code where it should have been.
 
-Any deviation lacking a justification **written when it was taken** is a defect,
-and it gets fixed in this pass. Not noted in the PR, not filed as a follow-up,
-not explained in the report. Correcting it is the requirement; reporting it is
-not a substitute. A reason invented now, for a choice made an hour ago, is
-rationalisation — and this skill does not accept self-authored triage anywhere
-else either.
+Any deviation lacking a justification **written when it was taken** is a defect, and it gets fixed in this pass. Not noted in the PR, not filed as a follow-up, not explained in the report. Correcting it is the requirement; reporting it is not a substitute. A reason invented now, for a choice made an hour ago, is rationalisation — and this skill does not accept self-authored triage anywhere else either.
 
 Then polish, and let the **diff** pick the instrument rather than your appetite:
 
-- **Under ~200 lines across ≤3 files** — `/simplify` alone. A full audit workflow
-  on a small diff is theatre. (`/harden` states this floor itself and will
-  decline; the number lives there, so if the two ever disagree, harden wins.)
-- **Anything larger, or anything the rest of the system stands on** — `/harden`
-  **until dry**. It runs `/simplify` as one of its own phases, so do not run one
-  first and then the other. It also carries its own plan-fidelity phase: tell it
-  the diff above was already done, so it records the result instead of repeating
-  it.
+- **Under ~200 lines across ≤3 files** — `/simplify` alone. A full audit workflow on a small diff is theatre. (`/harden` states this floor itself and will decline; the number lives there, so if the two ever disagree, harden wins.)
+- **Anything larger, or anything the rest of the system stands on** — `/harden` **until dry**. It runs `/simplify` as one of its own phases, so do not run one first and then the other. It also carries its own plan-fidelity phase: tell it the diff above was already done, so it records the result instead of repeating it.
 
-Whichever runs, pass the docs carve-out into the invocation, because `/simplify`
-reduces and the comments explaining *why* something works are the ones nobody can
-reconstruct from the code:
+Whichever runs, pass the docs carve-out into the invocation, because `/simplify` reduces and the comments explaining *why* something works are the ones nobody can reconstruct from the code:
 
 > Documentation is non-negotiable during `/simplify`. Do not shorten, remove, or
 > fold module-header docblocks, function doc comments, or `Why:` / invariant
 > notes. If a simplification would delete context about why something works, skip
 > the simplification.
 
-**"Foundational" is not a self-assessment you get to lower.** If the change
-touches the frame path, the watch engine, the diff oracle, or the budget gates,
-it is foundational — that is the whole system. Do not accept your own "not worth
-fixing" on a first pass either: that dismissal has a one-pushback half-life here,
-and three out of four have historically been wrong.
+**"Foundational" is not a self-assessment you get to lower.** If the change touches the frame path, the watch engine, the diff oracle, or the budget gates, it is foundational — that is the whole system. Do not accept your own "not worth fixing" on a first pass either: that dismissal has a one-pushback half-life here, and three out of four have historically been wrong.
 
 ## 7. Close the loop, all four places
 
 Skipping any of these is how the next session loses time.
 
 1. **The issue.** Close it, with the evidence: commit, test count, numbers.
-2. **`ROADMAP.md`.** Flip the status. Add to the deferral shelf or pull-forward
-   log if anything moved.
+2. **`ROADMAP.md`.** Flip the status. Add to the deferral shelf or pull-forward log if anything moved.
 3. **`SPEC.md`.** Only if the contract actually changed. Own commit.
 4. **The vault**, through the MCP:
-   - `record_work` for what happened here: changes, decisions, what was learned,
-     what is still open, how it was verified.
-   - `remember` for anything that would help someone on a **different** project.
-     A `gix` limitation that would bite any Rust project is a `remember`. "Landed
-     the watch engine" is a `record_work`. Both, when both are true.
+   - `record_work` for what happened here: changes, decisions, what was learned, what is still open, how it was verified.
+   - `remember` for anything that would help someone on a **different** project. A `gix` limitation that would bite any Rust project is a `remember`. "Landed the watch engine" is a `record_work`. Both, when both are true.
 
 ## 8. Report
 
-What was taken, what shipped, the numbers, what moved on the roadmap, and what
-the next task is. Then stop. Do not start it.
+What was taken, what shipped, the numbers, what moved on the roadmap, and what the next task is. Then stop. Do not start it.
 
-Include the **plan-fidelity result** explicitly — "every promise delivered", or
-the deviations and what was done about them. Silence here reads as clean, and a
-step whose absence is indistinguishable from success is a step that stops
-happening.
+Include the **plan-fidelity result** explicitly — "every promise delivered", or the deviations and what was done about them. Silence here reads as clean, and a step whose absence is indistinguishable from success is a step that stops happening.
 
 ## Anti-patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,27 +2,19 @@
 
 A live diff **monitor** for the terminal. Not a review tool.
 
-`vigia` is Portuguese: a watchman, and — nautically — a porthole. The window you
-look through. Also the verb: `vigia .` reads as "watch this."
+`vigia` is Portuguese: a watchman, and — nautically — a porthole. The window you look through. Also the verb: `vigia .` reads as "watch this."
 
 ## What this is, in one paragraph
 
-You run an AI coding agent in one pane and `vigia` in the pane beside it. It
-shows the working-tree diff as it changes, continuously, without being touched.
-It is ambient. It is closer to `btop` than to a git client: you read state from
-shape and colour, glance away, and glance back.
+You run an AI coding agent in one pane and `vigia` in the pane beside it. It shows the working-tree diff as it changes, continuously, without being touched. It is ambient. It is closer to `btop` than to a git client: you read state from shape and colour, glance away, and glance back.
 
 ## The product class is the whole thesis
 
-`vigia` is **monitor-class**: already open, rarely touched, correct with zero
-input, cheap for days, glanceable. It is not a **reviewer** — something you
-launch per changeset to step through, annotate and decide on.
+`vigia` is **monitor-class**: already open, rarely touched, correct with zero input, cheap for days, glanceable. It is not a **reviewer** — something you launch per changeset to step through, annotate and decide on.
 
-That distinction is not stylistic. It generates every budget in `SPEC.md`, and
-those budgets are the product.
+That distinction is not stylistic. It generates every budget in `SPEC.md`, and those budgets are the product.
 
-**If a change would make `vigia` a better reviewer at the cost of an invariant,
-the change is wrong.** Reject it and say why.
+**If a change would make `vigia` a better reviewer at the cost of an invariant, the change is wrong.** Reject it and say why.
 
 ## Stack — settled, do not relitigate
 
@@ -34,36 +26,23 @@ the change is wrong.** Reject it and say why.
 | Highlighting | `syntect` | Pure Rust, so no C toolchain in CI. What `delta` and `bat` use |
 | Release | `cargo-dist` | Cross-platform binaries + Homebrew formula + GH workflow |
 
-Everything above is pure Rust on purpose: `--target x86_64-unknown-linux-musl`
-gives a static binary with no cross-toolchain, and macOS/Windows are tier-1.
-**Choosing tree-sitter over `syntect` reintroduces a C toolchain** — that is a
-spec change, not an implementation detail.
+Everything above is pure Rust on purpose: `--target x86_64-unknown-linux-musl` gives a static binary with no cross-toolchain, and macOS/Windows are tier-1. **Choosing tree-sitter over `syntect` reintroduces a C toolchain** — that is a spec change, not an implementation detail.
 
-`gix` was the least-precedented dependency here (`delta` uses `git2`/libgit2
-instead, likely for age reasons), so Phase 1 proved it before anything was built
-on top. **Proven 2026-07-30:** hunk boundaries match `git diff -U3` exactly and
-every Phase 1 budget holds with room. Evidence and the one constraint it came
-with are in `SPEC.md` §10.
+`gix` was the least-precedented dependency here (`delta` uses `git2`/libgit2 instead, likely for age reasons), so Phase 1 proved it before anything was built on top. **Proven 2026-07-30:** hunk boundaries match `git diff -U3` exactly and every Phase 1 budget holds with room. Evidence and the one constraint it came with are in `SPEC.md` §10.
 
 ## Method: spec-driven, drift-enforced
 
 `SPEC.md` is the source of truth. Code is written against it.
 
-1. If the code and `SPEC.md` disagree, **stop.** One of them is wrong; decide
-   which, change that one deliberately, in its own commit.
-2. Every invariant in `SPEC.md` has a test that fails when it is violated.
-   An invariant without a failing test is a wish.
-3. Performance budgets are tests, not aspirations. The thesis is a measurable
-   claim, so a regression past budget **fails the build**.
+1. If the code and `SPEC.md` disagree, **stop.** One of them is wrong; decide which, change that one deliberately, in its own commit.
+2. Every invariant in `SPEC.md` has a test that fails when it is violated. An invariant without a failing test is a wish.
+3. Performance budgets are tests, not aspirations. The thesis is a measurable claim, so a regression past budget **fails the build**.
 
-Do not add a dependency, a flag, or a subcommand that `SPEC.md` does not name.
-Propose it, get it into the spec, then build it.
+Do not add a dependency, a flag, or a subcommand that `SPEC.md` does not name. Propose it, get it into the spec, then build it.
 
 ## Where design decisions live
 
-Design rationale for this project is recorded outside this repo, reachable
-through the **`vigil` MCP server**. This repo declares its identity as `vigia` in
-`.om-project`, which is what scopes reads and writes to this project.
+Design rationale for this project is recorded outside this repo, reachable through the **`vigil` MCP server**. This repo declares its identity as `vigia` in `.om-project`, which is what scopes reads and writes to this project.
 
 ### Reading
 
@@ -76,9 +55,7 @@ through the **`vigil` MCP server**. This repo declares its identity as `vigia` i
 | **`health`** | When something that should be there cannot be found. Every failure in this layer looks identical from the outside (no results), and this is what tells them apart. |
 | Resources | Notes are also exposed as `vault://note/<path>` and can be read directly when the title already answers the question. |
 
-**`recall` is empty until sessions put things in it.** Early on it returns
-nothing, and that is *not* evidence the record is missing. Do not conclude "there
-is no record" from an empty `recall`. Use `search`.
+**`recall` is empty until sessions put things in it.** Early on it returns nothing, and that is *not* evidence the record is missing. Do not conclude "there is no record" from an empty `recall`. Use `search`.
 
 Consult the record before changing:
 
@@ -87,54 +64,28 @@ Consult the record before changing:
 - the file-watching strategy and its platform assumptions
 - the performance budgets and what they were set against
 
-If that record and this repo disagree, the record holds the *why*. Reconcile
-before changing behaviour.
+If that record and this repo disagree, the record holds the *why*. Reconcile before changing behaviour.
 
 ### Writing
 
-Two tools, and picking the wrong one is the common mistake. **The test is whether
-it would help someone working on a different project.**
+Two tools, and picking the wrong one is the common mistake. **The test is whether it would help someone working on a different project.**
 
-**`remember`** stores a durable **lesson**: a constraint you discovered, a gotcha
-that cost time, a rule that generalises. Not status, not a task summary, not
-anything you would resent being told again in six weeks.
+**`remember`** stores a durable **lesson**: a constraint you discovered, a gotcha that cost time, a rule that generalises. Not status, not a task summary, not anything you would resent being told again in six weeks.
 
-- `confidence` is `verified` | `inferred` | `unverified`. Be honest, it is what a
-  reader trusts. Supply `verification` whenever you claim `verified`: how you
-  know, i.e. the test you ran or the source you read.
-- `scope` is `project` | `platform` | `general`. For something specific to this
-  tool use `scope: "project"` with `projects: ["vigia"]`. Use `general` only when
-  it genuinely applies everywhere.
-- `links` connects it to existing notes by title. `supersedes` corrects an
-  earlier memory: the old one is kept and back-linked rather than deleted.
+- `confidence` is `verified` | `inferred` | `unverified`. Be honest, it is what a reader trusts. Supply `verification` whenever you claim `verified`: how you know, i.e. the test you ran or the source you read.
+- `scope` is `project` | `platform` | `general`. For something specific to this tool use `scope: "project"` with `projects: ["vigia"]`. Use `general` only when it genuinely applies everywhere.
+- `links` connects it to existing notes by title. `supersedes` corrects an earlier memory: the old one is kept and back-linked rather than deleted.
 - `dry_run: true` previews first.
 
-**`record_work`** files what happened **here** into the vault. Use it at the end
-of a real piece of work. Write it for a session that will not have your context
-and cannot re-read your diff, so fill every field you can: `summary`, `changes`
-(one line per file, what and why), `decisions` (especially where you rejected an
-alternative), `learned` (surprises and near-misses), `open` (unresolved threads
-nobody should assume are handled), `verification` (tests run and their result,
-failures stated honestly). `kind: "decision"` files it as a decision record;
-`informed_by` credits the notes you actually read.
+**`record_work`** files what happened **here** into the vault. Use it at the end of a real piece of work. Write it for a session that will not have your context and cannot re-read your diff, so fill every field you can: `summary`, `changes` (one line per file, what and why), `decisions` (especially where you rejected an alternative), `learned` (surprises and near-misses), `open` (unresolved threads nobody should assume are handled), `verification` (tests run and their result, failures stated honestly). `kind: "decision"` files it as a decision record; `informed_by` credits the notes you actually read.
 
-Rule of thumb: **a `gix` limitation that would bite any Rust project is a
-`remember`. "Landed the watch engine and here is what it cost" is a
-`record_work`.** Do both when both are true.
+Rule of thumb: **a `gix` limitation that would bite any Rust project is a `remember`. "Landed the watch engine and here is what it cost" is a `record_work`.** Do both when both are true.
 
-Before finishing work that changed or clarified a decision here, write it down.
-A finding that stays in this session is a finding the next session pays for
-again.
+Before finishing work that changed or clarified a decision here, write it down. A finding that stays in this session is a finding the next session pays for again.
 
 ## House rules
 
-- **No agent-session artifacts in anything that lands in the repo.** No
-  `claude.ai/code/session_*` URL, no `Claude-Session:` trailer, no local
-  absolute path — not in commit messages, PR or issue bodies, or files.
-  `Co-Authored-By:` is fine and wanted.
-- **No em-dashes** in anything published under Brenno's name: README prose,
-  release notes, issue and PR bodies, commit messages. Use a period, a comma,
-  a colon, or parentheses.
-- Probe capability by behaviour, never by asking. A single green run is not
-  evidence when the defect is non-deterministic.
+- **No agent-session artifacts in anything that lands in the repo.** No `claude.ai/code/session_*` URL, no `Claude-Session:` trailer, no local absolute path — not in commit messages, PR or issue bodies, or files. `Co-Authored-By:` is fine and wanted.
+- **No em-dashes** in anything published under Brenno's name: README prose, release notes, issue and PR bodies, commit messages. Use a period, a comma, a colon, or parentheses.
+- Probe capability by behaviour, never by asking. A single green run is not evidence when the defect is non-deterministic.
 - Verify the whole artifact, not just the property you were fixing.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ and a regression past any of them fails the build.
 | 🎞️ **60fps** | Frame time under 16ms at p99, while files are being written |
 | 🧘 **Correct untouched** | Follows the newest change and scrolls to it with no input |
 | 📐 **Narrow panes** | Legible at 40 columns, because half a laptop screen is the point |
-| 🚪 **Clean exit** | Terminal restored exactly, including on Ctrl+C and on panic |
+| 🚪 **Clean exit** | Terminal restored on every exit it controls: the quit key, Ctrl+C, an error, or a panic |
 
 ## 🧱 Built with
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,11 @@
 
 You run a coding agent in one pane. You run `vigia` in the pane beside it.
 
-It shows your working tree changing, continuously, without being touched. No
-branches, no commits, no stash list, no staging. The diff, and nothing else.
+It shows your working tree changing, continuously, without being touched. No branches, no commits, no stash list, no staging. The diff, and nothing else.
 
-It is closer to `btop` than to a git client: something you glance at, read from
-shape and colour, then glance away from.
+It is closer to `btop` than to a git client: something you glance at, read from shape and colour, then glance away from.
 
-**A monitor, not a reviewer.** A reviewer is something you launch per changeset
-to step through, annotate, and decide on. `vigia` is already open. It should be
-correct when nobody has touched it for an hour, and still cheap when nobody has
-closed it for a week.
+**A monitor, not a reviewer.** A reviewer is something you launch per changeset to step through, annotate, and decide on. `vigia` is already open. It should be correct when nobody has touched it for an hour, and still cheap when nobody has closed it for a week.
 
 ## 🖼️ Where it is going
 
@@ -31,14 +26,11 @@ Target layout. **This is a mockup, not a screenshot.** Nothing renders yet.
 
 <img src="assets/preview.svg" alt="Mockup of the vigia interface: a file list with change sparklines above a syntax highlighted diff, and a status bar showing frame time and memory." width="900">
 
-The sparklines are change density over time. The bars locate change within each
-file. The frame time sits in the status bar because it is a promise, not a
-diagnostic.
+The sparklines are change density over time. The bars locate change within each file. The frame time sits in the status bar because it is a promise, not a diagnostic.
 
 ## ⚡ Design commitments
 
-These are budgets, not hopes. Each one gets a test that fails when it is missed,
-and a regression past any of them fails the build.
+These are budgets, not hopes. Each one gets a test that fails when it is missed, and a regression past any of them fails the build.
 
 | | |
 |---|---|
@@ -62,8 +54,7 @@ and a regression past any of them fails the build.
 | [notify](https://github.com/notify-rs/notify) | Native filesystem events per platform, which is what "no polling timer" requires |
 | [syntect](https://github.com/trishume/syntect) | Syntax highlighting, pure Rust, so no C toolchain in CI |
 
-Everything is pure Rust on purpose: a genuinely static Linux binary needs no
-cross toolchain, and macOS and Windows are plain tier 1 targets.
+Everything is pure Rust on purpose: a genuinely static Linux binary needs no cross toolchain, and macOS and Windows are plain tier 1 targets.
 
 ## 🗺️ Status
 
@@ -74,15 +65,11 @@ cross toolchain, and macOS and Windows are plain tier 1 targets.
 | ⬜ | **3. Glanceability** | Sparklines, heat bars, live counters, theming |
 | ⬜ | **4. Distribution** | crates.io, Homebrew tap, prebuilt binaries |
 
-Being built in the open, spec first. [`SPEC.md`](SPEC.md) is the source of truth
-and it is written before the code, so it is the honest place to see where this is
-going and to argue with it. [`ROADMAP.md`](ROADMAP.md) is the live state, issue
-linked: the table above is the shape, that file is what is actually done.
+Being built in the open, spec first. [`SPEC.md`](SPEC.md) is the source of truth and it is written before the code, so it is the honest place to see where this is going and to argue with it. [`ROADMAP.md`](ROADMAP.md) is the live state, issue linked: the table above is the shape, that file is what is actually done.
 
 ## 🏷️ The name
 
-*Vigia* is Portuguese. It means a watchman, a lookout, the one who keeps watch.
-At sea it also means a porthole: the small round window you look through.
+*Vigia* is Portuguese. It means a watchman, a lookout, the one who keeps watch. At sea it also means a porthole: the small round window you look through.
 
 Both readings are the tool. It watches, and it is the window you watch through.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,11 +90,12 @@ externally delivered `kill` is out of reach without a dependency `SPEC.md` does
 not name. That is [#24](https://github.com/breferrari/vigia/issues/24), on the
 shelf below.
 
-**Take [#6](https://github.com/breferrari/vigia/issues/6) next.** I5 is follow
-mode, and it is the last thing that makes the monitor correct with nobody
-touching it, which is the product class. Nothing in the shell reads follow state
-today: #9 deliberately shipped no `f` toggle rather than a key that flips a bool
-nothing consumes.
+**[#6](https://github.com/breferrari/vigia/issues/6) is what remains of the
+phase's correctness half.** I5 is follow mode, the last thing that makes the
+monitor correct with nobody touching it, which is the product class. Nothing in
+the shell reads follow state today: #9 deliberately shipped no `f` toggle rather
+than a key that flips a bool nothing consumes. It is **not** takeable yet, for the
+reason two paragraphs down.
 
 [#7](https://github.com/breferrari/vigia/issues/7) then has a baseline to argue
 with: there are 40- and 80-column snapshots already, and what I6 still needs is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,11 +1,8 @@
 # vigia — Roadmap
 
-**This file answers "what is next".** `SPEC.md` answers "what is true and why". Code
-is written against the spec; work is taken from here.
+**This file answers "what is next".** `SPEC.md` answers "what is true and why". Code is written against the spec; work is taken from here.
 
-Every task links to an issue, so "done" has an external source of truth (issue
-closed, PR merged) rather than a self-report. If this file and the issues
-disagree, the issues win and this file is stale: fix it in the same pass.
+Every task links to an issue, so "done" has an external source of truth (issue closed, PR merged) rather than a self-report. If this file and the issues disagree, the issues win and this file is stale: fix it in the same pass.
 
 Status legend: ✅ done · 🔨 in progress · ⬜ not started
 
@@ -13,31 +10,22 @@ Status legend: ✅ done · 🔨 in progress · ⬜ not started
 
 ## Principles
 
-Each of these is a filter you can quote back at a proposal to kill or delay it.
-If a line here cannot do that, it is ornament and should be cut.
+Each of these is a filter you can quote back at a proposal to kill or delay it. If a line here cannot do that, it is ornament and should be cut.
 
-1. **Monitor, not reviewer.** If a change makes vigia a better tool to *sit down
-   and review with*, at the cost of being correct-while-ignored, it is wrong.
-2. **The budgets are the product.** A feature that cannot hold the frame budget
-   is not a feature, it is a regression with a changelog entry.
-3. **An invariant without a failing test is a wish.** Nothing counts as landed
-   until a test fails when it is violated.
-4. **Pure Rust, no C toolchain.** Any dependency pulling `cc`, `cmake` or
-   `bindgen` breaks static Linux builds and Windows tier-1. That is a spec
-   change, argued in the spec, never an implementation detail.
-5. **Measure, never assume.** A type signature is not evidence. A single green
-   run is not evidence. Numbers or it did not happen.
+1. **Monitor, not reviewer.** If a change makes vigia a better tool to *sit down and review with*, at the cost of being correct-while-ignored, it is wrong.
+2. **The budgets are the product.** A feature that cannot hold the frame budget is not a feature, it is a regression with a changelog entry.
+3. **An invariant without a failing test is a wish.** Nothing counts as landed until a test fails when it is violated.
+4. **Pure Rust, no C toolchain.** Any dependency pulling `cc`, `cmake` or `bindgen` breaks static Linux builds and Windows tier-1. That is a spec change, argued in the spec, never an implementation detail.
+5. **Measure, never assume.** A type signature is not evidence. A single green run is not evidence. Numbers or it did not happen.
 
 ## Non-goals, permanent
 
 Not "later". Never. Listed so the debate does not have to recur.
 
-- **Staging, committing, rebasing.** Reviewer-class, and each would cost an
-  invariant. Use a git client.
+- **Staging, committing, rebasing.** Reviewer-class, and each would cost an invariant. Use a git client.
 - **Branch and commit browsing.** Same.
 - **Annotations and comment threads.** Reviewer-class by definition.
-- **AI features of any kind.** The tool watches files. It does not summarise,
-  explain or judge them.
+- **AI features of any kind.** The tool watches files. It does not summarise, explain or judge them.
 - **Remote operations.** No fetch, no push, no network.
 - **A GUI.** Terminal only.
 
@@ -56,11 +44,7 @@ Prove `gix` before anything is built on top, since everything sits on it. No TUI
 | ✅ | I2a the frame path never re-diffs what did not change | [#2](https://github.com/breferrari/vigia/issues/2) |
 | ✅ | Gate every Phase 1 budget in CI (I4, I7, I9) | [#3](https://github.com/breferrari/vigia/issues/3) |
 
-**Phase 1 is closed.** The engine holds every budget it was written against, and
-`gix` was the right call. On a 100-file, 100k-line diff: a real frame under
-continuous edits is 3.93ms p99 to revalidate and 6.97ms p99 with a file edited
-before every frame, against 18.28ms and 3.6 MiB for a cold frame with nothing to
-reuse. The 16ms budget holds with room, and only the cold frame breaches it.
+**Phase 1 is closed.** The engine holds every budget it was written against, and `gix` was the right call. On a 100-file, 100k-line diff: a real frame under continuous edits is 3.93ms p99 to revalidate and 6.97ms p99 with a file edited before every frame, against 18.28ms and 3.6 MiB for a cold frame with nothing to reuse. The 16ms budget holds with room, and only the cold frame breaches it.
 
 ## Phase 2 — minimum monitor
 
@@ -76,39 +60,15 @@ Milestone: [Phase 2](https://github.com/breferrari/vigia/milestone/2)
 | ⬜ | I2b re-highlight only changed hunks (`syntect`) | [#4](https://github.com/breferrari/vigia/issues/4) |
 | ⬜ | I3 flat resources over days (soak) | [#5](https://github.com/breferrari/vigia/issues/5) |
 
-**The shell is in, so the rest of this phase has something to render into.** It
-draws the working-tree diff, follows the watch engine's ticks, scrolls by keyboard
-and wheel, and holds its own half of I4: one screenful reads only the files it
-draws, gated across two fixtures in `crates/vigia/tests/reads.rs`.
+**The shell is in, so the rest of this phase has something to render into.** It draws the working-tree diff, follows the watch engine's ticks, scrolls by keyboard and wheel, and holds its own half of I4: one screenful reads only the files it draws, gated across two fixtures in `crates/vigia/tests/reads.rs`.
 
-**The shell is now safe to leave running.** [#8](https://github.com/breferrari/vigia/issues/8)
-closed the last untested module: the takeover is data, giving it back is asserted
-as its exact inverse, and a half-finished `Session::enter` undoes exactly what it
-took. Seven mutations, each killed by a named test. It also settled what I8 can
-honestly promise: raw mode means Ctrl-C is a key event and never a signal, so an
-externally delivered `kill` is out of reach without a dependency `SPEC.md` does
-not name. That is [#24](https://github.com/breferrari/vigia/issues/24), on the
-shelf below.
+**The shell is now safe to leave running.** [#8](https://github.com/breferrari/vigia/issues/8) closed the last untested module: the takeover is data, giving it back is asserted as its exact inverse, and a half-finished `Session::enter` undoes exactly what it took. Seven mutations, each killed by a named test. It also settled what I8 can honestly promise: raw mode means Ctrl-C is a key event and never a signal, so an externally delivered `kill` is out of reach without a dependency `SPEC.md` does not name. That is [#24](https://github.com/breferrari/vigia/issues/24), on the shelf below.
 
-**[#6](https://github.com/breferrari/vigia/issues/6) is what remains of the
-phase's correctness half.** I5 is follow mode, the last thing that makes the
-monitor correct with nobody touching it, which is the product class. Nothing in
-the shell reads follow state today: #9 deliberately shipped no `f` toggle rather
-than a key that flips a bool nothing consumes. It is **not** takeable yet, for the
-reason two paragraphs down.
+**[#6](https://github.com/breferrari/vigia/issues/6) is what remains of the phase's correctness half.** I5 is follow mode, the last thing that makes the monitor correct with nobody touching it, which is the product class. Nothing in the shell reads follow state today: #9 deliberately shipped no `f` toggle rather than a key that flips a bool nothing consumes. It is **not** takeable yet, for the reason two paragraphs down.
 
-[#7](https://github.com/breferrari/vigia/issues/7) then has a baseline to argue
-with: there are 40- and 80-column snapshots already, and what I6 still needs is
-the assertions that make it an invariant rather than a screenshot. A diff line
-does lose its tail at 40 columns today.
+[#7](https://github.com/breferrari/vigia/issues/7) then has a baseline to argue with: there are 40- and 80-column snapshots already, and what I6 still needs is the assertions that make it an invariant rather than a screenshot. A diff line does lose its tail at 40 columns today.
 
-**[#6](https://github.com/breferrari/vigia/issues/6) is blocked on a decision, not
-on code.** I5 promises the view follows the newest change untouched, and no follow
-mode exists yet, so what happens when the reader scrolls is undecided — `SPEC.md`
-§11.2 **B1**. Implementing #6 first would settle it accidentally inside a snapshot
-test, which is how a behaviour becomes permanent without anyone choosing it. Rule
-on B1, then take #6. **B2** — which file wins when a batch changes several — is
-the same decision one layer down and lands with it.
+**[#6](https://github.com/breferrari/vigia/issues/6) is blocked on a decision, not on code.** I5 promises the view follows the newest change untouched, and no follow mode exists yet, so what happens when the reader scrolls is undecided — `SPEC.md` §11.2 **B1**. Implementing #6 first would settle it accidentally inside a snapshot test, which is how a behaviour becomes permanent without anyone choosing it. Rule on B1, then take #6. **B2** — which file wins when a batch changes several — is the same decision one layer down and lands with it.
 
 ## Phase 3 — glanceability
 
@@ -119,35 +79,16 @@ Milestone: [Phase 3](https://github.com/breferrari/vigia/milestone/3)
 | ⬜ | Sparklines, heat strips, counters, pulse | [#10](https://github.com/breferrari/vigia/issues/10) |
 | ⬜ | Theming, with a 256-colour degradation path | [#11](https://github.com/breferrari/vigia/issues/11) |
 
-**This phase is mis-scoped and [#10](https://github.com/breferrari/vigia/issues/10)
-must split before anything here is taken.** Reading `assets/preview.svg` as the
-specification it already is (`SPEC.md` §5.1) turned up eight distinct pieces of
-work behind two rows, and #10 alone carries four features that share no
-implementation. `take-next` step 4 is explicit: *if the issue is genuinely two
-things, split the issue first.*
+**This phase is mis-scoped and [#10](https://github.com/breferrari/vigia/issues/10) must split before anything here is taken.** Reading `assets/preview.svg` as the specification it already is (`SPEC.md` §5.1) turned up eight distinct pieces of work behind two rows, and #10 alone carries four features that share no implementation. `take-next` step 4 is explicit: *if the issue is genuinely two things, split the issue first.*
 
-The correction that matters is not the count. **It is that this is not a rendering
-phase** (`SPEC.md` §5.2). Two of its headline elements need retained state in
-`vigia-core`, so they move invariants rather than sit on top of them:
+The correction that matters is not the count. **It is that this is not a rendering phase** (`SPEC.md` §5.2). Two of its headline elements need retained state in `vigia-core`, so they move invariants rather than sit on top of them:
 
-- the **sparkline** needs history that survives a file settling — which is exactly
-  what `FrameStats.evicted` throws away to keep I3 provable. Blocked on **proposed
-  I10 (bounded history)**: the data structure is the decision, the drawing is the
-  easy part.
-- the **heat strip** needs each file's total line count, a whole-file read the
-  frame path exists to avoid. Cacheable per `(path, blob id)`; without that cache
-  it breaks I2a.
+- the **sparkline** needs history that survives a file settling — which is exactly what `FrameStats.evicted` throws away to keep I3 provable. Blocked on **proposed I10 (bounded history)**: the data structure is the decision, the drawing is the easy part.
+- the **heat strip** needs each file's total line count, a whole-file read the frame path exists to avoid. Cacheable per `(path, blob id)`; without that cache it breaks I2a.
 
-Split #10 along the seams of what each element actually needs, not along what they
-look like: history-backed (sparkline, recency gradient, `just changed` decay — one
-clock, not three), whole-file-backed (heat strip), and free (per-file counters,
-which cost nothing because a file must be diffed to be drawn).
+Split #10 along the seams of what each element actually needs, not along what they look like: history-backed (sparkline, recency gradient, `just changed` decay — one clock, not three), whole-file-backed (heat strip), and free (per-file counters, which cost nothing because a file must be diffed to be drawn).
 
-Untracked entirely, and all visible in the mockup: the header **mode word**
-(`watching`, implying a mode set), the **status bar** (`0.8ms frame`, `11MB` — one
-measuring inside I9's budget, the other a syscall I3 only samples in soak), and the
-**key-hint bar**, which constrains I6 because roughly thirty columns of it has to
-degrade at forty.
+Untracked entirely, and all visible in the mockup: the header **mode word** (`watching`, implying a mode set), the **status bar** (`0.8ms frame`, `11MB` — one measuring inside I9's budget, the other a syscall I3 only samples in soak), and the **key-hint bar**, which constrains I6 because roughly thirty columns of it has to degrade at forty.
 
 ## Phase 4 — distribution
 
@@ -161,9 +102,7 @@ Milestone: [Phase 4](https://github.com/breferrari/vigia/milestone/4)
 
 Milestone: [Phase 5](https://github.com/breferrari/vigia/milestone/5)
 
-Everything on the deferral shelf below has a milestone here, so shelved work is
-still reachable by a milestone-filtered query rather than only readable in prose.
-The shelf carries the *reason*; this table carries the *state*.
+Everything on the deferral shelf below has a milestone here, so shelved work is still reachable by a milestone-filtered query rather than only readable in prose. The shelf carries the *reason*; this table carries the *state*.
 
 | | Task | Issue |
 |---|---|---|
@@ -179,9 +118,7 @@ The shelf carries the *reason*; this table carries the *state*.
 
 ## Deferral shelf
 
-Items that surfaced mid-phase and would have derailed the block they surfaced
-in. Deferral is a first-class outcome recorded here, not a dropped ball and not
-scope creep absorbed silently. Each one carries the phase it moved to.
+Items that surfaced mid-phase and would have derailed the block they surfaced in. Deferral is a first-class outcome recorded here, not a dropped ball and not scope creep absorbed silently. Each one carries the phase it moved to.
 
 | Item | Surfaced | Moved to | Why |
 |---|---|---|---|
@@ -197,9 +134,7 @@ scope creep absorbed silently. Each one carries the phase it moved to.
 
 ## Pull-forward log
 
-Items that moved into an *earlier* phase than planned. Recorded for the same
-reason as deferrals: movement should be visible. Over time the balance of this
-list against the shelf says whether the plan was too ambitious or too cautious.
+Items that moved into an *earlier* phase than planned. Recorded for the same reason as deferrals: movement should be visible. Over time the balance of this list against the shelf says whether the plan was too ambitious or too cautious.
 
 | Item | Moved | Why |
 |---|---|---|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,7 +71,7 @@ Milestone: [Phase 2](https://github.com/breferrari/vigia/milestone/2)
 | ✅ | The `ratatui` + `crossterm` shell | [#9](https://github.com/breferrari/vigia/issues/9) |
 | ⬜ | I5 correct with zero interaction | [#6](https://github.com/breferrari/vigia/issues/6) |
 | ⬜ | I6 legible at 40 columns | [#7](https://github.com/breferrari/vigia/issues/7) |
-| ⬜ | I8 terminal restored exactly on exit | [#8](https://github.com/breferrari/vigia/issues/8) |
+| ✅ | I8 terminal restored on every exit the process controls | [#8](https://github.com/breferrari/vigia/issues/8) |
 | ✅ | A truncated `.git/index` aborts instead of reporting | [#13](https://github.com/breferrari/vigia/issues/13) |
 | ⬜ | I2b re-highlight only changed hunks (`syntect`) | [#4](https://github.com/breferrari/vigia/issues/4) |
 | ⬜ | I3 flat resources over days (soak) | [#5](https://github.com/breferrari/vigia/issues/5) |
@@ -81,12 +81,20 @@ draws the working-tree diff, follows the watch engine's ticks, scrolls by keyboa
 and wheel, and holds its own half of I4: one screenful reads only the files it
 draws, gated across two fixtures in `crates/vigia/tests/reads.rs`.
 
-**Take [#8](https://github.com/breferrari/vigia/issues/8) next.** The restoration
-it proves is already implemented, in `crates/vigia/src/terminal.rs`, and it is the
-one module in the shell with no test at all: raw mode, the alternate screen, mouse
-capture and the panic hook are all outside a `TestBackend`, which is what the rest
-of the suite is built on. It is also the only thing standing between the shell
-being usable and being safe to leave running, and #13's abort is covered by it.
+**The shell is now safe to leave running.** [#8](https://github.com/breferrari/vigia/issues/8)
+closed the last untested module: the takeover is data, giving it back is asserted
+as its exact inverse, and a half-finished `Session::enter` undoes exactly what it
+took. Seven mutations, each killed by a named test. It also settled what I8 can
+honestly promise: raw mode means Ctrl-C is a key event and never a signal, so an
+externally delivered `kill` is out of reach without a dependency `SPEC.md` does
+not name. That is [#24](https://github.com/breferrari/vigia/issues/24), on the
+shelf below.
+
+**Take [#6](https://github.com/breferrari/vigia/issues/6) next.** I5 is follow
+mode, and it is the last thing that makes the monitor correct with nobody
+touching it, which is the product class. Nothing in the shell reads follow state
+today: #9 deliberately shipped no `f` toggle rather than a key that flips a bool
+nothing consumes.
 
 [#7](https://github.com/breferrari/vigia/issues/7) then has a baseline to argue
 with: there are 40- and 80-column snapshots already, and what I6 still needs is
@@ -163,6 +171,7 @@ The shelf carries the *reason*; this table carries the *state*.
 | ⬜ | Two paths differing outside UTF-8 collapse onto one cache key | [#17](https://github.com/breferrari/vigia/issues/17) |
 | ⬜ | A frame reads a whole file to discover it is binary | [#18](https://github.com/breferrari/vigia/issues/18) |
 | ⬜ | An idle frame is one `stat` per changed file | [#19](https://github.com/breferrari/vigia/issues/19) |
+| ⬜ | An external kill leaves the terminal in raw mode | [#24](https://github.com/breferrari/vigia/issues/24) |
 | ✅ | `take-next`: pre-flight the spec against the tracker | [#20](https://github.com/breferrari/vigia/issues/20) |
 
 ---
@@ -183,6 +192,7 @@ scope creep absorbed silently. Each one carries the phase it moved to.
 | Two paths differing outside UTF-8 collapse onto one cache key ([#17](https://github.com/breferrari/vigia/issues/17)) | I2a, 2026-07-30 | Phase 2 | `to_str_lossy` makes `FileChange::path` both the filesystem identity and the display string, and those are different jobs. The read half predates the frame path. Fixing it changes a published type, so it wants deciding rather than patching |
 | A frame reads a whole file to discover it is binary ([#18](https://github.com/breferrari/vigia/issues/18)) | I2a, 2026-07-30 | Phase 2 | 64 MiB read and 16.24ms for a file the first 8000 bytes already condemn, with no size cap on either side. Pre-existing in `Worktree::diff`. Belongs with I3, which is where a memory ceiling gets decided |
 | An idle frame is one `stat` per changed file ([#19](https://github.com/breferrari/vigia/issues/19)) | I2a, 2026-07-30 | Phase 2, with the shell | 36.71ms at 2000 changed files against a 16ms budget, almost all of it syscalls. The fix is to revalidate what is drawn rather than everything, which I4 already licenses and which needs a UI that knows what is visible. Not a defect in the rule, a consequence of the test having to materialise every file to avoid passing vacuously |
+| An external kill leaves the terminal in raw mode ([#24](https://github.com/breferrari/vigia/issues/24)) | I8, 2026-07-30 | Phase 5 | I8 promised "including `SIGINT`" and the shell falsified the premise: raw mode clears `ISIG` and `ENABLE_PROCESSED_INPUT`, so the interrupt key is a key event and never a signal. What is left is a signal nobody at this keyboard sent, and `std` has no way to catch one, so closing it is a dependency decision rather than an implementation detail. The single-task version is Unix-only (`signal-hook`, with `SetConsoleCtrlHandler` needed separately on Windows), which is the same asymmetric guarantee #16 already rejected as worse than one stated uniformly. `SPEC.md` I8 was narrowed to say so out loud instead of overselling |
 
 ## Pull-forward log
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,24 +1,18 @@
 # vigia — Specification
 
-Status: **v0, 2026-07-30.** Source of truth. Code is written against this
-document; see `CLAUDE.md` § Method for the drift rule.
+Status: **v0, 2026-07-30.** Source of truth. Code is written against this document; see `CLAUDE.md` § Method for the drift rule.
 
 ---
 
 ## 1. Problem
 
-Running a full git TUI in a pane beside an AI coding agent, to watch changes as
-they land, is the wrong tool. A multi-panel git client spends the pane on
-branches, commits, stashes and status. In a pane already halved against the
-agent, every panel is a few lines tall and names truncate.
+Running a full git TUI in a pane beside an AI coding agent, to watch changes as they land, is the wrong tool. A multi-panel git client spends the pane on branches, commits, stashes and status. In a pane already halved against the agent, every panel is a few lines tall and names truncate.
 
-What is wanted: **the live diff, fullscreen, auto-updating, scrollable,
-mouse-driven, and beautiful.** Nothing else.
+What is wanted: **the live diff, fullscreen, auto-updating, scrollable, mouse-driven, and beautiful.** Nothing else.
 
 ## 2. Product class — the load-bearing decision
 
-`vigia` is a **monitor**, not a reviewer. That single distinction generates every
-budget below, and the budgets are the product.
+`vigia` is a **monitor**, not a reviewer. That single distinction generates every budget below, and the budgets are the product.
 
 | | Reviewer | **Monitor (`vigia`)** |
 |---|---|---|
@@ -28,19 +22,15 @@ budget below, and the budgets are the product.
 | Runtime | Minutes | **Days** |
 | Latency budget | Seconds | **A frame** |
 
-`btop` is the reference for what monitor-class feels like: you read state from
-shape and colour, glance away, glance back, and never configure anything.
+`btop` is the reference for what monitor-class feels like: you read state from shape and colour, glance away, glance back, and never configure anything.
 
-Design rationale beyond this section is recorded outside the codebase; call
-`recall` when a decision needs it.
+Design rationale beyond this section is recorded outside the codebase; call `recall` when a decision needs it.
 
 ## 3. Invariants
 
-Numbered because tests reference them. Each must have a test that fails on
-violation. **An invariant without a failing test is a wish.**
+Numbered because tests reference them. Each must have a test that fails on violation. **An invariant without a failing test is a wish.**
 
-Budgets are **absolute** and chosen to be defensible on their own terms, not
-relative to any other tool.
+Budgets are **absolute** and chosen to be defensible on their own terms, not relative to any other tool.
 
 | # | Invariant | Budget | How it is proven |
 |---|---|---|---|
@@ -90,40 +80,28 @@ A regression past any budget **fails the build.**
 
 ## 4. Scope
 
-**In:** working-tree diff (unstaged by default), event-driven refresh, follow
-mode, scroll (keyboard + mouse wheel), syntax highlighting, per-file churn
-visualisation, responsive layout, theming.
+**In:** working-tree diff (unstaged by default), event-driven refresh, follow mode, scroll (keyboard + mouse wheel), syntax highlighting, per-file churn visualisation, responsive layout, theming.
 
-**Out of v1, deliberately:** staging, committing, rebasing, branch or commit
-browsing, annotations, comment threading, AI features, remote operations. Each is
-reviewer-class and each would cost an invariant.
+**Out of v1, deliberately:** staging, committing, rebasing, branch or commit browsing, annotations, comment threading, AI features, remote operations. Each is reviewer-class and each would cost an invariant.
 
-**Deferred, not rejected:** multi-worktree view (several agent sessions at once —
-the strongest differentiator after glanceability, and the most btop-shaped);
-Jujutsu and Sapling support.
+**Deferred, not rejected:** multi-worktree view (several agent sessions at once — the strongest differentiator after glanceability, and the most btop-shaped); Jujutsu and Sapling support.
 
 ## 5. The differentiator: glanceability
 
-`btop`'s real achievement is that state is readable from **shape and colour**
-without reading text. `vigia`'s translation:
+`btop`'s real achievement is that state is readable from **shape and colour** without reading text. `vigia`'s translation:
 
 - per-file **churn sparkline** — change density over time
 - a **heat strip** locating change within the file
 - live **+/− counters**
 - a **visual pulse** on what just changed
 
-This is what makes it a monitor rather than a narrow diff view, and it is where
-design effort goes once the invariants hold.
+This is what makes it a monitor rather than a narrow diff view, and it is where design effort goes once the invariants hold.
 
 ### 5.1 What the README mockup commits to
 
-`assets/preview.svg` is the most detailed design artifact in the project, it is
-**public**, and until now it was specified by a three-sentence caption. A picture
-in a README is a promise; these are the promises in it, and what each one costs.
+`assets/preview.svg` is the most detailed design artifact in the project, it is **public**, and until now it was specified by a three-sentence caption. A picture in a README is a promise; these are the promises in it, and what each one costs.
 
-Elements the four bullets above do **not** cover are marked **(unspecified)** —
-they are in the picture, so they are committed, and they had nowhere to be
-described.
+Elements the four bullets above do **not** cover are marked **(unspecified)** — they are in the picture, so they are committed, and they had nowhere to be described.
 
 | Element in the mockup | What it needs |
 |---|---|
@@ -140,36 +118,16 @@ described.
 
 Two of these are corrections rather than gaps:
 
-1. **`f` toggles follow.** The mockup shows a dedicated key and a state
-   indicator. That is the answer to §11.2 B1, and it was published before the
-   question was asked — `f` simply does not exist in `input.rs` yet.
-2. **The dimmed row and the `just changed` label are one mechanism**, not two:
-   both are recency rendered as intensity. Specifying them separately would
-   produce two decay clocks that disagree on screen.
+1. **`f` toggles follow.** The mockup shows a dedicated key and a state indicator. That is the answer to §11.2 B1, and it was published before the question was asked — `f` simply does not exist in `input.rs` yet.
+2. **The dimmed row and the `just changed` label are one mechanism**, not two: both are recency rendered as intensity. Specifying them separately would produce two decay clocks that disagree on screen.
 
-**A picture in a public README is a specification whether or not it is written
-down.** This one implied a retained time series, a recency gradient, two status
-readouts and a keybinding, none of which appeared in the spec, the roadmap, or
-any issue — while [#10](https://github.com/breferrari/vigia/issues/10) carried
-four of them in a single line. That is the same failure as §11: behaviour that
-exists somewhere real, with no line claiming it.
+**A picture in a public README is a specification whether or not it is written down.** This one implied a retained time series, a recency gradient, two status readouts and a keybinding, none of which appeared in the spec, the roadmap, or any issue — while [#10](https://github.com/breferrari/vigia/issues/10) carried four of them in a single line. That is the same failure as §11: behaviour that exists somewhere real, with no line claiming it.
 
 ### 5.2 Where the mockup pulls against the invariants
 
-§5 says design effort goes here "once the invariants hold", and
-[#10](https://github.com/breferrari/vigia/issues/10) repeats it: *"depends on the
-invariants holding first."* **That framing is wrong, and correcting it is the most
-consequential thing in this section.** At least two elements need retained state
-the frame path does not produce, in `vigia-core` rather than in the shell. They do
-not sit on top of the invariants. They **move** them.
+§5 says design effort goes here "once the invariants hold", and [#10](https://github.com/breferrari/vigia/issues/10) repeats it: *"depends on the invariants holding first."* **That framing is wrong, and correcting it is the most consequential thing in this section.** At least two elements need retained state the frame path does not produce, in `vigia-core` rather than in the shell. They do not sit on top of the invariants. They **move** them.
 
-**The sparkline needs precisely what eviction throws away.** `FrameStats.evicted`
-exists so the cached-diff map stays "bounded by the current diff rather than by
-everything ever edited" — that is how I3 is argued today. A churn sparkline is
-change density *over time*, so it has to survive a file settling: one that empties
-the moment a file stops changing shows nothing worth glancing at, and *"what was
-hot thirty seconds ago"* is the entire question it answers. Glanceability history
-therefore cannot live in the evicting map — and must not be unbounded either.
+**The sparkline needs precisely what eviction throws away.** `FrameStats.evicted` exists so the cached-diff map stays "bounded by the current diff rather than by everything ever edited" — that is how I3 is argued today. A churn sparkline is change density *over time*, so it has to survive a file settling: one that empties the moment a file stops changing shows nothing worth glancing at, and *"what was hot thirty seconds ago"* is the entire question it answers. Glanceability history therefore cannot live in the evicting map — and must not be unbounded either.
 
 > [!warning] Proposed I10 — bounded history
 > Deliberately **not** in the §3 table, because that table is for invariants with
@@ -185,263 +143,89 @@ therefore cannot live in the evicting map — and must not be unbounded either.
 > sparkline task is blocked on it, because **the data structure is the decision**
 > and the drawing is the easy part.
 
-**The heat strip needs a whole-file property.** Locating change within a file
-requires that file's **total line count**, and the frame path is built to avoid
-exactly that: pure revalidation reads **0 bytes** (§10), the number I2a is written
-against. Measured naively — every changed file, every frame — it reintroduces the
-read I2a removed. It is cacheable per `(path, blob id)`, since a file's length
-cannot change without its content changing, so it is payable once per version
-rather than once per frame. **That caching is not an optimisation; without it the
-heat strip breaks I2a.**
+**The heat strip needs a whole-file property.** Locating change within a file requires that file's **total line count**, and the frame path is built to avoid exactly that: pure revalidation reads **0 bytes** (§10), the number I2a is written against. Measured naively — every changed file, every frame — it reintroduces the read I2a removed. It is cacheable per `(path, blob id)`, since a file's length cannot change without its content changing, so it is payable once per version rather than once per frame. **That caching is not an optimisation; without it the heat strip breaks I2a.**
 
-**Two status readouts measure the thing they run inside.** `0.8ms frame` means
-instrumenting the render path and drawing the result — a readout whose own cost
-falls inside the budget it reports, gated by I9 at 16ms p99. `11MB` is a live RSS
-number, and I3 samples RSS in a **soak test** precisely because reading it is a
-syscall on some platforms rather than free per frame. Both are honest to show;
-neither is free to show; the spec said nothing about either.
+**Two status readouts measure the thing they run inside.** `0.8ms frame` means instrumenting the render path and drawing the result — a readout whose own cost falls inside the budget it reports, gated by I9 at 16ms p99. `11MB` is a live RSS number, and I3 samples RSS in a **soak test** precisely because reading it is a syscall on some platforms rather than free per frame. Both are honest to show; neither is free to show; the spec said nothing about either.
 
-**Consequence for sequencing:** Phase 3 is not a rendering phase. Its two headline
-elements each need a core-side change with an invariant attached, so they belong
-in the same conversation as I2a and I3 rather than strictly after them.
+**Consequence for sequencing:** Phase 3 is not a rendering phase. Its two headline elements each need a core-side change with an invariant attached, so they belong in the same conversation as I2a and I3 rather than strictly after them.
 
 ## 6. Architecture
 
 Cargo workspace, two crates:
 
-- **`vigia-core`** — library. Git (`gix`), diff modelling, incremental
-  highlighting (`syntect`), filesystem events (`notify`), the watch and coalesce
-  engine, the frame path. **No terminal I/O, no ratatui.** Every invariant except
-  I6 and I8 is testable here, headlessly.
-- **`vigia`** — the `ratatui` + `crossterm` shell: input, layout, theming. Thin by
-  design, so the TUI stays swappable and the engine stays provable. A library
-  with a five-line binary on top rather than a binary alone, because §7 makes the
-  snapshot suite the proof for I5 and I6 and a test cannot import a `main.rs`.
+- **`vigia-core`** — library. Git (`gix`), diff modelling, incremental highlighting (`syntect`), filesystem events (`notify`), the watch and coalesce engine, the frame path. **No terminal I/O, no ratatui.** Every invariant except I6 and I8 is testable here, headlessly.
+- **`vigia`** — the `ratatui` + `crossterm` shell: input, layout, theming. Thin by design, so the TUI stays swappable and the engine stays provable. A library with a five-line binary on top rather than a binary alone, because §7 makes the snapshot suite the proof for I5 and I6 and a test cannot import a `main.rs`.
 
-The split is a dependency decision, not a hedge: the TUI renders whatever the
-core produces, so the core has to work first or the TUI is being built on sand.
+The split is a dependency decision, not a hedge: the TUI renders whatever the core produces, so the core has to work first or the TUI is being built on sand.
 
-`notify` is named here because I1 requires filesystem events rather than a
-timer, and each platform delivers them differently: `inotify` on Linux,
-`FSEvents` on macOS, `ReadDirectoryChangesW` on Windows. `notify` is the
-standard Rust abstraction over those three, and it keeps the binary pure Rust.
-Verified 2026-07-30 against `x86_64-pc-windows-msvc`,
-`x86_64-unknown-linux-musl` and `aarch64-apple-darwin`: no `cc`, `cmake` or
-`bindgen` in any of the three graphs. The `-sys` crates it pulls
-(`inotify-sys`, `fsevent-sys`, `windows-sys`) are FFI declarations against
-facilities the OS already ships, so they compile no C.
+`notify` is named here because I1 requires filesystem events rather than a timer, and each platform delivers them differently: `inotify` on Linux, `FSEvents` on macOS, `ReadDirectoryChangesW` on Windows. `notify` is the standard Rust abstraction over those three, and it keeps the binary pure Rust. Verified 2026-07-30 against `x86_64-pc-windows-msvc`, `x86_64-unknown-linux-musl` and `aarch64-apple-darwin`: no `cc`, `cmake` or `bindgen` in any of the three graphs. The `-sys` crates it pulls (`inotify-sys`, `fsevent-sys`, `windows-sys`) are FFI declarations against facilities the OS already ships, so they compile no C.
 
-**Coalescing stays ours.** `notify` has a companion debouncer crate, and taking
-it would move coalesce policy out of `vigia-core`, which is the one place I1 is
-testable. `notify` supplies raw events and nothing else.
+**Coalescing stays ours.** `notify` has a companion debouncer crate, and taking it would move coalesce policy out of `vigia-core`, which is the one place I1 is testable. `notify` supplies raw events and nothing else.
 
-**The frame path keeps its diffs between frames.** I2a forbids re-diffing a file
-that did not change, so the core holds the previous frame's diff per path and
-revalidates instead of recomputing. Validity is decided from three things that
-cost no file read: the index blob the change names, the kind of change, and a
-`stat` of the working-tree file. Content is never hashed to decide this, because
-hashing is the read I2a exists to avoid.
+**The frame path keeps its diffs between frames.** I2a forbids re-diffing a file that did not change, so the core holds the previous frame's diff per path and revalidates instead of recomputing. Validity is decided from three things that cost no file read: the index blob the change names, the kind of change, and a `stat` of the working-tree file. Content is never hashed to decide this, because hashing is the read I2a exists to avoid.
 
-A `stat` on its own is not proof, and the gap is the one git calls *racily
-clean*: two writes of the same length inside a single modification-time granule
-are indistinguishable by `stat`.
+A `stat` on its own is not proof, and the gap is the one git calls *racily clean*: two writes of the same length inside a single modification-time granule are indistinguishable by `stat`.
 
-The rule that closes it has to account for **flooring**. A filesystem stamps a
-modification time by truncating the current time to its own granularity, so a
-write landing *after* a read can record a time *before* it. "Older than the
-read" therefore proves nothing, because the granule may still be open: measured
-on NTFS, that mistake serves a stale diff on about one same-length rewrite in
-four hundred, and on a 1s-granule volume it would be most of them. So a
-fingerprint is trusted only once a **full granule has passed** between the stamp
-and the read, and anything else is re-diffed. The margin is a constant that must
-be an upper bound on real granularity: **2 seconds**, since FAT and exFAT
-quantise to 2s and HFS+ to 1s, where NTFS, ext4 and APFS are milliseconds or
-finer. That trades redundant diffs of files written in the last two seconds,
-which are files that just changed, for never showing a stale one.
+The rule that closes it has to account for **flooring**. A filesystem stamps a modification time by truncating the current time to its own granularity, so a write landing *after* a read can record a time *before* it. "Older than the read" therefore proves nothing, because the granule may still be open: measured on NTFS, that mistake serves a stale diff on about one same-length rewrite in four hundred, and on a 1s-granule volume it would be most of them. So a fingerprint is trusted only once a **full granule has passed** between the stamp and the read, and anything else is re-diffed. The margin is a constant that must be an upper bound on real granularity: **2 seconds**, since FAT and exFAT quantise to 2s and HFS+ to 1s, where NTFS, ext4 and APFS are milliseconds or finer. That trades redundant diffs of files written in the last two seconds, which are files that just changed, for never showing a stale one.
 
-**What it still cannot see** is a writer that restores a modification time it did
-not advance: `cp -p`, `rsync -t`, `unzip`, `touch -r`. Git carries the inode
-change time to catch those, and `std` exposes no equivalent on Windows, so
-closing it is a dependency decision rather than an implementation detail. Tracked
-on the deferral shelf rather than assumed away.
+**What it still cannot see** is a writer that restores a modification time it did not advance: `cp -p`, `rsync -t`, `unzip`, `touch -r`. Git carries the inode change time to catch those, and `std` exposes no equivalent on Windows, so closing it is a dependency decision rather than an implementation detail. Tracked on the deferral shelf rather than assumed away.
 
-**And it assumes the modification time is stamped by the local clock.** The
-margin compares a filesystem timestamp against this process's clock, so on a
-network filesystem the server's skew subtracts directly from it: a server two
-seconds behind consumes the whole margin and the flooring problem returns. Local
-worktrees, which is what a monitor beside an agent watches, are unaffected.
+**And it assumes the modification time is stamped by the local clock.** The margin compares a filesystem timestamp against this process's clock, so on a network filesystem the server's skew subtracts directly from it: a server two seconds behind consumes the whole margin and the flooring problem returns. Local worktrees, which is what a monitor beside an agent watches, are unaffected.
 
 ## 7. Testing
 
-- **Snapshot tests over `ratatui::backend::TestBackend` with `insta`** — render
-  frames into an in-memory buffer, snapshot as text. This is what makes I5 and I6
-  assertable at all: the UI becomes diffable text.
-- **`criterion`** for I4, I7 and I9, **tracking rather than gating.** Criterion
-  compares a run against a saved baseline, and the budgets in §3 are absolute,
-  so it is the right instrument for "this got 20% slower" and the wrong one for
-  a pass/fail line. Compiled in CI so the benchmarks cannot rot; not timed
-  there, because a shared runner cannot produce a number worth comparing.
-- **Budget gates** in `crates/vigia-core/tests/budgets.rs`, in **two tiers**,
-  because an absolute wall-clock threshold is a strong instrument on a known
-  machine and a weak one on a hosted runner:
-  - *Structural* gates compare the engine against itself across fixtures that
-    differ only in how much changed. They are ratios and exact byte counts, so
-    they are hardware-independent, take **no slack**, and are what actually
-    catches a regression. Making the frame path re-read every changed file is a
-    5x wall-clock change that a generous threshold waves through, and a 100x
-    byte-count change that these cannot.
-  - *Absolute* gates hold the wall clock to §3. Release only, since the budgets
-    were set against optimised code, and with a slack multiplier
-    (`VIGIA_BUDGET_SLACK`, default 1) so a shared runner's variance does not
-    read as a code regression.
-- **An invariant the engine can only make possible gets a second structural gate
-  over the caller**, in `crates/vigia/tests/`. I4 is the case: the core fetches
-  content per file, so painting the top of a large diff without reading the bottom
-  is *available*, and nothing in the core stops a renderer from asking for every
-  file anyway. Asking is the natural way to write one. So what one screenful costs
-  is gated where the screen is, against two fixtures differing only in changed-file
-  count, for the reason the tier above gives.
-- **An invariant whose two failure modes are not symmetrical gets a gate for
-  each.** I2a is the case that made this a rule. Reusing too *little* is slow and
-  loud, and the budget gate catches it. Reusing too *much* is fast, passes every
-  budget, and shows a diff that no longer exists, so
-  `crates/vigia-core/tests/frame.rs` compares every reused frame against one
-  computed with no memory at all. A budget gate alone would have called the
-  second failure a success.
-- **A rule covering a window too small to race is extracted as a pure function
-  and tested directly.** The racily-clean guard in §6 cannot be reached on demand
-  from a filesystem: dropping it leaves the whole integration suite green and only
-  a unit test over the decision function goes red. Where a correctness rule has no
-  reachable integration path, the pure-function test *is* the gate, and that is
-  worth stating rather than discovering.
-- **Gates are mutation tested before they are trusted.** Break the code
-  deliberately, confirm the gate goes red, restore. Two of the flaws found this
-  way were invisible to reading: a structural gate comparing one call against the
-  sum of its own calls, and a p99 over too few cold samples.
-- **Steady-state budgets are sampled after a warmup**, and over enough frames
-  for a percentile to be one. I9 is a claim about steady state, so the cold path
-  is outside its scope by definition; measured cold frames run ~40ms against a
-  warm p99 of ~3ms, and at 30 samples a nearest-rank p99 is just the maximum.
-- **A CI guard fails the build if `cc`, `cmake` or `bindgen` enters the
-  dependency graph** on any tier-1 target, plus a musl build asserting the
-  binary links no shared libraries. The pure-Rust constraint is what makes
-  musl-static and Windows cheap, so it is enforced rather than trusted.
+- **Snapshot tests over `ratatui::backend::TestBackend` with `insta`** — render frames into an in-memory buffer, snapshot as text. This is what makes I5 and I6 assertable at all: the UI becomes diffable text.
+- **`criterion`** for I4, I7 and I9, **tracking rather than gating.** Criterion compares a run against a saved baseline, and the budgets in §3 are absolute, so it is the right instrument for "this got 20% slower" and the wrong one for a pass/fail line. Compiled in CI so the benchmarks cannot rot; not timed there, because a shared runner cannot produce a number worth comparing.
+- **Budget gates** in `crates/vigia-core/tests/budgets.rs`, in **two tiers**, because an absolute wall-clock threshold is a strong instrument on a known machine and a weak one on a hosted runner:
+  - *Structural* gates compare the engine against itself across fixtures that differ only in how much changed. They are ratios and exact byte counts, so they are hardware-independent, take **no slack**, and are what actually catches a regression. Making the frame path re-read every changed file is a 5x wall-clock change that a generous threshold waves through, and a 100x byte-count change that these cannot.
+  - *Absolute* gates hold the wall clock to §3. Release only, since the budgets were set against optimised code, and with a slack multiplier (`VIGIA_BUDGET_SLACK`, default 1) so a shared runner's variance does not read as a code regression.
+- **An invariant the engine can only make possible gets a second structural gate over the caller**, in `crates/vigia/tests/`. I4 is the case: the core fetches content per file, so painting the top of a large diff without reading the bottom is *available*, and nothing in the core stops a renderer from asking for every file anyway. Asking is the natural way to write one. So what one screenful costs is gated where the screen is, against two fixtures differing only in changed-file count, for the reason the tier above gives.
+- **An invariant whose two failure modes are not symmetrical gets a gate for each.** I2a is the case that made this a rule. Reusing too *little* is slow and loud, and the budget gate catches it. Reusing too *much* is fast, passes every budget, and shows a diff that no longer exists, so `crates/vigia-core/tests/frame.rs` compares every reused frame against one computed with no memory at all. A budget gate alone would have called the second failure a success.
+- **A rule covering a window too small to race is extracted as a pure function and tested directly.** The racily-clean guard in §6 cannot be reached on demand from a filesystem: dropping it leaves the whole integration suite green and only a unit test over the decision function goes red. Where a correctness rule has no reachable integration path, the pure-function test *is* the gate, and that is worth stating rather than discovering.
+- **Gates are mutation tested before they are trusted.** Break the code deliberately, confirm the gate goes red, restore. Two of the flaws found this way were invisible to reading: a structural gate comparing one call against the sum of its own calls, and a p99 over too few cold samples.
+- **Steady-state budgets are sampled after a warmup**, and over enough frames for a percentile to be one. I9 is a claim about steady state, so the cold path is outside its scope by definition; measured cold frames run ~40ms against a warm p99 of ~3ms, and at 30 samples a nearest-rank p99 is just the maximum.
+- **A CI guard fails the build if `cc`, `cmake` or `bindgen` enters the dependency graph** on any tier-1 target, plus a musl build asserting the binary links no shared libraries. The pure-Rust constraint is what makes musl-static and Windows cheap, so it is enforced rather than trusted.
 - **Soak test** for I3, scheduled rather than per-commit.
 - **`proptest`** over diff parsing and hunk-boundary logic.
 
 ## 8. Phases
 
-Live status, issue-linked, is in [`ROADMAP.md`](ROADMAP.md). This section is the
-shape; that file is the state. Work is taken one task at a time via
-`.claude/skills/take-next/`.
+Live status, issue-linked, is in [`ROADMAP.md`](ROADMAP.md). This section is the shape; that file is the state. Work is taken one task at a time via `.claude/skills/take-next/`.
 
-**Phase 1 — core engine.** `vigia-core` plus a `main` that prints frame timings.
-Prove `gix` gives working-tree-vs-index diffs at the fidelity and speed needed —
-it is the least-precedented dependency in the stack and everything sits on it.
-Land **I1, I2a, I4, I7, I9**, each gated. No TUI.
+**Phase 1 — core engine.** `vigia-core` plus a `main` that prints frame timings. Prove `gix` gives working-tree-vs-index diffs at the fidelity and speed needed — it is the least-precedented dependency in the stack and everything sits on it. Land **I1, I2a, I4, I7, I9**, each gated. No TUI.
 
-**Phase 2 — minimum monitor.** ratatui + crossterm shell. Follow mode (I5),
-scroll, mouse, exit safety (I8), 40-column layout (I6). Plus **I2b** (needs
-`syntect`) and **I3** (soak). Snapshot suite.
+**Phase 2 — minimum monitor.** ratatui + crossterm shell. Follow mode (I5), scroll, mouse, exit safety (I8), 40-column layout (I6). Plus **I2b** (needs `syntect`) and **I3** (soak). Snapshot suite.
 
 **Phase 3 — glanceability.** Section 5, plus theming.
 
-**Phase 4 — distribution.** `cargo-dist`, crates.io publish, personal Homebrew
-tap, prebuilt binaries on GitHub releases.
+**Phase 4 — distribution.** `cargo-dist`, crates.io publish, personal Homebrew tap, prebuilt binaries on GitHub releases.
 
 **Phase 5 — deferred items**, only if daily use asks for them.
 
 ## 9. Distribution
 
-- **crates.io** — `cargo install vigia`. A name **cannot be reserved; it must be
-  published**, and a publish is **permanent** (`cargo yank` hides a version from
-  new dependents, it does not delete it, and the name stays taken). So the first
-  publish should be a crate that does the minimal real thing. Verified free
-  2026-07-30.
-- **Homebrew** — `homebrew-core` **cannot be reserved** and requires notability:
-  ≥30 forks **or** ≥30 watchers **or** ≥75 stars, plus a stable versioned
-  release. Until then a **personal tap** (`breferrari/homebrew-tap`) gives
-  `brew install breferrari/tap/vigia` immediately, is fully under our control, and
-  is what `cargo-dist` generates.
+- **crates.io** — `cargo install vigia`. A name **cannot be reserved; it must be published**, and a publish is **permanent** (`cargo yank` hides a version from new dependents, it does not delete it, and the name stays taken). So the first publish should be a crate that does the minimal real thing. Verified free 2026-07-30.
+- **Homebrew** — `homebrew-core` **cannot be reserved** and requires notability: ≥30 forks **or** ≥30 watchers **or** ≥75 stars, plus a stable versioned release. Until then a **personal tap** (`breferrari/homebrew-tap`) gives `brew install breferrari/tap/vigia` immediately, is fully under our control, and is what `cargo-dist` generates.
 - **GitHub releases** — prebuilt binaries per platform via `cargo-dist`.
 - No domain. Not needed for a CLI.
 
 ## 10. Open questions
 
-- [x] ~~Does `gix` cover working-tree-vs-index diff at the fidelity and speed
-      needed?~~ **Answered 2026-07-30: yes.** Hunk boundaries match
-      `git diff -U3` exactly, with git used as the oracle at every edit gap from
-      0 to 10 lines. On a 100k-line diff, release build: first change available
-      in 3.84ms against the 100ms I4 budget, single-file re-diff 3.27ms p99
-      against the 16ms I9 budget, process start to first paint 20.37ms against
-      the 50ms I7 budget. The dependency that could have forced a rethink did
-      not.
-- [ ] Rename tracking cannot stream. Pairing a deletion with an addition needs
-      the whole walk, so with it on the first change arrives at 97% of the walk
-      and time-to-first equals time-to-last. It is on by default anyway, because
-      reporting a move as an unrelated delete plus add misdescribes what the
-      agent did. Confirm against a week of real use, or paint without renames
-      and reconcile them on a later frame.
-- [x] ~~Re-diffing every changed file costs 18.58ms p99 on a 100k-line diff,
-      over the I9 budget, against 3.27ms for a single file.~~ **Closed
-      2026-07-30:** I2a is enforced. The frame path revalidates from the index
-      blob, the change kind and a `stat`, so a single-line edit in a 100-file
-      worktree recomputes exactly one diff and reads exactly that file.
-      Measured over the same 100-file, 100k-line fixture, release build:
-      a **real frame under continuous edits is 6.97ms p99** against the 16ms I9
-      budget, revalidating 99 files and recomputing the one that moved. Pure
-      revalidation with nothing edited is 3.93ms and reads **0 bytes**. A cold
-      frame with nothing to reuse is 18.28ms and reads 3.6 MiB, which agrees with
-      the 18.58ms the spike measured over the primitives and is the cost I2a
-      removes. Every number in this bullet is a frame-path measurement; the
-      18.58ms above is the spike's, over `Worktree::diff` called per file.
-- [ ] The settle margin is a fixed 2 seconds, sized for the coarsest filesystem
-      anyone might use rather than the one in front of us, so on NTFS it is over a
-      hundred times more conservative than it needs to be and on APFS far more.
-      **Measured cost, and it is not only redundant work:** after a bulk rewrite
-      of all 100 files in the 100k-line fixture, every frame recomputes every diff
-      for the whole margin, 18 to 21ms per frame, putting 82 of 620 consecutive
-      frames over the 16ms I9 budget for about two seconds. A formatter, a branch
-      switch or a multi-file agent edit all produce that shape. Single-file
-      editing is unaffected: one write costs 503 redundant diffs over 2.004s and
-      never approaches the budget, and autosave every 500ms stayed under it on
-      every one of 973 frames.
-      It can be narrowed per worktree with no extra I/O, which removes the breach
-      rather than tolerating it: the smallest positive difference between the
-      modification times status already reports is an upper bound on that
-      filesystem's granularity, which on NTFS would take the margin from 2s to
-      about 16ms. Do this before the soak test, since I3 will see the redundant
-      work too.
-- [ ] The frame path walks status to completion before it reports a file list,
-      so it does not stream the way the raw change iterator does. Two reasons it
-      costs nothing today: rename tracking cannot stream either and is on by
-      default, and a scrollbar needs the file count regardless of how few files
-      are drawn. What is open is whether both hold at ten thousand changed files,
-      where the walk itself could exceed I4. Revisit together with rename
-      tracking above, since they stand or fall together.
-- [ ] The header counts changed files and not changed lines. A repository-wide
-      `+`/`-` total needs every file's diff, and I4 makes first paint independent
-      of total diff size, so the two cannot both hold on the first frame. §5's
-      counters are per-file and cost nothing extra, since a file has to be diffed
-      to be drawn; only the total is affected. What is open is whether it is worth
-      computing behind the frame and revealing when it arrives, which belongs with
-      the rest of §5 in Phase 3.
-- [ ] Is `syntect` fast enough incrementally to hold I2b, or does it force
-      tree-sitter — and with it a C toolchain — back in?
-- [ ] Default view: unstaged only, or working-tree-vs-HEAD? Unstaged is the
-      thesis; confirm against a week of real use.
-- [ ] Windows: supported target or best-effort? Truecolor needs Win10+, and
-      legacy conhost degrades.
+- [x] ~~Does `gix` cover working-tree-vs-index diff at the fidelity and speed needed?~~ **Answered 2026-07-30: yes.** Hunk boundaries match `git diff -U3` exactly, with git used as the oracle at every edit gap from 0 to 10 lines. On a 100k-line diff, release build: first change available in 3.84ms against the 100ms I4 budget, single-file re-diff 3.27ms p99 against the 16ms I9 budget, process start to first paint 20.37ms against the 50ms I7 budget. The dependency that could have forced a rethink did not.
+- [ ] Rename tracking cannot stream. Pairing a deletion with an addition needs the whole walk, so with it on the first change arrives at 97% of the walk and time-to-first equals time-to-last. It is on by default anyway, because reporting a move as an unrelated delete plus add misdescribes what the agent did. Confirm against a week of real use, or paint without renames and reconcile them on a later frame.
+- [x] ~~Re-diffing every changed file costs 18.58ms p99 on a 100k-line diff, over the I9 budget, against 3.27ms for a single file.~~ **Closed 2026-07-30:** I2a is enforced. The frame path revalidates from the index blob, the change kind and a `stat`, so a single-line edit in a 100-file worktree recomputes exactly one diff and reads exactly that file. Measured over the same 100-file, 100k-line fixture, release build: a **real frame under continuous edits is 6.97ms p99** against the 16ms I9 budget, revalidating 99 files and recomputing the one that moved. Pure revalidation with nothing edited is 3.93ms and reads **0 bytes**. A cold frame with nothing to reuse is 18.28ms and reads 3.6 MiB, which agrees with the 18.58ms the spike measured over the primitives and is the cost I2a removes. Every number in this bullet is a frame-path measurement; the 18.58ms above is the spike's, over `Worktree::diff` called per file.
+- [ ] The settle margin is a fixed 2 seconds, sized for the coarsest filesystem anyone might use rather than the one in front of us, so on NTFS it is over a hundred times more conservative than it needs to be and on APFS far more. **Measured cost, and it is not only redundant work:** after a bulk rewrite of all 100 files in the 100k-line fixture, every frame recomputes every diff for the whole margin, 18 to 21ms per frame, putting 82 of 620 consecutive frames over the 16ms I9 budget for about two seconds. A formatter, a branch switch or a multi-file agent edit all produce that shape. Single-file editing is unaffected: one write costs 503 redundant diffs over 2.004s and never approaches the budget, and autosave every 500ms stayed under it on every one of 973 frames. It can be narrowed per worktree with no extra I/O, which removes the breach rather than tolerating it: the smallest positive difference between the modification times status already reports is an upper bound on that filesystem's granularity, which on NTFS would take the margin from 2s to about 16ms. Do this before the soak test, since I3 will see the redundant work too.
+- [ ] The frame path walks status to completion before it reports a file list, so it does not stream the way the raw change iterator does. Two reasons it costs nothing today: rename tracking cannot stream either and is on by default, and a scrollbar needs the file count regardless of how few files are drawn. What is open is whether both hold at ten thousand changed files, where the walk itself could exceed I4. Revisit together with rename tracking above, since they stand or fall together.
+- [ ] The header counts changed files and not changed lines. A repository-wide `+`/`-` total needs every file's diff, and I4 makes first paint independent of total diff size, so the two cannot both hold on the first frame. §5's counters are per-file and cost nothing extra, since a file has to be diffed to be drawn; only the total is affected. What is open is whether it is worth computing behind the frame and revealing when it arrives, which belongs with the rest of §5 in Phase 3.
+- [ ] Is `syntect` fast enough incrementally to hold I2b, or does it force tree-sitter — and with it a C toolchain — back in?
+- [ ] Default view: unstaged only, or working-tree-vs-HEAD? Unstaged is the thesis; confirm against a week of real use.
+- [ ] Windows: supported target or best-effort? Truecolor needs Win10+, and legacy conhost degrades.
 
 ## 11. Behaviour
 
-§3 says how well `vigia` does things. Every number in it is defensible and every
-one has a test. Nothing above says **what happens when you press a key, or when
-nothing has changed** — and that gap is why the product reads as a screenshot
-with budgets attached.
+§3 says how well `vigia` does things. Every number in it is defensible and every one has a test. Nothing above says **what happens when you press a key, or when nothing has changed** — and that gap is why the product reads as a screenshot with budgets attached.
 
-Two parts: what the shell already does, recorded because it was decided in code
-first, and what is still undecided.
+Two parts: what the shell already does, recorded because it was decided in code first, and what is still undecided.
 
 > [!warning] Behaviour decided in code without a line here is a defect
 > The README says this file is the source of truth, written before the code. That
@@ -454,15 +238,9 @@ first, and what is still undecided.
 
 ### 11.1 What the shell does today
 
-Back-filled from the implementation on 2026-07-30, not newly decided. Where this
-disagrees with the code, the code is the bug.
+Back-filled from the implementation on 2026-07-30, not newly decided. Where this disagrees with the code, the code is the bug.
 
-**What the diff contains.** Working tree against the index. **Untracked files are
-included** and diff as all-additions — load-bearing rather than incidental, since
-creating new files is among the most common things an agent does, and a tool blind
-to them would miss its own use case. Rename tracking is **on by default**: showing
-a move as an unrelated delete plus add misdescribes what the agent did. Its
-streaming cost is the open question in §10, not a settled trade.
+**What the diff contains.** Working tree against the index. **Untracked files are included** and diff as all-additions — load-bearing rather than incidental, since creating new files is among the most common things an agent does, and a tool blind to them would miss its own use case. Rename tracking is **on by default**: showing a move as an unrelated delete plus add misdescribes what the agent did. Its streaming cost is the open question in §10, not a settled trade.
 
 **Keys.**
 
@@ -478,85 +256,38 @@ streaming cost is the open question in §10, not a settled trade.
 | mouse wheel | scroll |
 | terminal resize | redraw, no state change |
 
-**Scroll position is `(file, offset within that file)`, never a row index.** A
-frame that changes something above the viewport therefore does not teleport the
-view. This is a correctness property, not an implementation detail: with a row
-index, an agent writing to a file earlier in the list would yank the reader's
-position on every keystroke it makes.
+**Scroll position is `(file, offset within that file)`, never a row index.** A frame that changes something above the viewport therefore does not teleport the view. This is a correctness property, not an implementation detail: with a row index, an agent writing to a file earlier in the list would yank the reader's position on every keystroke it makes.
 
-**CLI.** One optional positional path, defaulting to the working directory. No
-flags today.
+**CLI.** One optional positional path, defaulting to the working directory. No flags today.
 
 ### 11.2 Undecided — these gate Phase 2
 
-Each carries a recommendation marked **(proposed)**. None is settled until ruled
-on, and none may contradict §3 — if one does, §3 wins and the recommendation is
-wrong.
+Each carries a recommendation marked **(proposed)**. None is settled until ruled on, and none may contradict §3 — if one does, §3 wins and the recommendation is wrong.
 
-**B1 — What happens to follow mode when the reader scrolls.** I5 promises the
-view "auto-follows the newest change and scrolls to it, untouched", and **no
-follow mode exists in the code yet** — `Action` is quit, scroll, page, top,
-bottom, redraw. So the relationship between following and scrolling is genuinely
-open, and [#6](https://github.com/breferrari/vigia/issues/6) will otherwise
-settle it by accident inside a snapshot test.
+**B1 — What happens to follow mode when the reader scrolls.** I5 promises the view "auto-follows the newest change and scrolls to it, untouched", and **no follow mode exists in the code yet** — `Action` is quit, scroll, page, top, bottom, redraw. So the relationship between following and scrolling is genuinely open, and [#6](https://github.com/breferrari/vigia/issues/6) will otherwise settle it by accident inside a snapshot test.
 
-*(proposed)* `less +F` semantics, with the toggle **the README mockup already
-published**: follow is **on** at startup, **any manual scroll disengages it**, and
-**`f` re-engages** — the status bar shows `follow ▶` for the state and `f follow`
-in the hints. `f` does not exist in `input.rs` yet.
+*(proposed)* `less +F` semantics, with the toggle **the README mockup already published**: follow is **on** at startup, **any manual scroll disengages it**, and **`f` re-engages** — the status bar shows `follow ▶` for the state and `f follow` in the hints. `f` does not exist in `input.rs` yet.
 
-Rationale: disengage-on-scroll is the only rule that never fights a reader
-mid-read, and a dedicated toggle beats overloading `G`/`End`, because "jump to the
-last file" and "resume following" are different intents that would otherwise be
-the same key — you would be unable to look at the newest file without also
-re-arming the view.
+Rationale: disengage-on-scroll is the only rule that never fights a reader mid-read, and a dedicated toggle beats overloading `G`/`End`, because "jump to the last file" and "resume following" are different intents that would otherwise be the same key — you would be unable to look at the newest file without also re-arming the view.
 
-*An earlier draft of this bullet proposed `G`/`End` as the re-engage key. That
-contradicted the mockup, which is public and predates the question. When a
-published artifact already answers an open question, it is the answer — the
-question is only whether to keep it.*
+*An earlier draft of this bullet proposed `G`/`End` as the re-engage key. That contradicted the mockup, which is public and predates the question. When a published artifact already answers an open question, it is the answer — the question is only whether to keep it.*
 
-**B2 — Which file wins when several change at once.** An agent rewriting five
-files in one action is the normal case, not an edge case. "The newest change" is
-ambiguous the moment a batch coalesces.
+**B2 — Which file wins when several change at once.** An agent rewriting five files in one action is the normal case, not an edge case. "The newest change" is ambiguous the moment a batch coalesces.
 
-*(proposed)* Follow the file whose write landed **last** in the settled batch,
-and let §5's visual pulse carry the others. Rationale: it reads "newest"
-literally, it is stable rather than heuristic, and the pulse already exists to
-say "these moved too" without moving the viewport for each.
+*(proposed)* Follow the file whose write landed **last** in the settled batch, and let §5's visual pulse carry the others. Rationale: it reads "newest" literally, it is stable rather than heuristic, and the pulse already exists to say "these moved too" without moving the viewport for each.
 
-**B3 — The empty state.** Zero changes is not an edge case; it is the state the
-tool sits in most of the time, and it is the **first** thing anyone sees when
-they open it beside an agent that has not written yet. A blank pane is
-indistinguishable from a hang.
+**B3 — The empty state.** Zero changes is not an edge case; it is the state the tool sits in most of the time, and it is the **first** thing anyone sees when they open it beside an agent that has not written yet. A blank pane is indistinguishable from a hang.
 
-*(proposed)* Name it: repository, branch, "no changes", and an explicit statement
-that it is watching. This screen is the product's first impression and currently
-has no specification at all.
+*(proposed)* Name it: repository, branch, "no changes", and an explicit statement that it is watching. This screen is the product's first impression and currently has no specification at all.
 
-**B4 — Is the file list navigable?** The README mockup shows a file list above
-the diff. Selectable, with the diff jumping to the selection, or a map rather
-than a menu?
+**B4 — Is the file list navigable?** The README mockup shows a file list above the diff. Selectable, with the diff jumping to the selection, or a map rather than a menu?
 
-*(proposed)* **Not navigable in v1** — one continuous scroll, list as map.
-Rationale: selection implies focus, focus implies a second mode, and modes are
-reviewer-class (§2). The pane is 40 columns beside an agent, not a full-screen
-client.
+*(proposed)* **Not navigable in v1** — one continuous scroll, list as map. Rationale: selection implies focus, focus implies a second mode, and modes are reviewer-class (§2). The pane is 40 columns beside an agent, not a full-screen client.
 
-**B5 — Not a git repository, and submodules.** Neither appears anywhere in this
-spec.
+**B5 — Not a git repository, and submodules.** Neither appears anywhere in this spec.
 
-*(proposed)* Not a repository: exit non-zero with one line, **before** entering
-the alternate screen — an error painted inside a TUI that then restores the
-terminal is an error nobody reads. Submodules: out of v1, shown as an opaque
-directory and said so, because recursing into them costs the incremental
-guarantees in I2a.
+*(proposed)* Not a repository: exit non-zero with one line, **before** entering the alternate screen — an error painted inside a TUI that then restores the terminal is an error nobody reads. Submodules: out of v1, shown as an opaque directory and said so, because recursing into them costs the incremental guarantees in I2a.
 
-**B6 — CLI surface and configuration.** No flags exist; §5 theming arrives in
-Phase 3 with nowhere to configure it.
+**B6 — CLI surface and configuration.** No flags exist; §5 theming arrives in Phase 3 with nowhere to configure it.
 
-*(proposed)* Hold the CLI at one positional path plus `--version` / `--help`
-through v1, and add flags only when something asks for one. Configuration lands
-**with** theming in Phase 3, not before: a config file with one thing in it
-invites a second thing, and every option is a behaviour that needs a line in this
-section.
+*(proposed)* Hold the CLI at one positional path plus `--version` / `--help` through v1, and add flags only when something asks for one. Configuration lands **with** theming in Phase 3, not before: a config file with one thing in it invites a second thing, and every option is a behaviour that needs a line in this section.

--- a/SPEC.md
+++ b/SPEC.md
@@ -52,7 +52,7 @@ relative to any other tool.
 | **I5** | **Correct with zero interaction.** Auto-follows the newest change and scrolls to it, untouched. | — | Scripted edit sequence, snapshot the frame, no input given |
 | **I6** | **Legible at 40 columns.** No horizontal overflow, no truncated-to-useless labels. | — | Snapshots at 40 / 80 / 120 columns |
 | **I7** | Startup to first paint is imperceptible. | **< 50ms** | Timed, gated in CI |
-| **I8** | Terminal restored exactly on exit — including `SIGINT` and panic. | — | Alternate-screen assertions; panic hook test |
+| **I8** | Terminal restored on **every exit the process controls**: the quit key (Ctrl-C included), an error return, and a panic under `panic = "abort"`. An externally delivered signal is not covered — see [#24](https://github.com/breferrari/vigia/issues/24). | — | Takeover order and its exact inverse; the partial-failure unwinding; a panic-hook test; escape sequences against DEC's own numbers |
 | **I9** | Steady-state frame time holds 60fps under continuous edits. | **< 16ms** p99 | Gated over the **frame path**, not the primitives: a settled frame, one line rewritten before each frame, every file materialised. `criterion` tracks the same shape |
 
 A regression past any budget **fails the build.**
@@ -68,6 +68,25 @@ A regression past any budget **fails the build.**
 > for a single file, so I2a is load bearing rather than an optimisation.
 > Issues [#2](https://github.com/breferrari/vigia/issues/2) and
 > [#4](https://github.com/breferrari/vigia/issues/4).
+
+> [!note] Why I8 no longer says `SIGINT`
+> It read "restored exactly on exit — including `SIGINT` and panic", and the
+> `SIGINT` half encoded an assumption the shell falsified. **Raw mode removes the
+> signal.** `enable_raw_mode` clears `ISIG` on Unix and `ENABLE_PROCESSED_INPUT`
+> on Windows, so Ctrl-C is never translated: it arrives as an ordinary key event
+> and is handled by the key map, which is why `Session` never needed a handler and
+> why no test could ever have been written for the clause as worded.
+>
+> What that leaves genuinely uncovered is a signal nobody at this keyboard sent:
+> `kill -INT` or `-TERM` from another pane, which runs neither `Drop` nor the panic
+> hook. `std` has no signal API, so closing it is a **dependency decision** rather
+> than an implementation detail, and the single-platform version of it
+> (`signal-hook` on Unix, with `SetConsoleCtrlHandler` needed separately on
+> Windows) ships a guarantee whose meaning differs by tier-1 platform. That is the
+> same trade [#16](https://github.com/breferrari/vigia/issues/16) already rejected
+> as worse than one stated uniformly. Tracked as
+> [#24](https://github.com/breferrari/vigia/issues/24) rather than assumed away,
+> and the invariant above now states its own limit instead of overselling it.
 
 ## 4. Scope
 

--- a/crates/vigia/src/terminal.rs
+++ b/crates/vigia/src/terminal.rs
@@ -35,11 +35,11 @@
 //! the other. `SPEC.md` §7 licenses this directly: where a correctness rule has no
 //! reachable integration path, the pure-function test *is* the gate.
 //!
-//! What that leaves untested is the mapping from a [`Step`] to the escape sequence
-//! it really emits, since a recorder cannot see it. `the_real_console_gives_back_every_mode_it_set`
-//! closes that by driving the real [`Crossterm`] into a byte sink, and the ANSI
-//! table below checks the commands against DEC's own mode numbers rather than
-//! against crossterm restating itself.
+//! What that leaves untested is the mapping from a [`Step`] to the escape
+//! sequence it really emits, since a recorder cannot see it. The last layer of
+//! the test module closes that by driving the real [`Crossterm`] into a byte
+//! sink, and the ANSI table beside it checks the commands against DEC's own mode
+//! numbers rather than against crossterm restating itself.
 //!
 //! **Not covered, deliberately:** an externally delivered signal. Raw mode means
 //! Ctrl-C is a key event and not a signal, so there is nothing to catch on the
@@ -354,14 +354,21 @@ mod tests {
 
     /// A console that records instead of acting, and can be told to fail.
     ///
-    /// `Arc<Mutex<..>>` rather than `Rc<RefCell<..>>` because the panic-hook test
-    /// needs the same log inside a `Send + Sync + 'static` closure.
+    /// The log is shared rather than owned because every one of these is handed
+    /// to a [`Takeover`] that then owns it, and the assertions run after that
+    /// takeover has been dropped. A clone the test keeps is the only way back to
+    /// what the moved-away copy saw.
     #[derive(Clone)]
     struct Recorder {
         log: Arc<Mutex<Vec<Event>>>,
         /// The index into [`TAKEOVER`] whose `take` fails, if any.
         fail_at: Option<usize>,
-        taken: usize,
+        /// Calls to [`Console::take`] so far, **including** the one that fails.
+        ///
+        /// Not the same quantity as [`Takeover`]'s `taken`, which counts only
+        /// steps that succeeded. Kept distinct on purpose: conflating the two is
+        /// how a test stops being able to tell the off-by-one it exists to catch.
+        attempts: usize,
     }
 
     impl Recorder {
@@ -369,7 +376,7 @@ mod tests {
             Self {
                 log: Arc::new(Mutex::new(Vec::new())),
                 fail_at: None,
-                taken: 0,
+                attempts: 0,
             }
         }
 
@@ -411,8 +418,8 @@ mod tests {
 
     impl Console for Recorder {
         fn take(&mut self, step: Step) -> io::Result<()> {
-            let at = self.taken;
-            self.taken += 1;
+            let at = self.attempts;
+            self.attempts += 1;
             if self.fail_at == Some(at) {
                 return Err(io::Error::other(INJECTED));
             }

--- a/crates/vigia/src/terminal.rs
+++ b/crates/vigia/src/terminal.rs
@@ -118,6 +118,13 @@ pub(crate) struct Crossterm<W: Write> {
     out: W,
 }
 
+impl Crossterm<Stdout> {
+    /// The console the shell actually runs on.
+    fn on_stdout() -> Self {
+        Self { out: stdout() }
+    }
+}
+
 impl<W: Write> Console for Crossterm<W> {
     fn take(&mut self, step: Step) -> io::Result<()> {
         match step {
@@ -171,13 +178,19 @@ impl<C: Console> Takeover<C> {
 
 impl<C: Console> Drop for Takeover<C> {
     fn drop(&mut self) {
-        for step in TAKEOVER[..self.taken].iter().rev() {
-            self.console.give_back(*step);
-        }
-        // So a second drop cannot double the work. Unreachable through `Drop`
-        // alone, and cheap insurance for the `?` path in `take`, where the value
-        // is moved out of a partially built state.
-        self.taken = 0;
+        give_back_all(&mut self.console, self.taken);
+    }
+}
+
+/// Give the first `taken` steps of [`TAKEOVER`] back, in reverse.
+///
+/// One function rather than a loop at each call site, because the reverse walk
+/// *is* the invariant: the guard and the panic hook are two different ways of
+/// leaving, and while each wrote its own loop only one of them was covered by the
+/// test that pins the order.
+fn give_back_all<C: Console>(console: &mut C, taken: usize) {
+    for step in TAKEOVER[..taken].iter().rev() {
+        console.give_back(*step);
     }
 }
 
@@ -216,7 +229,7 @@ impl Session {
         // frame still restores.
         install_hook();
 
-        let takeover = Takeover::take(Crossterm { out: stdout() })?;
+        let takeover = Takeover::take(Crossterm::on_stdout())?;
         // On the `?`, `takeover` drops and gives the terminal back. That is the
         // whole reason the guard is built before the screen rather than beside
         // it.
@@ -257,13 +270,29 @@ fn check_drawable(is_terminal: bool) -> io::Result<()> {
 }
 
 /// Chain a restore onto the panic hook, once per process.
+///
+/// Builds its own console rather than borrowing a [`Session`]'s, because it has
+/// to run when there is no session to borrow: it is installed before the first
+/// step is taken, and a panic in that window is exactly the case `Drop` cannot
+/// reach.
 fn install_hook() {
-    install_hook_in(&HOOK, || {
-        let mut console = Crossterm { out: stdout() };
-        for step in TAKEOVER.iter().rev() {
-            console.give_back(*step);
-        }
-    });
+    install_hook_in(&HOOK, || restore_everything(&mut Crossterm::on_stdout()));
+}
+
+/// Give back the whole of [`TAKEOVER`], whatever was actually taken.
+///
+/// Named rather than inlined into the hook so the *decision* is assertable: the
+/// hook itself can only be observed by panicking a real process against a real
+/// terminal, so inlined, neither the count nor the direction would be reached by
+/// any test, and the panic path is the one that matters most when it is wrong.
+///
+/// Deliberately not symmetrical with [`Takeover`], which gives back only the
+/// prefix it took. At panic time there is no prefix to read, and the two
+/// directions are not equally bad: giving back a step never taken is a no-op or
+/// an escape sequence the terminal ignores, while failing to give back one that
+/// was leaves the reader with no echo.
+fn restore_everything<C: Console>(console: &mut C) {
+    give_back_all(console, TAKEOVER.len());
 }
 
 /// Chain `restore` onto the panic hook, at most once per `once`.
@@ -525,6 +554,24 @@ mod tests {
         assert_eq!(
             *order.lock().expect("order"),
             vec!["restore", "previous hook"]
+        );
+    }
+
+    #[test]
+    fn the_panic_hook_gives_back_everything_in_reverse() {
+        // What the hook does, minus which console it writes to. Without this the
+        // production panic path is reached by no test at all: the test below
+        // installs its own counting closure, so it pins that the hook fires once
+        // and says nothing about what the real one restores.
+        let mut recorder = Recorder::new();
+        restore_everything(&mut recorder);
+
+        let mut expected = TAKEOVER.to_vec();
+        expected.reverse();
+        assert_eq!(recorder.gave_back(), expected);
+        assert!(
+            recorder.took().is_empty(),
+            "restoring took something instead"
         );
     }
 

--- a/crates/vigia/src/terminal.rs
+++ b/crates/vigia/src/terminal.rs
@@ -66,7 +66,7 @@ static HOOK: Once = Once::new();
 
 /// One thing a session takes from the terminal and has to give back.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Step {
+enum Step {
     /// No line buffering, no echo, and no signal translation.
     RawMode,
     /// The alternate screen, so the reader's scrollback survives being watched.
@@ -83,7 +83,7 @@ pub(crate) enum Step {
 /// effects than anything else here, and ratatui's own restore path orders it the
 /// same way for that reason: the escape sequences that leave the alternate screen
 /// should be written while the terminal is still in the mode they were written in.
-pub(crate) const TAKEOVER: [Step; 4] = [
+const TAKEOVER: [Step; 4] = [
     Step::RawMode,
     Step::AlternateScreen,
     Step::MouseCapture,
@@ -95,7 +95,7 @@ pub(crate) const TAKEOVER: [Step; 4] = [
 /// Exists so the order in [`TAKEOVER`] and the unwinding in [`Takeover::take`] can
 /// be asserted against a recorder. See this module's header for why the real
 /// terminal cannot be the oracle.
-pub(crate) trait Console {
+trait Console {
     /// Take one step, or report why it could not be taken.
     fn take(&mut self, step: Step) -> io::Result<()>;
 
@@ -114,7 +114,7 @@ pub(crate) trait Console {
 /// is always [`stdout`], and [`Step::RawMode`] ignores the sink entirely because
 /// both platforms change the mode through a syscall rather than an escape
 /// sequence.
-pub(crate) struct Crossterm<W: Write> {
+struct Crossterm<W: Write> {
     out: W,
 }
 
@@ -151,7 +151,7 @@ impl<W: Write> Console for Crossterm<W> {
 /// reason a half-finished [`Session::enter`] can be undone exactly. A bare "did we
 /// start?" flag would either give back a step that was never taken or leak one
 /// that was.
-pub(crate) struct Takeover<C: Console> {
+struct Takeover<C: Console> {
     console: C,
     taken: usize,
 }
@@ -163,7 +163,7 @@ impl<C: Console> Takeover<C> {
     /// no `Takeover` yet. A bare `?` here would hand an error to a caller that
     /// prints it into a terminal still in raw mode, with no echo and no line
     /// editing, which is a worse outcome than the failure it is reporting.
-    pub(crate) fn take(console: C) -> io::Result<Self> {
+    fn take(console: C) -> io::Result<Self> {
         let mut takeover = Self { console, taken: 0 };
         for step in TAKEOVER {
             takeover.console.take(step)?;
@@ -784,7 +784,16 @@ mod tests {
             .expect("lib.rs");
         let declared: Vec<&str> = lib
             .lines()
-            .filter_map(|line| line.trim().strip_prefix("mod "))
+            .map(str::trim)
+            // Visibility stripped first, or `pub mod foo;` slips past the check
+            // that keeps this list honest and the module is silently exempt from
+            // the scan below. That is the one way this gate rots quietly.
+            .map(|line| {
+                line.strip_prefix("pub(crate) ")
+                    .or_else(|| line.strip_prefix("pub "))
+                    .unwrap_or(line)
+            })
+            .filter_map(|line| line.strip_prefix("mod "))
             .filter_map(|rest| rest.strip_suffix(';'))
             .collect();
         assert!(!declared.is_empty(), "no modules found in lib.rs");

--- a/crates/vigia/src/terminal.rs
+++ b/crates/vigia/src/terminal.rs
@@ -10,11 +10,44 @@
 //! alternate screen with no prompt, no echo, and a mouse that reports every
 //! movement as garbage.
 //!
-//! Proving both paths is [#8](https://github.com/breferrari/vigia/issues/8),
-//! which is where the alternate-screen assertions and the panic-hook test land.
-//! This module is the implementation those tests are written against.
+//! ## Why this module is shaped as policy over a trait
+//!
+//! I8 is proven here rather than in `crates/vigia/tests/`, and the shape is
+//! forced by two things that are not visible from reading the crossterm API.
+//! Both were measured before this was written, not assumed.
+//!
+//! **Raw mode is not observable.** Under `cargo test` on Windows,
+//! `is_raw_mode_enabled()` returns `Ok(true)` before anything has enabled it, and
+//! `enable_raw_mode()` succeeds against a stdout that is not a terminal. A test
+//! that asserted on real raw-mode state would pass against broken code, which is
+//! worse than no test.
+//!
+//! **Mouse capture is not ANSI everywhere.** On Windows
+//! `EnableMouseCapture::is_ansi_code_supported()` is `false`, so `execute!` routes
+//! it through the console API and writes **zero bytes** into the sink. A
+//! byte-exact assertion over the whole takeover would quietly mean one thing on
+//! Unix and another on Windows.
+//!
+//! So the terminal itself cannot be the oracle. What can be asserted exactly is
+//! the *policy*: which steps are taken, in what order, and that giving back is
+//! their exact inverse. [`Step`] and [`TAKEOVER`] make that policy data, [`Console`]
+//! makes the mechanism swappable, and [`Takeover`] is the guard that runs one over
+//! the other. `SPEC.md` §7 licenses this directly: where a correctness rule has no
+//! reachable integration path, the pure-function test *is* the gate.
+//!
+//! What that leaves untested is the mapping from a [`Step`] to the escape sequence
+//! it really emits, since a recorder cannot see it. `the_real_console_gives_back_every_mode_it_set`
+//! closes that by driving the real [`Crossterm`] into a byte sink, and the ANSI
+//! table below checks the commands against DEC's own mode numbers rather than
+//! against crossterm restating itself.
+//!
+//! **Not covered, deliberately:** an externally delivered signal. Raw mode means
+//! Ctrl-C is a key event and not a signal, so there is nothing to catch on the
+//! path a reader uses; a `kill` from elsewhere runs neither the guard nor the
+//! hook, and closing that needs a dependency `SPEC.md` does not name. See I8 and
+//! [#24](https://github.com/breferrari/vigia/issues/24).
 
-use std::io::{self, IsTerminal, Stdout, stdout};
+use std::io::{self, IsTerminal, Stdout, Write, stdout};
 use std::sync::Once;
 
 use ratatui::Terminal;
@@ -31,13 +64,142 @@ pub type Screen = Terminal<CrosstermBackend<Stdout>>;
 
 static HOOK: Once = Once::new();
 
+/// One thing a session takes from the terminal and has to give back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Step {
+    /// No line buffering, no echo, and no signal translation.
+    RawMode,
+    /// The alternate screen, so the reader's scrollback survives being watched.
+    AlternateScreen,
+    /// Mouse reporting, which `SPEC.md` §4 puts in scope for the wheel.
+    MouseCapture,
+    /// The cursor, which a monitor never places anywhere meaningful.
+    Cursor,
+}
+
+/// The order the terminal is taken in. Giving it back walks this **backwards**.
+///
+/// Raw mode is first, so it is the last thing given back. It has more side
+/// effects than anything else here, and ratatui's own restore path orders it the
+/// same way for that reason: the escape sequences that leave the alternate screen
+/// should be written while the terminal is still in the mode they were written in.
+pub(crate) const TAKEOVER: [Step; 4] = [
+    Step::RawMode,
+    Step::AlternateScreen,
+    Step::MouseCapture,
+    Step::Cursor,
+];
+
+/// The terminal underneath a [`Session`], as something that can be swapped.
+///
+/// Exists so the order in [`TAKEOVER`] and the unwinding in [`Takeover::take`] can
+/// be asserted against a recorder. See this module's header for why the real
+/// terminal cannot be the oracle.
+pub(crate) trait Console {
+    /// Take one step, or report why it could not be taken.
+    fn take(&mut self, step: Step) -> io::Result<()>;
+
+    /// Give one step back.
+    ///
+    /// Infallible on purpose. Nothing useful can be done about an error here: it
+    /// runs while a process is already leaving, sometimes while it is panicking,
+    /// and reporting it would mean writing to a terminal whose state is exactly
+    /// what is in doubt.
+    fn give_back(&mut self, step: Step);
+}
+
+/// The real console, over `crossterm`.
+///
+/// Generic over the sink only so a test can read back what it wrote. Production
+/// is always [`stdout`], and [`Step::RawMode`] ignores the sink entirely because
+/// both platforms change the mode through a syscall rather than an escape
+/// sequence.
+pub(crate) struct Crossterm<W: Write> {
+    out: W,
+}
+
+impl<W: Write> Console for Crossterm<W> {
+    fn take(&mut self, step: Step) -> io::Result<()> {
+        match step {
+            Step::RawMode => enable_raw_mode(),
+            Step::AlternateScreen => execute!(self.out, EnterAlternateScreen),
+            Step::MouseCapture => execute!(self.out, EnableMouseCapture),
+            Step::Cursor => execute!(self.out, Hide),
+        }
+    }
+
+    fn give_back(&mut self, step: Step) {
+        let _ = match step {
+            Step::RawMode => disable_raw_mode(),
+            Step::AlternateScreen => execute!(self.out, LeaveAlternateScreen),
+            Step::MouseCapture => execute!(self.out, DisableMouseCapture),
+            Step::Cursor => execute!(self.out, Show),
+        };
+    }
+}
+
+/// The terminal, taken. Gives itself back on drop.
+///
+/// `taken` is how far into [`TAKEOVER`] the takeover got, and it is the whole
+/// reason a half-finished [`Session::enter`] can be undone exactly. A bare "did we
+/// start?" flag would either give back a step that was never taken or leak one
+/// that was.
+pub(crate) struct Takeover<C: Console> {
+    console: C,
+    taken: usize,
+}
+
+impl<C: Console> Takeover<C> {
+    /// Take every step of [`TAKEOVER`], giving back what succeeded if one fails.
+    ///
+    /// The unwinding cannot lean on `Drop`, because on the failing path there is
+    /// no `Takeover` yet. A bare `?` here would hand an error to a caller that
+    /// prints it into a terminal still in raw mode, with no echo and no line
+    /// editing, which is a worse outcome than the failure it is reporting.
+    pub(crate) fn take(console: C) -> io::Result<Self> {
+        let mut takeover = Self { console, taken: 0 };
+        for step in TAKEOVER {
+            takeover.console.take(step)?;
+            // After the call, never before: a step that failed was not taken, and
+            // giving it back would write the undo for something that never
+            // happened.
+            takeover.taken += 1;
+        }
+        Ok(takeover)
+    }
+}
+
+impl<C: Console> Drop for Takeover<C> {
+    fn drop(&mut self) {
+        for step in TAKEOVER[..self.taken].iter().rev() {
+            self.console.give_back(*step);
+        }
+        // So a second drop cannot double the work. Unreachable through `Drop`
+        // alone, and cheap insurance for the `?` path in `take`, where the value
+        // is moved out of a partially built state.
+        self.taken = 0;
+    }
+}
+
 /// A taken terminal that gives itself back.
 ///
 /// Holding one is what makes the screen the shell's; dropping it is what makes it
 /// the reader's again. There is deliberately no way to restore early and keep
-/// drawing.
+/// drawing: [`Takeover`] is private, and a shell that could put the terminal back
+/// and keep drawing would be drawing onto the reader's shell prompt.
 pub struct Session {
-    screen: Option<Screen>,
+    /// Declared **first**, so it drops first and no live `Terminal` outlives the
+    /// screen it draws on, even for the length of a drop.
+    ///
+    /// Checked rather than assumed, because the intuitive reason is the wrong
+    /// one: neither `ratatui::Terminal` nor `CrosstermBackend` implements `Drop`,
+    /// so there is no buffered frame here that could flush itself into the
+    /// reader's shell after the alternate screen is gone. The ordering is
+    /// tidiness, not a fix for that.
+    screen: Screen,
+    /// Second, so the terminal goes back after the screen is gone. Never read;
+    /// its whole job is its `Drop`.
+    _takeover: Takeover<Crossterm<Stdout>>,
 }
 
 impl Session {
@@ -48,97 +210,554 @@ impl Session {
     /// half a megabyte of escape sequences in a pipe is a worse answer than a
     /// sentence explaining it.
     pub fn enter() -> io::Result<Self> {
-        if !stdout().is_terminal() {
-            return Err(io::Error::other(
-                "standard output is not a terminal, so there is nothing to draw on",
-            ));
-        }
+        check_drawable(stdout().is_terminal())?;
 
         // Before anything is changed, so a panic between here and the first
         // frame still restores.
         install_hook();
 
-        enable_raw_mode()?;
-
-        // Every failure from here on has to undo what already succeeded, and
-        // cannot lean on `Drop` to do it: there is no `Session` yet. A bare `?`
-        // on either line below returns an error to a caller that prints it into
-        // a terminal still in raw mode, with no echo and no line editing, which
-        // is a worse outcome than the failure it is reporting.
-        Self::or_restore(execute!(
-            stdout(),
-            EnterAlternateScreen,
-            EnableMouseCapture,
-            Hide
-        ))?;
+        let takeover = Takeover::take(Crossterm { out: stdout() })?;
+        // On the `?`, `takeover` drops and gives the terminal back. That is the
+        // whole reason the guard is built before the screen rather than beside
+        // it.
+        let screen = Terminal::new(CrosstermBackend::new(stdout()))?;
 
         Ok(Self {
-            screen: Some(Self::or_restore(Terminal::new(CrosstermBackend::new(
-                stdout(),
-            )))?),
+            screen,
+            _takeover: takeover,
         })
-    }
-
-    /// Put the terminal back before handing a failure to the caller.
-    fn or_restore<T>(result: io::Result<T>) -> io::Result<T> {
-        if result.is_err() {
-            restore();
-        }
-        result
     }
 
     /// The terminal to draw through.
     pub fn screen(&mut self) -> &mut Screen {
-        self.screen
-            .as_mut()
-            .expect("the screen is only taken away by Drop")
+        &mut self.screen
     }
 }
 
-impl Drop for Session {
-    fn drop(&mut self) {
-        // Dropped before the restore so that no live `Terminal` outlives the
-        // screen it draws on, even for the length of this function.
-        //
-        // Checked rather than assumed, because the intuitive reason is the wrong
-        // one: neither `ratatui::Terminal` nor `CrosstermBackend` implements
-        // `Drop`, so there is no buffered frame here that could flush itself into
-        // the reader's shell after the alternate screen is gone. Ordering these
-        // two lines is tidiness, not a fix for that.
-        self.screen = None;
-        restore();
+/// Refuse a standard output that is not a terminal.
+///
+/// Split out from [`Session::enter`] so the refusal is testable. `cargo test`
+/// captures stdout and `--nocapture` does not, so a test driving `Session::enter`
+/// directly would assert opposite things depending on how it was run, and would
+/// take over the terminal of anyone who ran it the second way.
+///
+/// Takes the answer rather than something to ask, because `std::io::IsTerminal`
+/// is a **sealed trait**: it cannot be implemented outside `std`, so there is no
+/// fake terminal to hand this. What that leaves uncovered is the single
+/// `stdout().is_terminal()` at the call site, which is one std call rather than a
+/// derivation that could be subtly wrong.
+fn check_drawable(is_terminal: bool) -> io::Result<()> {
+    if is_terminal {
+        Ok(())
+    } else {
+        Err(io::Error::other(
+            "standard output is not a terminal, so there is nothing to draw on",
+        ))
     }
-}
-
-/// Put the terminal back the way it was, ignoring failures.
-///
-/// Nothing useful can be done about an error here. It runs while a process is
-/// already leaving, sometimes while it is panicking, and reporting it would mean
-/// writing to a terminal whose state is exactly what is in doubt.
-///
-/// Private, and the three callers are all in this file. Restoring is a
-/// consequence of giving up a [`Session`] or of dying, never something a caller
-/// asks for: a shell that could put the terminal back and keep drawing would be
-/// drawing onto the reader's shell prompt.
-fn restore() {
-    // Raw mode first: it has more side effects than the alternate screen, and
-    // ratatui's own restore path orders it this way for that reason.
-    let _ = disable_raw_mode();
-    let _ = execute!(stdout(), DisableMouseCapture, LeaveAlternateScreen, Show);
 }
 
 /// Chain a restore onto the panic hook, once per process.
+fn install_hook() {
+    install_hook_in(&HOOK, || {
+        let mut console = Crossterm { out: stdout() };
+        for step in TAKEOVER.iter().rev() {
+            console.give_back(*step);
+        }
+    });
+}
+
+/// Chain `restore` onto the panic hook, at most once per `once`.
 ///
 /// Chained rather than replaced, so the panic message still reaches the reader
-/// through whatever hook was already there. `Once` because a second install
-/// would nest the restore inside itself, and every future panic would pay for
-/// every session ever opened.
-fn install_hook() {
-    HOOK.call_once(|| {
+/// through whatever hook was already there. `Once` because a second install would
+/// nest the restore inside itself, and every future panic would pay for every
+/// session ever opened.
+///
+/// Takes the `Once` rather than reaching for the static, so a test can install
+/// into one of its own instead of racing the process-global gate.
+fn install_hook_in(once: &Once, restore: impl Fn() + Send + Sync + 'static) {
+    once.call_once(|| {
         let previous = std::panic::take_hook();
-        std::panic::set_hook(Box::new(move |info| {
-            restore();
-            previous(info);
-        }));
+        std::panic::set_hook(Box::new(move |info| on_panic(&restore, &previous, info)));
     });
+}
+
+/// The order the panic path runs in: restore, then whatever hook was there.
+///
+/// A free function because `PanicHookInfo` cannot be constructed outside `std`,
+/// so a test cannot call a real hook, but it can call this. The order is the
+/// point: the previous hook prints the panic message, and it has to land on a
+/// terminal that has already been given back or the reader cannot read it.
+fn on_panic<T>(restore: impl Fn(), previous: impl Fn(T), info: T) {
+    restore();
+    previous(info);
+}
+
+#[cfg(test)]
+mod tests {
+    //! I8, as the policy it is.
+    //!
+    //! The module header says why none of this can be asserted against a real
+    //! terminal. What follows is in three layers, and the layers are not
+    //! interchangeable:
+    //!
+    //! 1. The **policy**, against a recorder: order, the exact inverse, and what
+    //!    a half-finished takeover gives back. This is most of I8.
+    //! 2. The **panic path**, which is a separate mechanism because
+    //!    `panic = "abort"` runs no destructors.
+    //! 3. The **adapter**, because a recorder cannot see that
+    //!    `Step::AlternateScreen` is wired to `LeaveAlternateScreen` rather than
+    //!    to `EnterAlternateScreen`. Layers 1 and 2 would both pass with that
+    //!    wire crossed.
+
+    use std::sync::{Arc, Mutex};
+
+    use ratatui::crossterm::Command;
+
+    use super::*;
+
+    /// What a [`Recorder`] saw, in the order it happened.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Event {
+        Took(Step),
+        GaveBack(Step),
+    }
+
+    /// A console that records instead of acting, and can be told to fail.
+    ///
+    /// `Arc<Mutex<..>>` rather than `Rc<RefCell<..>>` because the panic-hook test
+    /// needs the same log inside a `Send + Sync + 'static` closure.
+    #[derive(Clone)]
+    struct Recorder {
+        log: Arc<Mutex<Vec<Event>>>,
+        /// The index into [`TAKEOVER`] whose `take` fails, if any.
+        fail_at: Option<usize>,
+        taken: usize,
+    }
+
+    impl Recorder {
+        fn new() -> Self {
+            Self {
+                log: Arc::new(Mutex::new(Vec::new())),
+                fail_at: None,
+                taken: 0,
+            }
+        }
+
+        fn failing_at(index: usize) -> Self {
+            Self {
+                fail_at: Some(index),
+                ..Self::new()
+            }
+        }
+
+        fn events(&self) -> Vec<Event> {
+            self.log.lock().expect("log").clone()
+        }
+
+        fn took(&self) -> Vec<Step> {
+            self.events()
+                .into_iter()
+                .filter_map(|e| match e {
+                    Event::Took(step) => Some(step),
+                    Event::GaveBack(_) => None,
+                })
+                .collect()
+        }
+
+        fn gave_back(&self) -> Vec<Step> {
+            self.events()
+                .into_iter()
+                .filter_map(|e| match e {
+                    Event::GaveBack(step) => Some(step),
+                    Event::Took(_) => None,
+                })
+                .collect()
+        }
+    }
+
+    /// The message the injected failure carries, so a test can tell it apart from
+    /// an error the code invented.
+    const INJECTED: &str = "injected by the recorder";
+
+    impl Console for Recorder {
+        fn take(&mut self, step: Step) -> io::Result<()> {
+            let at = self.taken;
+            self.taken += 1;
+            if self.fail_at == Some(at) {
+                return Err(io::Error::other(INJECTED));
+            }
+            self.log.lock().expect("log").push(Event::Took(step));
+            Ok(())
+        }
+
+        fn give_back(&mut self, step: Step) {
+            self.log.lock().expect("log").push(Event::GaveBack(step));
+        }
+    }
+
+    // ---- 1. The policy ----------------------------------------------------
+
+    #[test]
+    fn takeover_order_is_raw_mode_first_then_the_screen() {
+        let recorder = Recorder::new();
+        let takeover = Takeover::take(recorder.clone()).expect("take");
+
+        assert_eq!(
+            recorder.took(),
+            TAKEOVER.to_vec(),
+            "the takeover did not walk TAKEOVER in order"
+        );
+        assert_eq!(takeover.taken, TAKEOVER.len());
+        assert!(
+            recorder.gave_back().is_empty(),
+            "a live takeover gave something back"
+        );
+    }
+
+    #[test]
+    fn giving_back_is_the_exact_reverse_of_taking() {
+        let recorder = Recorder::new();
+        let takeover = Takeover::take(recorder.clone()).expect("take");
+        // Derived from what was actually taken rather than restated as a literal,
+        // so adding a step to TAKEOVER cannot leave this test asserting the old
+        // list while looking green.
+        let mut expected = recorder.took();
+        expected.reverse();
+        assert!(!expected.is_empty(), "nothing was taken to give back");
+
+        drop(takeover);
+
+        assert_eq!(
+            recorder.gave_back(),
+            expected,
+            "giving back is not the reverse of taking"
+        );
+    }
+
+    #[test]
+    fn a_failure_part_way_through_gives_back_only_what_was_taken() {
+        // Every failure point, not one: the interesting bug is off by one, and a
+        // single k can miss it in whichever direction k happens to sit.
+        for k in 0..TAKEOVER.len() {
+            let recorder = Recorder::failing_at(k);
+            // `let ... else` rather than `expect_err`, which needs the `Ok` side
+            // to be `Debug`: a `Takeover` owns a `Console`, and neither is.
+            let Err(error) = Takeover::take(recorder.clone()) else {
+                panic!("failure at {k} was not reported");
+            };
+
+            assert_eq!(
+                error.to_string(),
+                INJECTED,
+                "failure at {k} reported an error the takeover invented"
+            );
+            assert_eq!(
+                recorder.took(),
+                TAKEOVER[..k].to_vec(),
+                "failure at {k} took the wrong steps"
+            );
+
+            let mut expected = TAKEOVER[..k].to_vec();
+            expected.reverse();
+            assert_eq!(
+                recorder.gave_back(),
+                expected,
+                "failure at {k} gave back the wrong steps"
+            );
+        }
+    }
+
+    #[test]
+    fn nothing_is_given_back_when_nothing_was_taken() {
+        let recorder = Recorder::failing_at(0);
+        let Err(_) = Takeover::take(recorder.clone()) else {
+            panic!("the first step was told to fail and did not");
+        };
+
+        assert!(
+            recorder.events().is_empty(),
+            "a takeover that never started still touched the terminal: {:?}",
+            recorder.events()
+        );
+    }
+
+    #[test]
+    fn a_takeover_gives_the_terminal_back_exactly_once() {
+        let recorder = Recorder::new();
+        drop(Takeover::take(recorder.clone()).expect("take"));
+
+        let gave_back = recorder.gave_back();
+        assert_eq!(
+            gave_back.len(),
+            TAKEOVER.len(),
+            "expected one give-back per step, got {gave_back:?}"
+        );
+        for step in TAKEOVER {
+            assert_eq!(
+                gave_back.iter().filter(|s| **s == step).count(),
+                1,
+                "{step:?} was not given back exactly once"
+            );
+        }
+    }
+
+    // ---- 2. The panic path ------------------------------------------------
+
+    #[test]
+    fn the_panic_hook_restores_before_it_defers_to_the_previous_hook() {
+        let order = Arc::new(Mutex::new(Vec::new()));
+
+        let restore = {
+            let order = Arc::clone(&order);
+            move || order.lock().expect("order").push("restore".to_owned())
+        };
+        let previous = {
+            let order = Arc::clone(&order);
+            move |what: &str| order.lock().expect("order").push(what.to_owned())
+        };
+
+        on_panic(restore, previous, "previous hook");
+
+        // Restore first is not cosmetic: the previous hook is what prints the
+        // panic message, and a message printed into the alternate screen in raw
+        // mode is a message the reader never sees.
+        assert_eq!(
+            *order.lock().expect("order"),
+            vec!["restore", "previous hook"]
+        );
+    }
+
+    #[test]
+    fn two_installs_leave_one_restore_on_the_panic_path() {
+        // The only test that touches the process-global panic hook, and it is one
+        // test for that reason: `set_hook` is process-wide, so splitting this
+        // across two tests would have them racing each other under the default
+        // parallel harness.
+        let restores = Arc::new(Mutex::new(0usize));
+
+        // Silence the hook that is already there *before* chaining onto it. The
+        // chain defers to whatever it replaced, and what it replaced would print
+        // a backtrace for a panic this test causes deliberately. Doing it the
+        // other way round, installing and then replacing, would take the chained
+        // hook straight back out and leave nothing to count.
+        let real = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+
+        let once = Once::new();
+        for _ in 0..2 {
+            let restores = Arc::clone(&restores);
+            install_hook_in(&once, move || *restores.lock().expect("count") += 1);
+        }
+
+        let panicked = std::panic::catch_unwind(|| panic!("on purpose")).is_err();
+
+        // The process's own hook goes back before anything is asserted. A failing
+        // assertion below panics, and panicking while the chained hook is still
+        // installed would run the restore counter again on the way out.
+        std::panic::set_hook(real);
+
+        // Read out, then assert. `assert_eq!(*m.lock(), ..)` holds the guard for
+        // the whole macro, so a failure panics while holding it, and a panic hook
+        // that touches the same mutex deadlocks against a test that was only
+        // trying to report a wrong number.
+        let count = *restores.lock().expect("count");
+
+        assert!(panicked, "the panic did not happen, so nothing was proven");
+        assert_eq!(
+            count, 1,
+            "a second install nested the restore inside itself"
+        );
+    }
+
+    // ---- 3. The adapter ---------------------------------------------------
+
+    fn ansi(command: &impl Command) -> String {
+        let mut rendered = String::new();
+        command.write_ansi(&mut rendered).expect("write_ansi");
+        rendered
+    }
+
+    #[test]
+    fn every_command_is_the_escape_sequence_it_is_named_for() {
+        // The oracle is DEC's own private mode numbers, not crossterm restating
+        // itself: 1049 is the alternate screen buffer, 25 is cursor visibility,
+        // and 1000/1002/1003/1015/1006 are the mouse reporting modes. `h` sets a
+        // mode and `l` resets it, so a swapped pair is visible here as a letter.
+        assert_eq!(ansi(&EnterAlternateScreen), "\x1b[?1049h");
+        assert_eq!(ansi(&LeaveAlternateScreen), "\x1b[?1049l");
+        assert_eq!(ansi(&Hide), "\x1b[?25l");
+        assert_eq!(ansi(&Show), "\x1b[?25h");
+        assert_eq!(
+            ansi(&EnableMouseCapture),
+            "\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1015h\x1b[?1006h"
+        );
+    }
+
+    #[test]
+    fn the_mouse_disable_is_the_derived_inverse_of_the_enable() {
+        // Derived from the actual enable rather than written out again, so the
+        // two cannot be wrong in the same way twice. Mouse capture is the one
+        // step that is five modes, which is where an incomplete undo would hide.
+        let mut expected: Vec<String> = modes(&ansi(&EnableMouseCapture))
+            .into_iter()
+            .map(|(number, set)| {
+                assert!(set, "the enable reset mode {number} instead of setting it");
+                format!("\x1b[?{number}l")
+            })
+            .collect();
+        expected.reverse();
+
+        assert_eq!(ansi(&DisableMouseCapture), expected.concat());
+    }
+
+    /// Every `ESC [ ? <number> (h|l)` in `stream`, as `(number, is_set)`.
+    ///
+    /// Deliberately ignores anything else: crossterm writes mode changes in this
+    /// one shape, and a parser that tried to cover the whole grammar would be a
+    /// second implementation to get wrong.
+    fn modes(stream: &str) -> Vec<(u32, bool)> {
+        stream
+            .split('\x1b')
+            .filter_map(|chunk| chunk.strip_prefix("[?"))
+            .filter_map(|chunk| {
+                let set = chunk.ends_with('h');
+                if !set && !chunk.ends_with('l') {
+                    return None;
+                }
+                chunk[..chunk.len() - 1].parse().ok().map(|n| (n, set))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn the_real_console_gives_back_every_mode_it_set() {
+        // What layers 1 and 2 cannot see. A recorder is blind to which crossterm
+        // command a step is wired to, so `Step::AlternateScreen` giving back
+        // `EnterAlternateScreen` would pass every test above.
+        //
+        // `Step::RawMode` is skipped because it is a syscall against the real
+        // console on both platforms rather than an escape sequence, and a unit
+        // test has no business changing the mode of the terminal running it.
+        let emitting = || TAKEOVER.iter().filter(|step| **step != Step::RawMode);
+
+        let mut console = Crossterm { out: Vec::new() };
+        for step in emitting() {
+            console.take(*step).expect("take");
+        }
+        let taken = String::from_utf8(std::mem::take(&mut console.out)).expect("utf8");
+
+        for step in emitting().rev() {
+            console.give_back(*step);
+        }
+        let given_back = String::from_utf8(console.out).expect("utf8");
+
+        let took = modes(&taken);
+
+        // Non-vacuity. A platform that routed every one of these through a
+        // console API would leave both streams empty, and every assertion below
+        // would hold over nothing. That is a result worth failing on rather than
+        // passing quietly.
+        assert!(
+            !took.is_empty(),
+            "the real console wrote no escape sequences at all, so this proves nothing"
+        );
+
+        // The inverse, derived from what was actually written rather than listed
+        // again. Polarity flipped and order reversed, per mode.
+        //
+        // Flipped, not "all resets": hiding the cursor is `?25l`, which *resets*
+        // mode 25, and showing it again sets the same mode. A rule saying taking
+        // sets and giving back resets would be wrong for the cursor in one
+        // direction and wrong for everything else in the other.
+        let expected: Vec<(u32, bool)> = took
+            .iter()
+            .rev()
+            .map(|(number, set)| (*number, !set))
+            .collect();
+
+        assert_eq!(
+            modes(&given_back),
+            expected,
+            "giving back is not the inverse of taking, mode for mode"
+        );
+    }
+
+    // ---- The refusal, and the exits ---------------------------------------
+
+    #[test]
+    fn a_redirected_stdout_is_refused_and_the_message_says_why() {
+        let error = check_drawable(false).expect_err("must refuse");
+        assert!(
+            error.to_string().contains("not a terminal"),
+            "the message does not say why: {error}"
+        );
+
+        check_drawable(true).expect("a terminal is drawable");
+    }
+
+    #[test]
+    fn no_exit_path_in_the_shell_skips_the_destructors() {
+        // The structural half of "the terminal is restored on every exit". What
+        // makes that true is that every exit drops `Shell`, which owns the
+        // `Session`. Nothing in this crate may reach for a call that skips
+        // destructors, because one of those anywhere in the shell would put the
+        // reader back in raw mode with no message and nothing to report.
+        //
+        // `main` returns an `ExitCode` for exactly this reason.
+        const SOURCES: [(&str, &str); 8] = [
+            ("lib.rs", include_str!("lib.rs")),
+            ("main.rs", include_str!("main.rs")),
+            ("app.rs", include_str!("app.rs")),
+            ("input.rs", include_str!("input.rs")),
+            ("render.rs", include_str!("render.rs")),
+            ("terminal.rs", include_str!("terminal.rs")),
+            ("theme.rs", include_str!("theme.rs")),
+            ("view.rs", include_str!("view.rs")),
+        ];
+
+        // The list above is checked against `lib.rs` rather than trusted, so a
+        // module added later cannot be quietly exempt from the scan.
+        let lib = SOURCES
+            .iter()
+            .find(|(name, _)| *name == "lib.rs")
+            .map(|(_, source)| *source)
+            .expect("lib.rs");
+        let declared: Vec<&str> = lib
+            .lines()
+            .filter_map(|line| line.trim().strip_prefix("mod "))
+            .filter_map(|rest| rest.strip_suffix(';'))
+            .collect();
+        assert!(!declared.is_empty(), "no modules found in lib.rs");
+        for module in &declared {
+            assert!(
+                SOURCES
+                    .iter()
+                    .any(|(name, _)| name.strip_suffix(".rs") == Some(module)),
+                "`mod {module};` is not scanned; add it to SOURCES"
+            );
+        }
+
+        for (name, source) in SOURCES {
+            // Only what ships. Cutting at the test module is what lets this file
+            // scan itself rather than being exempt from its own rule: the names
+            // being searched for appear literally below this line, and nowhere
+            // above it.
+            let shipped = source.split("#[cfg(test)]").next().expect("split");
+
+            // Non-vacuity, per file rather than in aggregate: a path that read
+            // nothing would satisfy every assertion below.
+            assert!(
+                shipped.contains("//!") && shipped.len() > 200,
+                "{name} was not read, so scanning it proves nothing"
+            );
+
+            for skips in ["process::exit", "process::abort", "mem::forget"] {
+                assert!(
+                    !shipped.contains(skips),
+                    "{name} calls {skips}, which skips the Drop that restores the terminal"
+                );
+            }
+        }
+    }
 }

--- a/crates/vigia/src/terminal.rs
+++ b/crates/vigia/src/terminal.rs
@@ -544,10 +544,22 @@ mod tests {
         let real = std::panic::take_hook();
         std::panic::set_hook(Box::new(|_| {}));
 
+        // Counted per thread, not per process. The hook is global for as long as
+        // this test holds it, so a *different* test failing in that window would
+        // run this restore too and report a second failure here, pointing at code
+        // that is fine. The harness gives each test its own thread and a hook runs
+        // on the thread that panicked, so this is exact rather than a narrowed
+        // race.
+        let me = std::thread::current().id();
+
         let once = Once::new();
         for _ in 0..2 {
             let restores = Arc::clone(&restores);
-            install_hook_in(&once, move || *restores.lock().expect("count") += 1);
+            install_hook_in(&once, move || {
+                if std::thread::current().id() == me {
+                    *restores.lock().expect("count") += 1;
+                }
+            });
         }
 
         let panicked = std::panic::catch_unwind(|| panic!("on purpose")).is_err();

--- a/crates/vigia/tests/rows.rs
+++ b/crates/vigia/tests/rows.rs
@@ -340,10 +340,12 @@ fn a_real_repository_draws() {
     // frame produces are the ones the renderer was designed against; the rest of
     // this file builds rows and never draws them.
     //
-    // What it still does not cover, and what
-    // [#8](https://github.com/breferrari/vigia/issues/8) is for: the terminal
-    // itself. Raw mode, the alternate screen, mouse capture and the panic hook
-    // are all outside a `TestBackend`.
+    // What it still does not cover is the terminal itself: raw mode, the
+    // alternate screen, mouse capture and the panic hook are all outside a
+    // `TestBackend`, so none of them can be reached from here.
+    // [#8](https://github.com/breferrari/vigia/issues/8) proves them where they
+    // live instead, in `crates/vigia/src/terminal.rs`, against a recorded console
+    // rather than a real one.
     let scratch = Scratch::new("shell-rows-draw");
     scratch.write("src/lib.rs", numbered(12));
     scratch.write("README.md", unique("readme", 3));


### PR DESCRIPTION
Closes #8.

`crates/vigia/src/terminal.rs` was the one module in the shell with no test at all, and the one standing between the shell being usable and being safe to leave running for days. I8 is now proven where it lives.

## Two measurements decided the shape

Neither is visible from reading the crossterm API, and both were probed before anything was written.

**Raw mode is not observable from a test.** Under `cargo test` on Windows, `is_raw_mode_enabled()` returns `Ok(true)` before anything enables it, and `enable_raw_mode()` succeeds against a stdout that is not a terminal. A test asserting on real raw-mode state would pass against broken code.

**Mouse capture is not ANSI on Windows.** `EnableMouseCapture::is_ansi_code_supported()` is `false` there, so `execute!` routes it through the console API and writes zero bytes into a sink. A byte-exact assertion over the takeover would quietly mean one thing on Unix and another on Windows.

So the terminal cannot be the oracle. The policy is now data: `Step` and `TAKEOVER` say which steps and in what order, `Console` makes the mechanism swappable, and `Takeover` is the guard that runs one over the other, tracking how far it got so a half-finished `Session::enter` undoes exactly what it took. `SPEC.md` section 7 licenses this directly, and `vigia-core/src/frame.rs` is the existing precedent.

Three things go away because `Takeover` covers them: `Session::or_restore`, the `Option<Screen>` with its `expect`, and `Drop for Session`. Field order gives screen-before-restore, and the comment explaining why that is safe is kept. **The public API is unchanged** (`Screen`, `Session::enter`, `Session::screen`), so `lib.rs` is untouched.

## The spec changed, deliberately, in its own commit

I8 read "restored exactly on exit, including `SIGINT` and panic". Raw mode clears `ISIG` on Unix and `ENABLE_PROCESSED_INPUT` on Windows, so the interrupt key never becomes a signal: it is an ordinary key event, already handled by the key map. The clause encoded an assumption the shell falsified, and no test could ever have been written for it as worded.

What is genuinely left uncovered is an externally delivered `kill`, which runs neither `Drop` nor the hook. `std` has no signal API, so closing it is a dependency decision, and the single-task version is Unix only, which is the same asymmetric guarantee #16 already rejected. Filed as #24 with a milestone, a `ROADMAP.md` row and a shelf entry carrying the reason.

## Thirteen tests, in three layers

The layers are not interchangeable.

1. **The policy**, against a recorder: order, the exact inverse, and what a failure at each of the four steps gives back.
2. **The panic path**, separate because `panic = "abort"` runs no destructors.
3. **The adapter**, because a recorder cannot see which crossterm command a step is wired to. The real console is driven into a byte sink and the escape sequences checked against DEC's own mode numbers, with a non-vacuity guard so a platform routing everything through a console API fails loudly instead of passing blank.

Giving back is asserted as the inverse mode by mode, not as "takes set and give-backs reset": hiding the cursor is `?25l`, which resets mode 25, so the simpler rule is wrong in one direction for the cursor and the other for everything else.

`no_exit_path_in_the_shell_skips_the_destructors` is the structural half of "restored on every exit": what makes that true is that every exit drops `Shell`, and a `process::exit` anywhere in the crate would silently end it. The module list is derived from `lib.rs`'s own `mod` lines so a new module cannot be quietly exempt, and the scan cuts each file at its test module so this file is subject to its own rule.

## Verification

- `cargo test --workspace`: **105 passed, 0 failed, 1 ignored** (the pre-existing distribution diagnostic). 92 before, so 13 new.
- **Ten mutations, ten killed**, each by the test named for it. Detectors ordered `test result: FAILED` before `^error`, per the recorded trap.
- `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` clean under `RUSTFLAGS=-D warnings`.
- `cargo test --release --test budgets` with `VIGIA_BUDGET_SLACK` unset: 4 passed, held to `SPEC.md` exactly. Distribution over 250 warm frames on the 100-file, 100k-line fixture: p50 2.35ms, p90 2.62ms, p99 2.82ms, max 3.02ms against the 16ms I9 budget, 0 of 250 over. Not strictly required, since `terminal.rs` is not on the frame path, and run anyway.

**Scope decision, per step 5 of `take-next`:** the diff contains `.rs` files, so it is a code diff and the full suite ran. No manifest or workflow file is touched.

## Harden Audit

Reference PR: #22 (the ratatui and crossterm shell), which set the bar with 38 mutations, five audit rounds, and a triage log.

**Note on method:** this session is configured not to spawn subagents, so the `/simplify` angles and the three audit remits were executed directly rather than by parallel agents. Same remits, same rounds, one reader. Recorded here rather than claiming an agent fan-out that did not happen.

### Gates before the loop

- **/simplify (phase 4)**: 4 findings. The reverse give-back walk was written twice (guard and panic hook) with only one covered; `Crossterm { out: stdout() }` built at two call sites; `self.taken = 0` in `Drop` was type-level dead code, since Rust drops a value at most once; the hook's unconditional full restore was undocumented and reads as a bug.
- **Plan-fidelity (phase 5)**: 0 unfulfilled promises. Run by `take-next` before harden. All 12 planned tests present by name, all three promised deletions gone, public API unchanged (`lib.rs` zero diff), no manifest change. Two deviations, both justified at the moment taken and recorded in the code: `check_drawable` takes a `bool` because `std::io::IsTerminal` is a sealed trait and cannot be implemented for a fake; and "write the failing test first" was inverted, named upfront in the plan, because the behaviour predates the test.

### Rounds

- **Round 1** (adversarial + correctness + docs): 3 findings. `README.md` still advertised the pre-narrowing promise; five items were `pub(crate)` with no consumer outside the module; the exit scan's `strip_prefix("mod ")` would let a future `pub mod foo;` escape the check that keeps its own list honest.
- **Round 2** (test module): 3 findings. `Recorder`'s docstring justified `Arc<Mutex>` by a panic-hook test that no longer touches it; `Recorder::taken` and `Takeover::taken` were the same word for two different quantities in the one module where that difference is the off-by-one the tests exist to catch; one header line ran past the file's width.
- **Round 3** (full re-read): 0 findings.

Trajectory: 4 → 3 → 3 → 0. Exit: dry at round 3.

### Round closers

- **Mutation (decider and producer)**: 10 mutations, 10 killed. Producer side covered: M2 and M3 mutate the code computing `taken`, M8 and M9 mutate the argument the panic hook is given. M9 initially read as surviving, which was a false result from the mutation script's `git checkout --` reverting uncommitted work; re-run against the committed tree it is killed.
- **Coverage-shape**: the long-lived surface here is the process-global panic hook, which outlives any session. `two_installs_leave_one_restore_on_the_panic_path` covers the second-install case. No iterated component surface in this diff.
- **Measurement instruments**: n/a, no new perf gate. The existing budget gates are unchanged and were run at zero slack.

### Real bugs found

- **The panic hook's own restore was reached by no test** — `terminal.rs` — `two_installs_leave_one_restore` installs its own counting closure, so it pinned that the hook fires once and said nothing about what the real one restores. Mutating its step count to `0` or `1` survived until `restore_everything` was extracted and asserted.
- **The reverse walk was duplicated, and only one copy was covered** — `terminal.rs` — mutating the panic hook's inline loop would have survived. Now one `give_back_all` that both call.
- **A hung test suite from a lock held across a failing assertion** — `terminal.rs` — `assert_eq!(*mutex.lock(), ..)` holds the guard for the whole macro, so a failing assertion panics while holding it and the panic hook under test deadlocks against it.
- **A cross-test false failure** — `terminal.rs` — the hook test's counter was process-global, so any other test panicking in its window inflated it. Three mutations of `Takeover` reddened it spuriously. Counted per thread now.
- **`README.md` promised an exit safety the spec no longer claims** — `README.md:54`.

### Tests added

13 in `crates/vigia/src/terminal.rs`: 5 policy, 3 panic path, 3 adapter, 2 structural. Whole workspace 92 → 105.

### Deferrals

- #24: an external kill leaves the terminal in raw mode. Milestone Phase 5, `ROADMAP.md` row, and a shelf entry carrying the reason.

### Triage log

- **`Session::enter` called twice would take the terminal twice.** Not fixed, and not a defect today: `run` constructs exactly one `Session`, `Takeover` is private, and the hook is `Once`-gated. Guarding it would need a second global flag whose only job is to make an unreachable state unreachable.
- **The `Session` field order that guarantees screen-before-restore has no test.** It cannot have one in process: it rests on Rust's drop-order rule, not on our logic. Documented on the field instead.
- **`stdout().is_terminal()` at the `check_drawable` call site is uncovered.** `std::io::IsTerminal` is sealed, so there is no fake to pass. That leaves one std call untested rather than a derivation, and the docstring says so.
