### PR TITLE
I10 lands: bounded history, and the sparkline, gradient and pulse drawn from it

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,19 +120,27 @@ Milestone: [Phase 3](https://github.com/breferrari/vigia/milestone/3)
 
 | | Task | Issue |
 |---|---|---|
-| ⬜ | Sparklines, heat strips, counters, pulse | [#10](https://github.com/breferrari/vigia/issues/10) |
+| ✅ | I10 bounded history, and the sparkline, gradient and pulse drawn from it | [#38](https://github.com/breferrari/vigia/issues/38) |
+| ⬜ | The heat strip, and the whole-file line count it needs | [#39](https://github.com/breferrari/vigia/issues/39) |
+| ⬜ | The header mode word, the mode set, and the empty state (B3) | [#40](https://github.com/breferrari/vigia/issues/40) |
+| ⬜ | The status bar: frame time and RSS | [#41](https://github.com/breferrari/vigia/issues/41) |
 | ⬜ | Theming, with a 256-colour degradation path | [#11](https://github.com/breferrari/vigia/issues/11) |
 
-**This phase is mis-scoped and [#10](https://github.com/breferrari/vigia/issues/10) must split before anything here is taken.** Reading `assets/preview.svg` as the specification it already is (`SPEC.md` §5.1) turned up eight distinct pieces of work behind two rows, and #10 alone carries four features that share no implementation. `take-next` step 4 is explicit: *if the issue is genuinely two things, split the issue first.*
+**[#10](https://github.com/breferrari/vigia/issues/10) was split before anything here was taken**, which this file had blocked the phase on. Reading `assets/preview.svg` as the specification it already is (`SPEC.md` §5.1) turned up eight distinct pieces of work behind two rows, and #10 alone carried four features that share no implementation.
 
-The correction that matters is not the count. **It is that this is not a rendering phase** (`SPEC.md` §5.2). Two of its headline elements need retained state in `vigia-core`, so they move invariants rather than sit on top of them:
+The correction that mattered was not the count. **It is that this is not a rendering phase** (`SPEC.md` §5.2), and building the first child confirmed it: the diff was mostly `vigia-core`. The split follows what each element needs rather than what it looks like: history-backed (#38), whole-file-backed (#39), chrome (#40), self-measuring (#41).
 
-- the **sparkline** needs history that survives a file settling — which is exactly what `FrameStats.evicted` throws away to keep I3 provable. Blocked on **proposed I10 (bounded history)**: the data structure is the decision, the drawing is the easy part.
-- the **heat strip** needs each file's total line count, a whole-file read the frame path exists to avoid. Cacheable per `(path, blob id)`; without that cache it breaks I2a.
+**One of #10's four bullets had already shipped.** Per-file `+42 −7` counters are built in `view.rs` and drawn by `render.rs`, and §5.1 has said "Covered" for them since the mockup was specified: a file has to be diffed to be drawn, so they cost nothing and landed early and quietly. No issue was filed. This file also claimed the **key-hint bar** was "untracked entirely" when [#7](https://github.com/breferrari/vigia/issues/7) landed it with I6, and `follow ▶` alongside it under [#6](https://github.com/breferrari/vigia/issues/6). Both corrected here.
 
-Split #10 along the seams of what each element actually needs, not along what they look like: history-backed (sparkline, recency gradient, `just changed` decay — one clock, not three), whole-file-backed (heat strip), and free (per-file counters, which cost nothing because a file must be diffed to be drawn).
+**I10 is in, and the thing it was blocked on turned out to be the thing it produced.** [#38](https://github.com/breferrari/vigia/issues/38) promoted proposed I10 into `SPEC.md` §3 with a budget of **256 paths and 120 seconds**: a bounded store in `vigia-core`, fed one coalesced tick at a time, evicted by window and by least-recently-changed. Ten thousand distinct paths leave it sitting exactly at the cap, and the soak says the same about the real process, reporting 256 tracked with 207 evicted over 359 paths at a 300-file fixture.
 
-Untracked entirely, and all visible in the mockup: the header **mode word** (`watching`, implying a mode set), the **status bar** (`0.8ms frame`, `11MB` — one measuring inside I9's budget, the other a syscall I3 only samples in soak), and the **key-hint bar**, which constrains I6 because roughly thirty columns of it has to degrade at forty.
+**The store had to be fed from the watch, not from the frame path.** A burst that saves twelve files has to record twelve, and `Tick` named only the last one because that is all follow mode needed. It now carries the whole set, capped at the same 256 so a bulk operation cannot make a tick expensive before the store has a chance to bound it, and `Tick::newest` became a method over that list rather than a second field holding the same fact.
+
+**The decay the mockup asks for was an I1 question, not a rendering one.** §5.1 draws the pulse as a label that persists and fades, and a fade against a wall clock has to be *seen* fading, which needs a redraw nothing schedules and which I1 forbids inventing a timer to get. So the window stayed real time and the sampling became event-driven, and the top rung of the ladder is *named by the newest tick* rather than *within N seconds*. That is what keeps it honest on a quiet tree: the label sits on the file that really is the newest change instead of freezing a clock mid-count. The dimmed row and the label are the same ladder read once, which §5.1 demanded and which two clocks would have broken.
+
+**What it cost the reader, again: the gradient is three steps rather than a fade.** Sixteen foreground-only colours have bold, plain and dim to spend, so recency is a ramp of three. That is the same loss §11.1 already records for the diff signal narrowing to the sigil column, and the same issue fixes both: [#11](https://github.com/breferrari/vigia/issues/11).
+
+**And a rule went into `SPEC.md` §7 that the soak found on its own.** A bound is only evidence when something reached it. The per-commit soak window touches about eighty paths against a cap of 256 and never turns the window over, so `tracked <= 256` is satisfied there by a store nothing filled. The gate now refuses to assert when the run reached neither eviction rule and prints why, exactly as the drift gate does, and the deterministic proof runs in every `cargo test` instead.
 
 ## Phase 4 — distribution
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -44,6 +44,7 @@ Budgets are **absolute** and chosen to be defensible on their own terms, not rel
 | **I7** | Startup to first paint is imperceptible. | **< 50ms** | Timed, gated in CI |
 | **I8** | Terminal restored on **every exit the process controls**: the quit key (Ctrl-C included), an error return, and a panic under `panic = "abort"`. An externally delivered signal is not covered — see [#24](https://github.com/breferrari/vigia/issues/24). | — | Takeover order and its exact inverse; the partial-failure unwinding; a panic-hook test; escape sequences against DEC's own numbers |
 | **I9** | Steady-state frame time holds 60fps under continuous edits. | **< 16ms** p99 | Gated over the **frame path**, not the primitives: a settled frame, one line rewritten before each frame, every file materialised. `criterion` tracks the same shape |
+| **I10** | **Glanceability history is bounded.** Churn history is bounded by a fixed window and a fixed cap on tracked paths, independent of how many files the session changed. A path that ages out of the window is dropped entirely. | **≤ 256 paths**, **≤ 120s**, whatever the session changed | Structural, in `crates/vigia-core/tests/history.rs`: a fixture recording **10,000** distinct paths asserts the store sits *at* the cap and that eviction actually ran, and a window of silence empties it. The soak asserts the same over the real process, and **refuses to assert** in a window that reached neither rule. Not in `tests/budgets.rs`: every gate there is a ratio or a duration, and this is a count |
 
 A regression past any budget **fails the build.**
 
@@ -124,11 +125,11 @@ Elements the four bullets above do **not** cover are marked **(unspecified)** �
 | Element in the mockup | What it needs |
 |---|---|
 | Header: `watching · 3 files` | A **mode word**, so there is a set of modes. `watching` implies at least a settling state and an idle one. Changed-file count is the §10 header question. **(unspecified: the mode set)** |
-| Per-file **sparkline** | A **retained time series per file** — samples of churn over a window, bucketed. This is the only unbounded state in the design and it is the one I3 forbids growing: the window and the sample rate are part of the invariant, not a rendering detail. **(unspecified: window, bucket width, eviction)** |
+| Per-file **sparkline** | A **retained time series per file** — samples of churn over a window, bucketed. This is the only unbounded state in the design and it is the one I3 forbids growing: the window and the sample rate are part of the invariant, not a rendering detail. **Ruled 2026-07-31 and implemented: a 120-second window in 8 buckets of 15 seconds, capped at 256 paths, evicted by window and by least-recently-changed.** That is I10, which now has a row above rather than a warning below. One sample per path per coalesced tick, and heights are scaled against the **busiest bucket on screen** rather than per row, because the question a reader asks down a file list is which file is busiest |
 | Per-file **heat strip** | Hunk line-ranges projected onto a fixed number of buckets across the file's length, so it needs the file's **total line count**, not only its diff. Colour rule when one bucket holds both additions and deletions. **(unspecified: bucket count, mixed-bucket colour)** |
 | Per-file `+42 −7` | Covered. Per-file counters are free — a file must be diffed to be drawn (§10). |
-| A **dimmed row** (`Cargo.toml` in the mockup renders fainter than the rows above it) | A **recency gradient**: rows fade as their last change ages. **(unspecified entirely — and it is doing real work in the picture, since it is how the eye finds what moved without reading)** |
-| `● just changed` on the diff header | The pulse, but drawn as a **persisting label with a dot**, not a flash. So it has a **decay**. **(unspecified: how long it persists, and whether it fades or cuts)** |
+| A **dimmed row** (`Cargo.toml` in the mockup renders fainter than the rows above it) | A **recency gradient**: rows fade as their last change ages. **Ruled 2026-07-31 and implemented as three rungs of one ladder** — pulse, live, cold — read from I10's store; see §11.1. Sixteen foreground-only colours have three intensities to spend, so the gradient is a ramp of three rather than a fade, and the real one is [#11](https://github.com/breferrari/vigia/issues/11)'s |
+| `● just changed` on the diff header | The pulse, but drawn as a **persisting label with a dot**, not a flash. So it has a **decay**. **Ruled 2026-07-31 and implemented: it persists for exactly one tick and cuts rather than fades.** It is the top rung of the recency ladder above, not a second mechanism, and the rung is deliberately *not* a duration: see §11.1 for why a wall-clock decay cannot be drawn without the timer I1 forbids. It marks **every** path in the newest tick, which is what §11.2 B2 said the pulse was for |
 | Diff body: **syntax highlighted content**, five classes deep (`kw`, `fnn`, `typ`, `var`, `con`) over a default foreground | I2b, and a **class set** rather than a palette: what the picture commits to is which distinctions are worth a colour, not which colour each one gets. Ruled 2026-07-30 and implemented; the engine emits meanings and the shell colours them, which is what leaves the palette to #11. See §11.1 |
 | A **tinted row** with a coloured left bar on every added and removed line | A per-row **background**. It is what separates a changed line from a context line in the picture, because the text itself is highlighted identically on both, and it is doing the same work the dimmed row above does: it is how the eye finds what moved without reading. Not drawable at sixteen foreground-only colours, where an ANSI background is a solid block rather than a tint, so it belongs with [#11](https://github.com/breferrari/vigia/issues/11). **(unspecified entirely, and the reason I2b's ruling costs something: see §11.1)** |
 | Status bar `0.8ms frame` | Instrumenting the render path and drawing the result. Self-referential: measuring and painting the number costs frame time that I9 gates. **(unspecified: sampled or per-frame, and which statistic)** |
@@ -149,25 +150,30 @@ Two of these are corrections rather than gaps:
 
 **The sparkline needs precisely what eviction throws away.** `FrameStats.evicted` exists so the cached-diff map stays "bounded by the current diff rather than by everything ever edited" — that is how I3 is argued today. A churn sparkline is change density *over time*, so it has to survive a file settling: one that empties the moment a file stops changing shows nothing worth glancing at, and *"what was hot thirty seconds ago"* is the entire question it answers. Glanceability history therefore cannot live in the evicting map — and must not be unbounded either.
 
-> [!warning] Proposed I10 — bounded history
-> Deliberately **not** in the §3 table, because that table is for invariants with
-> a failing test and this has none. By this document's own rule it is a wish, and
-> writing it into the table would make the table lie.
+> [!note] I10 earned its row on 2026-07-31
+> It was written here as a **proposal**, deliberately kept out of the §3 table,
+> because that table is for invariants with a failing test and this had none. It
+> now has a budget (256 paths, 120 seconds), a fixture that drives ten thousand
+> paths through it, and a soak assertion over the real process, so it has moved
+> up. [#38](https://github.com/breferrari/vigia/issues/38).
 >
-> *Glanceability history is bounded by a fixed time window and a fixed cap on
-> tracked paths, independent of how many files have changed in the session.* A
-> bulk operation touching ten thousand files must not grow it past the cap, and a
-> path that ages out of the window is dropped entirely.
+> Two things it cost that this section did not predict. The store had to be fed
+> from the **watch** rather than from the frame path, so `Tick` now carries every
+> file a burst wrote instead of only the last, capped at the same 256 so a bulk
+> operation cannot make a tick expensive before the store gets a chance to bound
+> it. And the decay the mockup asks for turned out to be an I1 question rather
+> than a rendering one: see §11.1.
 >
-> It needs a budget and a soak assertion before it earns a row. Until then every
-> sparkline task is blocked on it, because **the data structure is the decision**
-> and the drawing is the easy part.
+> What it got right is the sentence everything else followed from. **The data
+> structure was the decision and the drawing was the easy part.**
 
 **The heat strip needs a whole-file property.** Locating change within a file requires that file's **total line count**, and the frame path is built to avoid exactly that: pure revalidation reads **0 bytes** (§10), the number I2a is written against. Measured naively — every changed file, every frame — it reintroduces the read I2a removed. It is cacheable per `(path, blob id)`, since a file's length cannot change without its content changing, so it is payable once per version rather than once per frame. **That caching is not an optimisation; without it the heat strip breaks I2a.**
 
 **Two status readouts measure the thing they run inside.** `0.8ms frame` means instrumenting the render path and drawing the result — a readout whose own cost falls inside the budget it reports, gated by I9 at 16ms p99. `11MB` is a live RSS number, and I3 samples RSS in a **soak test** precisely because reading it is a syscall on some platforms rather than free per frame. Both are honest to show; neither is free to show; the spec said nothing about either.
 
 **Consequence for sequencing:** Phase 3 is not a rendering phase. Its two headline elements each need a core-side change with an invariant attached, so they belong in the same conversation as I2a and I3 rather than strictly after them.
+
+**Confirmed by building the first one.** [#38](https://github.com/breferrari/vigia/issues/38) landed the sparkline, the recency gradient and the pulse, and the diff was mostly `vigia-core`: a new bounded store, a change to what a `Tick` carries, a new invariant with its own budget, and a soak assertion. The drawing was a bucket ladder and a three-step ramp. This section predicted that split and it was right, which is worth recording because the alternative reading — that Phase 3 is where the shell gets prettier — was the one both §5 and [#10](https://github.com/breferrari/vigia/issues/10) originally invited.
 
 ## 6. Architecture
 
@@ -212,6 +218,7 @@ The rule that closes it has to account for **flooring**. A filesystem stamps a m
 - **The soak drives the whole pipeline, not the engine.** I3 is a claim about the process a reader leaves open, so measuring `vigia-core` alone would prove it about a program nobody runs. The harness is `vigia::run` with the terminal removed: a real `notify` watch thread, real coalescing, `Frame::advance` per tick, follow and scroll through `App`, `View::collect` driving the `Highlighter`, and `render` into a `ratatui` buffer. What it leaves out is named rather than discovered later: the terminal takeover, which needs a tty and is I8's; the input thread; and index writes, because the loop reaches the same mass-eviction state by reverting files and keeping `git` out of the measured window is what makes the temp-file gate exact.
 - **The soak is two tiers, like every other budget here.** *Structural* gates — the retained caches bounded by the current diff and by the viewport, eviction actually happening, and **zero temp files retained** — are counters and directory entries, so they are hardware-independent, take no slack, and run in every `cargo test`. The *absolute* gate is RSS drift, and it is the one that has to be scheduled.
 - **A drift gate over a window shorter than its own warmup is measuring warmup.** RSS climbs to an allocator plateau in the first minutes of any process and only then goes flat, so a short window reads that climb as a leak and a generous threshold would then wave a real leak through. The gate therefore discards a warmup prefix, compares the median of the first quarter of what remains against the median of the last quarter, and **refuses to assert at all** below a window where that leaves two ends worth comparing. Refusing is the point: a gate that cannot say "no drift" has not been tested, and one that says it from four samples is worse than absent.
+- **A bound is only evidence when something reached it, so a gate over one asserts that eviction happened as well as that the bound held.** I10 is the case that made this a rule and the numbers say why: the per-commit soak window touches about eighty distinct paths against a cap of 256 and never turns the 120-second window over once, so the per-sample bound `tracked <= 256` is satisfied there the way an empty room satisfies a fire code. The soak therefore **refuses to assert** when the run reached neither eviction rule and prints why, exactly as the drift gate does; the deterministic proof is a fixture that drives ten thousand paths in every `cargo test`. Verified by running the soak at 300 files, where it reports 256 tracked at the cap with 207 evicted, so the gate can say yes and not only "not applicable".
 - **`proptest`** over diff parsing and hunk-boundary logic.
 
 ## 8. Phases
@@ -342,6 +349,24 @@ Three things follow, and each is a constraint rather than a preference.
 **The diff signal degrades to the sigil column, and that is a loss rather than a simplification.** What separates an added line from a context line in the mockup is the row tint and the left bar of §5.1, and sixteen foreground-only colours can draw neither. So until #11 lands a background, `+` and `−` carry it alone. Recorded out loud because §5 makes shape and colour the whole differentiator, and this is the one place where following the picture spends some of it. The alternative considered and rejected was to keep unclassified text green on an added line and red on a removed one: it preserves the wash, it contradicts the picture, and it would have made the shell's colours mean two different things at once.
 
 **A file type nothing recognises is not an error.** The syntax is resolved from the path, by extension and then by whole file name, and anything unresolved draws exactly as it did before there was highlighting at all. A monitor that refused a file because it could not colour it would have inverted its own job.
+
+**How recency is drawn**, which is I10 and which §5.1 asked for as two separate things. It is **one ladder with three rungs**, read from one store through one lookup, and each rung is an intensity on the file's own heading:
+
+| Rung | What it means | How it draws |
+|---|---|---|
+| **pulse** | named by the **most recent tick** | brightest, plus `● just changed` |
+| **live** | has a sample inside the 120-second window | plain |
+| **cold** | nothing in the window, so nothing is tracked for it | faintest |
+
+Two rulings are inside that table and neither is cosmetic.
+
+**The top rung is not a duration, and I1 is the reason.** §5.1 reads the mockup's persisting label as a decay, and a decay measured against a wall clock has to be *seen* decaying, which needs a redraw nothing schedules. Inventing a timer to get one is exactly what I1 forbids, and it is the same wall §10's highlight-tail bullet already hit. So the window stays real time and the **sampling** is event-driven: the store advances once per coalesced tick, on the wake that was already going to redraw. Nothing on screen changes without something changing on disk, which is what a monitor is for. Defining the pulse as *newest tick* rather than *last three seconds* is what stops that from being a lie: a tree that has gone quiet keeps the label on the file that really is the newest change, indefinitely and correctly, instead of freezing a clock mid-count.
+
+**Cold is not a fourth rule.** A path with nothing left in the window is dropped from the store entirely, per I10, so "cold" and "untracked" are the same state. That is also what the **first** frame of a session looks like: a worktree that was already dirty draws every row cold, because a monitor has no way to know what happened before it was looking and inventing a recency for it would light up rows nothing has touched.
+
+**The sparkline is a thing made of items**, so under the layout rule above it **breaks**: it drops whole buckets, oldest first, and never draws a partial one or a squeezed strip. Its heights are scaled against the busiest bucket **on screen** rather than against each row's own maximum, because scaling per row draws every file at full height the moment it is the busiest thing it has ever been, which answers a question nobody asked while destroying the one comparison a file list is for. A file with no churn draws no strip at all rather than an empty one, so it spends none of its row.
+
+**And no glance element may take a heading below twelve columns of path.** The counters, the pulse and the strip are all placed from the right, in that order of priority, against a floor the path keeps. A row reduced to `M …` would have stopped naming its own file, which is the truncated-to-useless shape I6 forbids, arrived at by decoration rather than by narrowing.
 
 **CLI.** One optional positional path, defaulting to the working directory. No flags today.
 

--- a/crates/vigia-core/src/history.rs
+++ b/crates/vigia-core/src/history.rs
@@ -1,0 +1,604 @@
+//! Glanceability history: I10.
+//!
+//! > Churn history is bounded by a fixed window and a fixed cap on tracked
+//! > paths, independent of how many files the session changed. A path that ages
+//! > out of the window is dropped entirely.
+//!
+//! `SPEC.md` §5 makes shape and colour the whole differentiator, and three of
+//! the things it asks for are the same question asked at different resolutions:
+//! *when did this file last change, and how busy has it been.* A churn
+//! sparkline, the recency gradient that dims a settled row, and the
+//! `● just changed` pulse all read from here.
+//!
+//! ## Why this cannot live in the frame path
+//!
+//! [`Frame`](crate::Frame) drops a diff the moment its path stops being
+//! changed, and `FrameStats.evicted` exists to prove it: that is how I3 is
+//! argued, because the map is then bounded by the current diff rather than by
+//! everything ever edited. History needs the opposite. *What was hot thirty
+//! seconds ago* is the entire question a sparkline answers, so it has to
+//! survive a file settling, and a store that emptied when a file went quiet
+//! would show nothing worth glancing at.
+//!
+//! Surviving is not the same as growing without limit, which is what I10 is
+//! for. Two rules bound it, and both are tested:
+//!
+//! * **By window.** A path with no sample left inside [`HISTORY_WINDOW`] is
+//!   dropped entirely, not merely drawn as empty.
+//! * **By cap.** At [`HISTORY_PATHS`] the least recently changed path is
+//!   evicted to make room. A bulk operation touching ten thousand files must
+//!   not grow this past the cap, which is the case the gate in
+//!   `tests/history.rs` actually drives rather than approximating.
+//!
+//! ## The clock is a tick, never a timer
+//!
+//! `SPEC.md` §5.1 asks the pulse to persist and decay, and the dimmed row to
+//! fade as its last change ages. Taken literally against a wall clock, both need
+//! a redraw to be *seen*, and **I1 forbids inventing a timer to get one**. That
+//! is the same trap §10 already records for the highlight tail.
+//!
+//! So the window is real time and the *sampling* is not: [`History::record`] is
+//! called once per coalesced tick, from the wake that was already going to
+//! redraw. Nothing on screen changes without an event. A tree that has gone
+//! quiet holds its last picture, which is what a monitor is supposed to do.
+//!
+//! The top rung of the ladder is deliberately **not** a duration for the same
+//! reason. [`Recency::Pulse`] means *named by the most recent tick*, so it
+//! cannot age into a lie while the loop is asleep, and it marks **every** path
+//! in that tick rather than one. That is `SPEC.md` §11.2 B2's ruling arriving
+//! from the other side: follow moves to the write that landed last, and the
+//! pulse is what says the others moved too.
+//!
+//! ## One mechanism, not three
+//!
+//! §5.1 rules that the dimmed row and the `just changed` label are one
+//! mechanism, because specifying them separately would produce two decay clocks
+//! that disagree on screen. They are three rungs of [`Recency`], read from one
+//! store through one lookup, and [`Recency::Cold`] is not a fourth rule: it is
+//! what I10's own eviction leaves behind.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// How far back a churn sparkline reaches.
+///
+/// Two minutes. Long enough that a file which went quiet is still visibly
+/// warmer than one nobody has touched, short enough that the whole strip turns
+/// over while a reader is still working on the same thing. It is also the
+/// gradient's only boundary: a path with a sample in this window is
+/// [`Recency::Live`] and one without is [`Recency::Cold`], so there is one
+/// number here rather than two that could disagree.
+pub const HISTORY_WINDOW: Duration = Duration::from_secs(120);
+
+/// Buckets a sparkline is drawn from, oldest first.
+///
+/// Eight, which is what the strip costs in columns. `SPEC.md` §11.1 makes a
+/// sparkline a thing made of items, so at narrow widths it drops whole buckets
+/// rather than being squeezed, and eight halves cleanly on the way down.
+pub const HISTORY_BUCKETS: usize = 8;
+
+/// How much time one bucket covers.
+pub const HISTORY_BUCKET: Duration =
+    Duration::from_nanos(HISTORY_WINDOW.as_nanos() as u64 / HISTORY_BUCKETS as u64);
+
+/// The most paths history will track at once.
+///
+/// The cap is the half of I10 that a window cannot provide: a bulk operation
+/// puts ten thousand paths inside the window at the same instant, and without a
+/// cap the store would be bounded by what the session did rather than by
+/// anything fixed.
+///
+/// 256 is comfortably above any changed-file count a reader can look at (a
+/// forty-row pane shows a few dozen) and small enough that the whole store is
+/// tens of kilobytes against the ~26 MiB the soak measures. It is a bound, not
+/// a tuning parameter: nothing is drawn from a path the reader cannot reach.
+pub const HISTORY_PATHS: usize = 256;
+
+/// How recently a path changed, as three rungs of one ladder.
+///
+/// Ordered by intensity rather than alphabetically, so the enum reads the way
+/// the screen does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Recency {
+    /// Named by the most recent tick. Drawn brightest, and the only rung that
+    /// carries the `● just changed` label.
+    ///
+    /// Not a duration. See the module docs: a rung measured in seconds would
+    /// have to age while the event loop is blocked, and being able to see that
+    /// happen needs a redraw I1 forbids scheduling.
+    Pulse,
+    /// Changed inside [`HISTORY_WINDOW`], but not in the newest tick.
+    Live,
+    /// Nothing inside the window, so nothing is tracked for it at all.
+    ///
+    /// The ordinary state for a file that was edited before `vigia` started
+    /// watching, which is the mockup's dimmed `Cargo.toml`.
+    Cold,
+}
+
+/// What a [`History`] has done since it was created.
+///
+/// Cumulative, like [`FrameStats`](crate::FrameStats), so a test describes one
+/// step by subtracting two readings.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct HistoryStats {
+    /// Path samples taken, counting a path once per tick that named it.
+    pub recorded: u64,
+    /// Paths dropped to stay under [`HISTORY_PATHS`].
+    ///
+    /// The number that separates a bound which *held* from one that was never
+    /// approached. A gate asserting the cap without asserting this passes
+    /// against a store nothing ever filled.
+    pub evicted_by_cap: u64,
+    /// Paths dropped because nothing was left inside [`HISTORY_WINDOW`].
+    pub evicted_by_window: u64,
+}
+
+/// One path's churn, and when it last moved.
+#[derive(Debug, Clone, Copy)]
+struct Track {
+    /// Oldest bucket first, so the array is drawn left to right as written.
+    buckets: [u16; HISTORY_BUCKETS],
+    /// Ordinal of the last tick that named this path.
+    ///
+    /// A counter rather than an [`Instant`], because the only question asked of
+    /// it is "was this the newest tick", and comparing ordinals cannot drift
+    /// the way two clocks can.
+    tick: u64,
+}
+
+impl Track {
+    fn new(tick: u64) -> Self {
+        Self {
+            buckets: [0; HISTORY_BUCKETS],
+            tick,
+        }
+    }
+
+    /// Slide `steps` buckets into the past, filling the newest end with zeroes.
+    fn shift(&mut self, steps: usize) {
+        if steps >= HISTORY_BUCKETS {
+            self.buckets = [0; HISTORY_BUCKETS];
+            return;
+        }
+        self.buckets.rotate_left(steps);
+        self.buckets[HISTORY_BUCKETS - steps..].fill(0);
+    }
+
+    fn empty(&self) -> bool {
+        self.buckets.iter().all(|&count| count == 0)
+    }
+
+    fn bump(&mut self) {
+        let newest = &mut self.buckets[HISTORY_BUCKETS - 1];
+        // Saturating rather than wrapping: a path written 65,536 times inside
+        // one bucket is already at the top of the ramp, and wrapping would draw
+        // the busiest file in the worktree as the quietest.
+        *newest = newest.saturating_add(1);
+    }
+}
+
+/// Per-path churn over a bounded window: I10.
+///
+/// Created by [`History::new`], fed one coalesced tick at a time by
+/// [`History::record`], and read per drawn row by [`History::churn`] and
+/// [`History::recency`].
+///
+/// ```
+/// use std::time::Instant;
+/// use vigia_core::{History, Recency};
+///
+/// let mut history = History::new();
+/// let now = Instant::now();
+/// history.record(["src/lib.rs", "Cargo.toml"], now);
+///
+/// // Both were named by the newest tick, so both pulse. Follow mode moves to
+/// // one of them; the pulse is what says the other moved too.
+/// assert_eq!(history.recency("src/lib.rs"), Recency::Pulse);
+/// assert_eq!(history.recency("Cargo.toml"), Recency::Pulse);
+/// assert_eq!(history.recency("README.md"), Recency::Cold);
+///
+/// history.record(["src/lib.rs"], now);
+/// assert_eq!(history.recency("src/lib.rs"), Recency::Pulse);
+/// assert_eq!(history.recency("Cargo.toml"), Recency::Live);
+/// ```
+#[derive(Debug)]
+pub struct History {
+    tracks: HashMap<String, Track>,
+    /// Ticks that named at least one path.
+    ///
+    /// Only those, because staging rewrites the index without changing a byte
+    /// on disk, and letting it advance the counter would clear the pulse off
+    /// the file the reader was watching for a reason they cannot see.
+    tick: u64,
+    /// When the newest bucket opened.
+    opened: Instant,
+    peak: u16,
+    stats: HistoryStats,
+}
+
+impl History {
+    /// An empty history, with its first bucket opening now.
+    pub fn new() -> Self {
+        Self::starting_at(Instant::now())
+    }
+
+    /// An empty history whose first bucket opened at `now`.
+    ///
+    /// Separate from [`History::new`] so a test can drive the window without
+    /// sleeping through two minutes of it. `Instant` cannot be constructed from
+    /// nothing, so the base has to come from somewhere real either way.
+    pub fn starting_at(now: Instant) -> Self {
+        Self {
+            tracks: HashMap::new(),
+            tick: 0,
+            opened: now,
+            peak: 0,
+            stats: HistoryStats::default(),
+        }
+    }
+
+    /// Take one coalesced tick's worth of samples.
+    ///
+    /// Rolls the window forward to `now` first, so a sample lands in the bucket
+    /// its wall-clock time belongs to rather than in whichever one was open when
+    /// the last tick arrived.
+    ///
+    /// **An empty `paths` still rolls the window and still does not move the
+    /// pulse.** That is the index-write case: staging is a real change and
+    /// produces a real tick, because the index is the left-hand side of every
+    /// diff drawn, but nothing on disk moved, so the file the reader is watching
+    /// keeps its label.
+    ///
+    /// Called once per tick and never on a timer. See the module docs: the
+    /// window is real time and the sampling is event-driven, which is what keeps
+    /// I1 intact.
+    ///
+    /// # Cost
+    ///
+    /// A path already tracked is a hash lookup. A new one at the cap costs a
+    /// scan for the least recently changed, which is bounded by
+    /// [`HISTORY_PATHS`] and therefore constant rather than proportional to the
+    /// session.
+    pub fn record<'p>(&mut self, paths: impl IntoIterator<Item = &'p str>, now: Instant) {
+        self.roll(now);
+
+        let mut named = false;
+        for path in paths {
+            if !named {
+                // Bumped once for the whole tick, before the first sample, so
+                // every path in one burst shares an ordinal and therefore
+                // pulses together.
+                self.tick += 1;
+                named = true;
+            }
+            self.stats.recorded += 1;
+
+            if let Some(track) = self.tracks.get_mut(path) {
+                track.tick = self.tick;
+                track.bump();
+                continue;
+            }
+
+            if self.tracks.len() >= HISTORY_PATHS {
+                self.evict_one();
+            }
+            let mut track = Track::new(self.tick);
+            track.bump();
+            self.tracks.insert(path.to_owned(), track);
+        }
+
+        self.repeak();
+    }
+
+    /// This path's buckets, oldest first, or `None` when nothing is tracked.
+    ///
+    /// Copied rather than borrowed. It is [`HISTORY_BUCKETS`] `u16`s, which is
+    /// smaller than the reference on every target, and returning it by value is
+    /// what lets a caller hold one while asking about the next path.
+    pub fn churn(&self, path: &str) -> Option<[u16; HISTORY_BUCKETS]> {
+        self.tracks.get(path).map(|track| track.buckets)
+    }
+
+    /// Which rung of the recency ladder this path is on.
+    pub fn recency(&self, path: &str) -> Recency {
+        match self.tracks.get(path) {
+            // `self.tick` is zero until something is recorded, and no track can
+            // exist before then, so this never reads a pulse out of an empty
+            // store.
+            Some(track) if track.tick == self.tick => Recency::Pulse,
+            Some(_) => Recency::Live,
+            None => Recency::Cold,
+        }
+    }
+
+    /// The largest bucket any tracked path holds.
+    ///
+    /// Rows share one scale rather than each being drawn against its own
+    /// maximum, because the question a reader asks across a file list is which
+    /// file is busiest, and per-file scaling draws every file at full height the
+    /// moment it is the busiest thing it has ever been. Zero when nothing is
+    /// tracked, which a caller must treat as "draw nothing" rather than dividing
+    /// by it.
+    pub fn peak(&self) -> u16 {
+        self.peak
+    }
+
+    /// Paths currently tracked. Never more than [`HISTORY_PATHS`].
+    ///
+    /// This is the number I10 is a claim about: it follows the window and the
+    /// cap, never the number of files the session has touched.
+    pub fn tracked(&self) -> usize {
+        self.tracks.len()
+    }
+
+    /// Counters for what this history has done.
+    pub fn stats(&self) -> HistoryStats {
+        self.stats
+    }
+
+    /// Advance the window to `now`, dropping whatever fell out of it.
+    fn roll(&mut self, now: Instant) {
+        let elapsed = now.saturating_duration_since(self.opened);
+        // Saturating into `usize` before the comparison below, so an instant far
+        // in the future cannot overflow the multiplication that moves `opened`.
+        let steps = usize::try_from(elapsed.as_nanos() / HISTORY_BUCKET.as_nanos())
+            .unwrap_or(HISTORY_BUCKETS);
+        if steps == 0 {
+            return;
+        }
+
+        if steps >= HISTORY_BUCKETS {
+            // The whole window has turned over, so nothing tracked can have a
+            // sample left in it. Clearing beats shifting every track by more
+            // buckets than it has, and it is the state a monitor left open
+            // overnight wakes up in.
+            self.stats.evicted_by_window += self.tracks.len() as u64;
+            self.tracks.clear();
+            self.opened = now;
+            self.peak = 0;
+            return;
+        }
+
+        // Advanced by whole buckets rather than set to `now`, so the boundaries
+        // stay on a fixed grid and a burst of ticks inside one bucket cannot
+        // walk it forward a fraction at a time.
+        self.opened += HISTORY_BUCKET * steps as u32;
+
+        let before = self.tracks.len();
+        self.tracks.retain(|_, track| {
+            track.shift(steps);
+            !track.empty()
+        });
+        self.stats.evicted_by_window += (before - self.tracks.len()) as u64;
+        self.repeak();
+    }
+
+    /// Drop the least recently changed path to make room for a new one.
+    ///
+    /// Least recently *changed* rather than least recently inserted: a path that
+    /// keeps moving is the one a reader is watching, and evicting by age of
+    /// arrival would throw it away in favour of something written once and
+    /// forgotten.
+    fn evict_one(&mut self) {
+        let victim = self
+            .tracks
+            .iter()
+            .min_by_key(|(path, track)| (track.tick, (*path).clone()))
+            .map(|(path, _)| path.clone());
+        if let Some(path) = victim {
+            self.tracks.remove(&path);
+            self.stats.evicted_by_cap += 1;
+        }
+    }
+
+    fn repeak(&mut self) {
+        self.peak = self
+            .tracks
+            .values()
+            .flat_map(|track| track.buckets)
+            .max()
+            .unwrap_or(0);
+    }
+}
+
+impl Default for History {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! The window, the cap and the ladder, tested as the arithmetic they are.
+    //!
+    //! Every one of these drives the clock by handing [`History::record`] an
+    //! instant rather than by sleeping. That is not only for speed: the window
+    //! is two minutes long and the cap needs a bulk write, so a suite that
+    //! waited for real time could not gate either of them at all.
+
+    use super::*;
+
+    fn base() -> Instant {
+        // Far enough ahead that a test can step backwards inside a bucket
+        // without underflowing a monotonic clock.
+        Instant::now() + HISTORY_WINDOW
+    }
+
+    #[test]
+    fn an_untracked_path_is_cold_rather_than_absent() {
+        let history = History::starting_at(base());
+        assert_eq!(history.recency("src/lib.rs"), Recency::Cold);
+        assert_eq!(history.churn("src/lib.rs"), None);
+        assert_eq!(history.peak(), 0);
+    }
+
+    #[test]
+    fn a_path_named_by_the_newest_tick_pulses_and_the_rest_do_not() {
+        let now = base();
+        let mut history = History::starting_at(now);
+        history.record(["a"], now);
+        history.record(["b"], now);
+
+        assert_eq!(history.recency("b"), Recency::Pulse);
+        assert_eq!(history.recency("a"), Recency::Live);
+    }
+
+    /// `SPEC.md` §11.2 B2: follow moves to the write that landed last, and the
+    /// pulse is what says the others in the batch moved too. One tick, one
+    /// ordinal, so a twelve-file save lights all twelve.
+    #[test]
+    fn every_path_in_one_tick_pulses_together() {
+        let now = base();
+        let mut history = History::starting_at(now);
+        history.record(["a", "b", "c"], now);
+
+        for path in ["a", "b", "c"] {
+            assert_eq!(history.recency(path), Recency::Pulse, "{path}");
+        }
+    }
+
+    /// Staging rewrites the index and produces a real tick that names no file.
+    /// It must not clear the pulse off whatever the reader was watching.
+    #[test]
+    fn a_tick_naming_no_path_leaves_the_pulse_where_it_was() {
+        let now = base();
+        let mut history = History::starting_at(now);
+        history.record(["a"], now);
+        history.record(std::iter::empty(), now);
+
+        assert_eq!(history.recency("a"), Recency::Pulse);
+    }
+
+    #[test]
+    fn a_bucket_rolls_forward_rather_than_accumulating_for_ever() {
+        let now = base();
+        let mut history = History::starting_at(now);
+        history.record(["a"], now);
+        assert_eq!(history.churn("a").unwrap()[HISTORY_BUCKETS - 1], 1);
+
+        // One bucket on: the old sample slides left, the newest is empty again.
+        history.record(std::iter::empty(), now + HISTORY_BUCKET);
+        let buckets = history.churn("a").unwrap();
+        assert_eq!(buckets[HISTORY_BUCKETS - 2], 1);
+        assert_eq!(buckets[HISTORY_BUCKETS - 1], 0);
+    }
+
+    #[test]
+    fn a_path_with_nothing_left_in_the_window_is_dropped_entirely() {
+        let now = base();
+        let mut history = History::starting_at(now);
+        history.record(["a"], now);
+        assert_eq!(history.tracked(), 1);
+
+        history.record(std::iter::empty(), now + HISTORY_WINDOW);
+
+        assert_eq!(history.tracked(), 0, "the path is dropped, not drawn empty");
+        assert_eq!(history.recency("a"), Recency::Cold);
+        assert_eq!(history.churn("a"), None);
+        assert_eq!(history.stats().evicted_by_window, 1);
+    }
+
+    /// The boundary in both directions, because a window that is a bucket too
+    /// generous still passes the test above.
+    #[test]
+    fn a_sample_survives_until_the_window_has_wholly_passed() {
+        let now = base();
+        let mut history = History::starting_at(now);
+        history.record(["a"], now);
+
+        history.record(std::iter::empty(), now + HISTORY_WINDOW - HISTORY_BUCKET);
+        assert_eq!(history.tracked(), 1, "one bucket short of the window");
+
+        history.record(std::iter::empty(), now + HISTORY_WINDOW);
+        assert_eq!(history.tracked(), 0);
+    }
+
+    #[test]
+    fn the_cap_evicts_the_least_recently_changed_path() {
+        let now = base();
+        let mut history = History::starting_at(now);
+
+        // Fill it exactly, each path in its own tick so the ordinals differ.
+        for n in 0..HISTORY_PATHS {
+            history.record([format!("f{n}").as_str()], now);
+        }
+        assert_eq!(history.tracked(), HISTORY_PATHS);
+        assert_eq!(history.stats().evicted_by_cap, 0);
+
+        // Touch the oldest, so it is no longer the least recently changed.
+        history.record(["f0"], now);
+        history.record(["new"], now);
+
+        assert_eq!(history.tracked(), HISTORY_PATHS);
+        assert_eq!(history.stats().evicted_by_cap, 1);
+        assert_ne!(history.recency("f0"), Recency::Cold, "it was touched");
+        assert_eq!(history.recency("f1"), Recency::Cold, "it was the oldest");
+    }
+
+    #[test]
+    fn peak_is_the_largest_bucket_across_paths_so_rows_share_a_scale() {
+        let now = base();
+        let mut history = History::starting_at(now);
+        history.record(["a"], now);
+        history.record(["a"], now);
+        history.record(["b"], now);
+
+        assert_eq!(history.peak(), 2);
+        assert_eq!(history.churn("b").unwrap()[HISTORY_BUCKETS - 1], 1);
+    }
+
+    /// A path written more than `u16::MAX` times in one bucket is already at the
+    /// top of the ramp; wrapping would draw the busiest file as the quietest.
+    #[test]
+    fn a_bucket_saturates_rather_than_wrapping() {
+        let now = base();
+        let mut history = History::starting_at(now);
+        let mut track = Track::new(1);
+        track.buckets[HISTORY_BUCKETS - 1] = u16::MAX;
+        track.bump();
+        assert_eq!(track.buckets[HISTORY_BUCKETS - 1], u16::MAX);
+
+        history.record(["a"], now);
+        assert!(history.peak() > 0);
+    }
+
+    /// A monitor left open overnight wakes up with nothing in the window, and
+    /// the shift path must not be asked to move a track further than it has
+    /// buckets.
+    #[test]
+    fn a_gap_longer_than_the_whole_window_clears_the_store() {
+        let now = base();
+        let mut history = History::starting_at(now);
+        history.record(["a", "b"], now);
+
+        history.record(std::iter::empty(), now + HISTORY_WINDOW * 100);
+
+        assert_eq!(history.tracked(), 0);
+        assert_eq!(history.peak(), 0);
+        assert_eq!(history.stats().evicted_by_window, 2);
+    }
+
+    /// Bucket boundaries stay on a fixed grid. Ticks arriving repeatedly just
+    /// inside one bucket must not walk the grid forward a fraction at a time,
+    /// which would make the window drift longer than it is specified to be.
+    #[test]
+    fn ticks_inside_one_bucket_do_not_move_the_boundary() {
+        let now = base();
+        let mut history = History::starting_at(now);
+        history.record(["a"], now);
+
+        let nearly = HISTORY_BUCKET - Duration::from_millis(1);
+        for _ in 0..8 {
+            history.record(std::iter::empty(), now + nearly);
+        }
+        assert_eq!(
+            history.churn("a").unwrap()[HISTORY_BUCKETS - 1],
+            1,
+            "still in the bucket it was recorded in"
+        );
+
+        history.record(std::iter::empty(), now + HISTORY_BUCKET);
+        assert_eq!(history.churn("a").unwrap()[HISTORY_BUCKETS - 2], 1);
+    }
+}

--- a/crates/vigia-core/src/lib.rs
+++ b/crates/vigia-core/src/lib.rs
@@ -21,6 +21,11 @@
 //! on by default and cannot stream either, so today it costs nothing, and a
 //! scrollbar needs the file count anyway. `SPEC.md` §10 tracks it.
 //!
+//! [`History`] is the one thing here that deliberately outlives the diff. A
+//! `Frame` forgets a path the moment it stops being changed, which is how I3 is
+//! argued; a churn sparkline is about what was hot a minute ago, so it must not.
+//! I10 is what keeps "must not forget" from becoming "never forgets".
+//!
 //! ```no_run
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let worktree = vigia_core::Worktree::discover(".")?;
@@ -40,6 +45,7 @@ mod change;
 mod error;
 mod frame;
 mod highlight;
+mod history;
 mod hunk;
 mod timing;
 mod watch;
@@ -49,6 +55,9 @@ pub use change::{ChangeKind, FileChange};
 pub use error::{Error, Result};
 pub use frame::{Frame, FrameStats};
 pub use highlight::{CHECKPOINT_STRIDE, Class, HighlightStats, Highlighter, Pass, Span};
+pub use history::{
+    HISTORY_BUCKET, HISTORY_BUCKETS, HISTORY_PATHS, HISTORY_WINDOW, History, HistoryStats, Recency,
+};
 pub use hunk::{CONTEXT, FileDiff, Hunk, Line, LineKind};
 pub use timing::{FrameTiming, Samples};
 pub use watch::{Stop, Tick, WatchOptions, WatchStats, Watcher};

--- a/crates/vigia-core/src/watch.rs
+++ b/crates/vigia-core/src/watch.rs
@@ -14,14 +14,22 @@
 //! saving twelve files produces twelve events for one logical change, so
 //! accepted events are coalesced into a single tick.
 //!
-//! A tick also **names the file whose write landed last in it**, which is what
-//! follow mode moves to (`SPEC.md` §11.1, I5). That is not extra work: the
-//! gitignore filter already resolves every event against the worktree root, so
-//! the path is a by-product of a decision this module was making anyway. The
-//! alternative was deriving recency by `stat`-ing every changed file, which is
-//! the cost [#19](https://github.com/breferrari/vigia/issues/19) records as
-//! breaching I9 at scale, for an answer the event was carrying all along.
+//! A tick also **names the files written in it**, which is what follow mode and
+//! the glance history both read (`SPEC.md` §11.1, I5 and I10). That is not extra
+//! work: the gitignore filter already resolves every event against the worktree
+//! root, so the paths are a by-product of a decision this module was making
+//! anyway. The alternative was deriving recency by `stat`-ing every changed
+//! file, which is the cost [#19](https://github.com/breferrari/vigia/issues/19)
+//! records as breaching I9 at scale, for an answer the event was carrying all
+//! along.
+//!
+//! The set a burst reports is **capped**, at the same [`HISTORY_PATHS`] that
+//! bounds the store it feeds. A bulk operation can put ten thousand writes
+//! inside one hundred-millisecond burst, and a tick that carried all of them
+//! would hand I10 a bound to enforce after the allocation had already happened.
+//! What the cap refuses is counted rather than dropped silently.
 
+use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -32,6 +40,7 @@ use std::time::{Duration, Instant};
 use notify::{EventKind, RecursiveMode, Watcher as _};
 
 use crate::error::{Error, Result};
+use crate::history::HISTORY_PATHS;
 
 /// How the watch loop folds a burst of events into one refresh.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -61,24 +70,97 @@ impl Default for WatchOptions {
 
 /// A coalesced signal that the working tree changed.
 ///
-/// Not `Copy`, because [`Tick::newest`] owns a path. One allocation per burst,
-/// on a path that only exists while something is being edited.
+/// Not `Copy`, because it owns the paths. One `Vec` per burst, holding paths
+/// that only exist while something is being edited, and never more than
+/// [`HISTORY_PATHS`] of them.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Tick {
     /// Accepted events folded into this tick.
     pub events: u32,
     /// How long the tick was held back to coalesce.
     pub coalesced_for: Duration,
-    /// Repository-relative path of the write that landed **last** in this
-    /// tick, spelled the way [`crate::FileChange::path`] spells it.
+    /// The distinct files written in this tick, spelled the way
+    /// [`crate::FileChange::path`] spells them.
     ///
-    /// This is what I5 follows, and `SPEC.md` §11.1 is the rule it obeys.
+    /// **The write that landed last is the last element**, which is what
+    /// [`Tick::newest`] reads and what I5 follows. The order of everything
+    /// before it is unspecified: I10 bumps a bucket per path and does not care
+    /// which order they arrive in, so imposing one would be a promise with no
+    /// reader and a sort with no purpose.
     ///
-    /// `None` when the burst named no file the view could move to, which is an
-    /// ordinary outcome rather than a failure: a write to `.git/index` is a
-    /// real change and produces a real tick, because the index is the
-    /// left-hand side of every diff drawn, but it is not somewhere to scroll.
-    pub newest: Option<String>,
+    /// Empty when the burst wrote no file the view could move to, which is an
+    /// ordinary outcome rather than a failure: a write to `.git/index` is a real
+    /// change and produces a real tick, because the index is the left-hand side
+    /// of every diff drawn, but it is not somewhere to scroll.
+    pub paths: Vec<String>,
+    /// How many further paths this burst touched past [`HISTORY_PATHS`].
+    ///
+    /// Reported rather than dropped quietly. A bulk operation is exactly when a
+    /// reader most wants to know the picture is partial, and a cap that lied by
+    /// omission would make the sparkline understate the busiest moment a session
+    /// ever has.
+    pub dropped: u32,
+}
+
+impl Tick {
+    /// The write that landed **last** in this tick.
+    ///
+    /// This is what I5 follows, and `SPEC.md` §11.1 is the rule it obeys. It is
+    /// the last element of [`Tick::paths`] rather than a field of its own,
+    /// because two fields holding one fact are two things that can disagree, and
+    /// the one that would be wrong is the one the viewport jumps to.
+    ///
+    /// `None` for a tick that named no followable file. See [`Tick::paths`].
+    pub fn newest(&self) -> Option<&str> {
+        self.paths.last().map(String::as_str)
+    }
+}
+
+/// The paths accumulated while a burst is still being coalesced.
+///
+/// A set rather than a list, because the same file saved four times inside one
+/// burst is one change to the reader and I10 samples per tick. The write that
+/// landed last is tracked alongside it, and is the one path the cap may never
+/// refuse: it is where the viewport is about to move.
+#[derive(Debug, Default)]
+struct Burst {
+    seen: HashSet<String>,
+    newest: Option<String>,
+    dropped: u32,
+}
+
+impl Burst {
+    /// Record a followable path, which by construction is the newest so far.
+    fn push(&mut self, path: String) {
+        if !self.seen.contains(&path) {
+            if self.seen.len() >= HISTORY_PATHS {
+                // Displace something rather than refuse this one. Refusing
+                // would eventually refuse the newest path, and losing that is
+                // losing follow mode's answer at the exact moment it had one.
+                // Which path goes is arbitrary and says so: past the cap this
+                // is a bulk operation, where no individual membership is
+                // information a reader could act on.
+                let victim = self.seen.iter().next().cloned();
+                if let Some(victim) = victim {
+                    self.seen.remove(&victim);
+                }
+                self.dropped += 1;
+            }
+            self.seen.insert(path.clone());
+        }
+        self.newest = Some(path);
+    }
+
+    /// The paths, with the newest moved to the end.
+    fn finish(mut self) -> (Vec<String>, u32) {
+        let Some(newest) = self.newest else {
+            return (self.seen.into_iter().collect(), self.dropped);
+        };
+        self.seen.remove(&newest);
+        let mut paths: Vec<String> = self.seen.into_iter().collect();
+        paths.push(newest);
+        (paths, self.dropped)
+    }
 }
 
 /// What one accepted message meant.
@@ -248,7 +330,10 @@ impl<'repo> Watcher<'repo> {
             let hard_deadline = started + self.options.max_delay;
             let mut quiet_until = started + self.options.quiet;
             let mut events = 1;
-            let mut newest = accepted.newest;
+            let mut burst = Burst::default();
+            if let Some(path) = accepted.newest {
+                burst.push(path);
+            }
 
             // Inside a burst, and only inside it, waiting is bounded.
             loop {
@@ -267,14 +352,13 @@ impl<'repo> Watcher<'repo> {
                             None => break,
                             Some(accepted) if accepted.relevant => {
                                 events += 1;
-                                // Overwritten only by an event that named a
-                                // file. An agent that edits and then stages
-                                // ends its burst on an index write, and
-                                // letting that blank the target would lose
-                                // follow mode's answer at the exact moment it
-                                // had one.
-                                if accepted.newest.is_some() {
-                                    newest = accepted.newest;
+                                // Only an event that named a file adds one. An
+                                // agent that edits and then stages ends its
+                                // burst on an index write, and letting that
+                                // blank the target would lose follow mode's
+                                // answer at the exact moment it had one.
+                                if let Some(path) = accepted.newest {
+                                    burst.push(path);
                                 }
                                 quiet_until = Instant::now() + self.options.quiet;
                             }
@@ -287,10 +371,12 @@ impl<'repo> Watcher<'repo> {
             }
 
             self.stats.ticks += 1;
+            let (paths, dropped) = burst.finish();
             return Some(Tick {
                 events,
                 coalesced_for: started.elapsed(),
-                newest,
+                paths,
+                dropped,
             });
         }
     }
@@ -669,5 +755,90 @@ mod tests {
 
         assert!(!accepted.relevant);
         assert_eq!(accepted.newest, None);
+    }
+
+    /// The burst accumulator, tested directly for the reason `SPEC.md` §7
+    /// gives about the racily-clean guard: the cases that matter need ten
+    /// thousand writes inside one hundred-millisecond window, which no
+    /// integration test in this suite can arrange on demand.
+    mod burst {
+        use super::*;
+
+        fn collect(paths: &[&str]) -> (Vec<String>, u32) {
+            let mut burst = Burst::default();
+            for path in paths {
+                burst.push((*path).to_owned());
+            }
+            burst.finish()
+        }
+
+        #[test]
+        fn the_write_that_landed_last_is_last() {
+            let (paths, dropped) = collect(&["a", "b", "c"]);
+
+            assert_eq!(paths.last().map(String::as_str), Some("c"));
+            assert_eq!(paths.len(), 3);
+            assert_eq!(dropped, 0);
+        }
+
+        /// Four saves of one file inside one burst is one change to the reader,
+        /// and I10 samples per tick rather than per event.
+        #[test]
+        fn a_file_saved_repeatedly_inside_one_burst_appears_once() {
+            let (paths, _) = collect(&["a", "a", "a", "a"]);
+
+            assert_eq!(paths, vec!["a".to_owned()]);
+        }
+
+        /// Repeating an earlier path still moves the follow target, because the
+        /// last write is the last write however many times it has happened
+        /// before.
+        #[test]
+        fn a_repeat_of_an_earlier_path_still_becomes_the_newest() {
+            let (paths, _) = collect(&["a", "b", "a"]);
+
+            assert_eq!(paths.last().map(String::as_str), Some("a"));
+            assert_eq!(paths.len(), 2);
+        }
+
+        #[test]
+        fn a_burst_that_named_nothing_carries_nothing() {
+            let (paths, dropped) = collect(&[]);
+
+            assert!(paths.is_empty());
+            assert_eq!(dropped, 0);
+        }
+
+        /// I10's cap, enforced where the allocation would otherwise happen. A
+        /// tick that carried ten thousand paths would hand the store a bound to
+        /// apply after the cost had already been paid.
+        #[test]
+        fn a_bulk_burst_is_capped_and_says_how_much_it_refused() {
+            let owned: Vec<String> = (0..10_000).map(|n| format!("f{n}")).collect();
+            let mut burst = Burst::default();
+            for path in &owned {
+                burst.push(path.clone());
+            }
+            let (paths, dropped) = burst.finish();
+
+            assert_eq!(paths.len(), HISTORY_PATHS);
+            assert_eq!(dropped, 10_000 - HISTORY_PATHS as u32);
+        }
+
+        /// The one path the cap may never refuse. Losing it loses follow mode's
+        /// answer, and it would be lost precisely during a bulk operation, which
+        /// is when the viewport moving matters most.
+        #[test]
+        fn the_newest_path_survives_the_cap() {
+            let owned: Vec<String> = (0..10_000).map(|n| format!("f{n}")).collect();
+            let mut burst = Burst::default();
+            for path in &owned {
+                burst.push(path.clone());
+            }
+            let (paths, _) = burst.finish();
+
+            assert_eq!(paths.last().map(String::as_str), Some("f9999"));
+            assert_eq!(paths.len(), HISTORY_PATHS, "and it did not exceed the cap");
+        }
     }
 }

--- a/crates/vigia-core/tests/budgets.rs
+++ b/crates/vigia-core/tests/budgets.rs
@@ -14,6 +14,14 @@
 //! only in release, because the budgets were set against optimised code, and
 //! they accept a slack multiplier so a hosted runner's variance does not read
 //! as a code regression. A developer machine runs them with no slack at all.
+//!
+//! **I10 is the one budget that is not here**, and the pointer is worth a line
+//! so nobody concludes it is ungated. Every gate in this file is either a ratio
+//! between two fixtures or a duration; I10's budget is a **count** (256 paths,
+//! a 120s window) with neither shape, and the fixture that puts it under
+//! pressure is ten thousand paths rather than two worktrees. It lives in
+//! `tests/history.rs`, named for the invariant, and `SPEC.md` §3's proof column
+//! names that file the way I6's names `crates/vigia/tests/legibility.rs`.
 
 mod support;
 

--- a/crates/vigia-core/tests/history.rs
+++ b/crates/vigia-core/tests/history.rs
@@ -1,0 +1,193 @@
+//! I10, as an invariant over the public store rather than over its arithmetic.
+//!
+//! > Churn history is bounded by a fixed window and a fixed cap on tracked
+//! > paths, independent of how many files the session changed. A path that ages
+//! > out of the window is dropped entirely.
+//!
+//! The unit tests inside `src/history.rs` cover the rules one step at a time:
+//! one path aging out, one eviction picking the right victim, one bucket
+//! rolling. This file covers the claim those rules add up to, and it covers it
+//! **at the scale I10 is written against**, which is the part no arithmetic test
+//! reaches. `SPEC.md` §5.2 names the case in as many words: *a bulk operation
+//! touching ten thousand files must not grow it past the cap.*
+//!
+//! Every gate here drives the clock by handing an [`Instant`] in rather than by
+//! sleeping. The window is two minutes long, so a suite that waited for real
+//! time could not assert the time rule at all, and one that shortened the window
+//! for testing would be gating a constant the product does not ship.
+//!
+//! Structural throughout: counts and bounds, hardware-independent, no slack.
+//! There is nothing to time here, because I10 is a claim about size.
+
+use std::time::Instant;
+
+use vigia_core::{
+    HISTORY_BUCKET, HISTORY_BUCKETS, HISTORY_PATHS, HISTORY_WINDOW, History, Recency,
+};
+
+/// Paths a bulk operation invents, well past the cap.
+///
+/// `SPEC.md` §5.2's own number. It matters that it is far above
+/// [`HISTORY_PATHS`] rather than just above: a fixture that only grazed the cap
+/// would pass against an off-by-one in the eviction rule.
+const BULK: usize = 10_000;
+
+/// A base far enough ahead that a gate can step forward through a whole window
+/// without leaving the monotonic clock's range.
+fn base() -> Instant {
+    Instant::now() + HISTORY_WINDOW * 4
+}
+
+fn bulk_paths() -> Vec<String> {
+    (0..BULK)
+        .map(|n| format!("src/generated/f{n}.rs"))
+        .collect()
+}
+
+/// The case `SPEC.md` §5.2 names, driven rather than approximated.
+///
+/// Both halves are asserted, and the second is the one that matters. A store
+/// nothing ever filled satisfies a cap the way an empty room satisfies a fire
+/// code, so the bound is only evidence when the eviction counter says the cap
+/// was doing the bounding.
+#[test]
+fn ten_thousand_distinct_paths_leave_the_store_at_the_cap() {
+    let now = base();
+    let mut history = History::starting_at(now);
+    let paths = bulk_paths();
+
+    history.record(paths.iter().map(String::as_str), now);
+
+    assert_eq!(
+        history.tracked(),
+        HISTORY_PATHS,
+        "{BULK} paths left {} tracked, so glance history is bounded by what the \
+         session touched rather than by anything fixed",
+        history.tracked()
+    );
+    assert_eq!(
+        history.stats().evicted_by_cap as usize,
+        BULK - HISTORY_PATHS,
+        "the cap held without evicting, so it was never what bounded the store"
+    );
+    assert_eq!(history.stats().recorded as usize, BULK);
+}
+
+/// The bound has to hold *throughout*, not only when the dust settles.
+///
+/// A store that collected everything and pruned at the end would pass the gate
+/// above while allocating for ten thousand paths, which is the cost I10 exists
+/// to prevent rather than to clean up after.
+#[test]
+fn the_store_never_grows_past_the_cap_at_any_point_during_the_bulk() {
+    let now = base();
+    let mut history = History::starting_at(now);
+
+    for (n, path) in bulk_paths().iter().enumerate() {
+        history.record([path.as_str()], now);
+        assert!(
+            history.tracked() <= HISTORY_PATHS,
+            "after {n} paths the store held {}, over the cap of {HISTORY_PATHS}",
+            history.tracked()
+        );
+    }
+}
+
+/// The time rule, which is the half a cap cannot provide.
+///
+/// A worktree that goes quiet must empty the store rather than hold its last
+/// picture for ever: `SPEC.md` §5.2 asks for history that survives a file
+/// settling, and I10 is what stops "survives" from meaning "never leaves".
+#[test]
+fn a_window_of_silence_empties_the_store() {
+    let now = base();
+    let mut history = History::starting_at(now);
+    let paths = bulk_paths();
+    history.record(paths.iter().map(String::as_str), now);
+    assert_eq!(history.tracked(), HISTORY_PATHS);
+
+    // One tick, naming nothing, a whole window later. This is the staging case
+    // and the idle case at once: the wake that arrives after a quiet spell.
+    history.record(std::iter::empty(), now + HISTORY_WINDOW);
+
+    assert_eq!(
+        history.tracked(),
+        0,
+        "{} paths survived a whole window of silence",
+        history.tracked()
+    );
+    assert!(history.stats().evicted_by_window >= HISTORY_PATHS as u64);
+    assert_eq!(history.peak(), 0, "the shared scale outlived its samples");
+}
+
+/// A path that ages out is **dropped**, not drawn empty.
+///
+/// The distinction is the whole of I10's second sentence, and it is
+/// observable: a path drawn empty would still occupy a slot the cap counts, so
+/// a store that zeroed instead of removing would be bounded by paths-ever-seen
+/// rather than by the window.
+#[test]
+fn a_path_that_ages_out_is_dropped_rather_than_kept_empty() {
+    let now = base();
+    let mut history = History::starting_at(now);
+    history.record(["src/lib.rs"], now);
+    assert!(history.churn("src/lib.rs").is_some());
+
+    history.record(["src/other.rs"], now + HISTORY_WINDOW);
+
+    assert_eq!(history.churn("src/lib.rs"), None);
+    assert_eq!(history.recency("src/lib.rs"), Recency::Cold);
+    assert_eq!(
+        history.tracked(),
+        1,
+        "the aged-out path is still occupying a slot the cap counts"
+    );
+}
+
+/// Churn survives a file settling, which is the reason this store exists at all.
+///
+/// `SPEC.md` §5.2: the frame path's cache empties the moment a path stops being
+/// changed, and a sparkline built on that would show nothing worth glancing at.
+/// This is the property that had to be added rather than reused.
+#[test]
+fn a_path_keeps_its_churn_after_it_stops_changing() {
+    let now = base();
+    let mut history = History::starting_at(now);
+    history.record(["src/lib.rs"], now);
+
+    // Several ticks later, about other files entirely: the shape of an agent
+    // that moved on to something else.
+    for step in 1..=4 {
+        history.record(["src/other.rs"], now + HISTORY_BUCKET * step);
+    }
+
+    let buckets = history
+        .churn("src/lib.rs")
+        .expect("the settled file lost its history");
+    assert!(
+        buckets.iter().any(|&count| count > 0),
+        "the settled file is tracked but its window is empty"
+    );
+    assert_eq!(
+        history.recency("src/lib.rs"),
+        Recency::Live,
+        "a settled file inside the window is live, not cold and not pulsing"
+    );
+}
+
+/// The buckets have to tile the window exactly.
+///
+/// [`HISTORY_BUCKET`] is an integer division of [`HISTORY_WINDOW`], so a window
+/// that is not a multiple of the bucket count leaves a remainder no bucket
+/// covers: a sample could then fall outside every one of them, and the strip
+/// would silently describe a shorter span than the gradient's boundary uses.
+/// Cheap to check and impossible to notice by reading.
+#[test]
+fn the_window_is_exactly_the_buckets_it_is_divided_into() {
+    assert_eq!(
+        HISTORY_BUCKET * HISTORY_BUCKETS as u32,
+        HISTORY_WINDOW,
+        "the buckets do not tile the window, so a sample can fall outside every \
+         one of them"
+    );
+}

--- a/crates/vigia-core/tests/history.rs
+++ b/crates/vigia-core/tests/history.rs
@@ -120,6 +120,50 @@ fn a_window_of_silence_empties_the_store() {
     assert_eq!(history.peak(), 0, "the shared scale outlived its samples");
 }
 
+/// The same claim, reached one bucket at a time.
+///
+/// **This is a different code path from the gate above and mutation testing is
+/// what found that.** A gap of a whole window or more is a special case: nothing
+/// tracked can have a sample left, so the store clears outright rather than
+/// shifting anything. Every gate here jumped a full window, so the ordinary path
+/// (shift the buckets, drop whatever came out empty) was never run, and breaking
+/// it left the whole suite green.
+///
+/// A monitor beside a working agent takes exactly this shape: ticks arrive
+/// steadily, each one a fraction of the window, and a path ages out through
+/// accumulated shifts rather than through one long silence.
+#[test]
+fn a_path_ages_out_through_ordinary_ticks_and_not_only_through_one_long_gap() {
+    let now = base();
+    let mut history = History::starting_at(now);
+    history.record(["src/lib.rs"], now);
+
+    // One bucket per tick, each naming a *different* file, so the store stays
+    // busy and only the first path is aging.
+    for step in 1..=HISTORY_BUCKETS as u32 {
+        history.record(["src/other.rs"], now + HISTORY_BUCKET * step);
+        assert!(
+            history.tracked() > 0,
+            "the store emptied at step {step}, so this walked off the end \
+             instead of aging one path out"
+        );
+    }
+
+    assert_eq!(
+        history.churn("src/lib.rs"),
+        None,
+        "the path still has buckets after the window slid past it a step at a \
+         time, so eviction only happens on the whole-window shortcut"
+    );
+    assert_eq!(history.recency("src/lib.rs"), Recency::Cold);
+    assert_eq!(
+        history.tracked(),
+        1,
+        "the aged-out path is still occupying a slot the cap counts"
+    );
+    assert!(history.stats().evicted_by_window > 0);
+}
+
 /// A path that ages out is **dropped**, not drawn empty.
 ///
 /// The distinction is the whole of I10's second sentence, and it is

--- a/crates/vigia-core/tests/watch.rs
+++ b/crates/vigia-core/tests/watch.rs
@@ -217,10 +217,10 @@ fn a_tick_names_the_file_whose_write_landed_last() {
 
         let tick = tick_within(&mut watcher, SETTLE).expect("a burst must produce a tick");
         assert_eq!(
-            tick.newest.as_deref(),
+            tick.newest(),
             Some(last),
             "wrote {first} then {last}, and the tick named {:?}",
-            tick.newest
+            tick.newest()
         );
     }
 }
@@ -253,10 +253,10 @@ fn a_rename_is_followed_to_where_the_file_now_is() {
 
     let tick = tick_within(&mut watcher, SETTLE).expect("a rename must produce a tick");
     assert_eq!(
-        tick.newest.as_deref(),
+        tick.newest(),
         Some("after.txt"),
         "a rename named {:?}, so the view moves to a path that no longer exists",
-        tick.newest
+        tick.newest()
     );
 }
 

--- a/crates/vigia/src/app.rs
+++ b/crates/vigia/src/app.rs
@@ -5,7 +5,7 @@
 //! optional message. A monitor with more state than that has started becoming a
 //! reviewer.
 
-use vigia_core::{Frame, Highlighter, Result};
+use vigia_core::{Frame, Highlighter, History, Result};
 
 use crate::input::Action;
 use crate::render::Chrome;
@@ -246,13 +246,20 @@ impl App {
     /// to remember; a [`Highlighter`] owns seventy-five compiled grammars, and
     /// putting one behind a derived `Clone` leaves a two-megabyte copy one
     /// keystroke away from being made by accident.
+    ///
+    /// The history is passed in for the same reason and with the same force.
+    /// It is `vigia_core`'s, it is bounded by I10 rather than by anything here,
+    /// and a copy of it behind [`App`]'s derived `Clone` would be a second
+    /// answer to "what changed recently" that nothing keeps in step with the
+    /// first.
     pub fn view(
         &mut self,
         frame: &mut Frame,
         highlighter: &mut Highlighter,
+        history: &History,
         height: usize,
     ) -> Result<View> {
-        let view = View::collect(frame, highlighter, self.position, height)?;
+        let view = View::collect(frame, highlighter, history, self.position, height)?;
         self.position = view.top;
         Ok(view)
     }

--- a/crates/vigia/src/lib.rs
+++ b/crates/vigia/src/lib.rs
@@ -48,9 +48,10 @@ pub use view::{Position, Row, View, rows_in};
 
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Sender};
+use std::time::Instant;
 
 use ratatui::layout::Rect;
-use vigia_core::{Highlighter, WatchOptions, Worktree};
+use vigia_core::{Highlighter, History, WatchOptions, Worktree};
 
 /// Anything that stops the shell from starting or from drawing.
 ///
@@ -65,11 +66,11 @@ enum Wake {
     Input(ratatui::crossterm::event::Event),
     /// The working tree changed, coalesced into one signal by the core.
     ///
-    /// Carries the path of the write that landed last in the burst, when it
-    /// named one, which is what follow mode moves to. `None` is ordinary: a
-    /// staging write changes every diff's left-hand side and is nowhere to
-    /// scroll to.
-    Tick(Option<String>),
+    /// Carries every file the burst wrote, with the one that landed last at the
+    /// end. The tail is what follow mode moves to (I5) and the whole list is
+    /// what the glance history samples (I10). Empty is ordinary: a staging write
+    /// changes every diff's left-hand side and is nowhere to scroll to.
+    Tick(Vec<String>),
     /// The watch stopped, so the shell is a still picture.
     ///
     /// Reported rather than fatal. A diff nobody is watching for changes is
@@ -109,6 +110,11 @@ pub fn run(path: &Path) -> Result<(), Failure> {
         // ours by the time this runs. The placement is right and the reason was
         // wrong.
         highlighter: Highlighter::new(),
+        // Empty at startup, so every file in an already-dirty worktree draws
+        // cold until something writes to it. That is the honest first frame: a
+        // monitor has no way to know what happened before it was looking, and
+        // inventing a recency for it would light up rows nothing has touched.
+        history: History::new(),
         theme: Theme::default(),
         name: short_name(worktree.workdir()),
         screen: View::default(),
@@ -146,8 +152,16 @@ pub fn run(path: &Path) -> Result<(), Failure> {
                     Err(e) => shell.app.warn(e.to_string()),
                 }
             }
-            Wake::Tick(newest) => {
+            Wake::Tick(paths) => {
                 shell.app.clear_notice();
+                // Sampled here and nowhere else, which is the whole of I10's
+                // relationship with I1: the window is real time, and the only
+                // thing that moves it is a wake the loop was already having.
+                // An empty burst still rolls the window and still leaves the
+                // pulse where it was, which is the staging case.
+                shell
+                    .history
+                    .record(paths.iter().map(String::as_str), Instant::now());
                 // The core leaves the frame exactly as it was on failure, so the
                 // previous diff is still valid to draw. Saying so on the footer
                 // beats blanking a pane for a reason the reader cannot see.
@@ -159,8 +173,8 @@ pub fn run(path: &Path) -> Result<(), Failure> {
                     // to sit, which is the shape of a bug that only appears
                     // when the list changes length.
                     Ok(()) => {
-                        if let Some(path) = newest {
-                            shell.app.follow(&path, &frame);
+                        if let Some(path) = paths.last() {
+                            shell.app.follow(path, &frame);
                         }
                     }
                     Err(e) => shell.app.warn(e.to_string()),
@@ -185,6 +199,15 @@ struct Shell {
     /// [`App::view`]. Bounded by the viewport rather than by the diff, so a day
     /// of scrolling leaves it the size of one screen.
     highlighter: Highlighter,
+    /// What changed recently: the source for the sparkline, the recency gradient
+    /// and the pulse.
+    ///
+    /// The one thing the shell keeps that deliberately outlives the diff. A file
+    /// that settles leaves [`vigia_core::Frame`]'s cache and must not leave this,
+    /// or the strip would empty exactly when a reader glances over to ask what
+    /// was busy. I10 bounds it instead, by a window and a path cap rather than by
+    /// the session.
+    history: History,
     theme: Theme,
     /// What the header calls the working tree.
     name: String,
@@ -214,7 +237,10 @@ impl Shell {
         // keeps this row budget and the renderer's layout in agreement.
         let chrome = self.app.chrome(&self.name);
         let height = body_height(self.area()?, &chrome, frame.files().len());
-        match self.app.view(frame, &mut self.highlighter, height) {
+        match self
+            .app
+            .view(frame, &mut self.highlighter, &self.history, height)
+        {
             Ok(view) => self.screen = view,
             Err(e) => self.app.warn(e.to_string()),
         }
@@ -265,7 +291,7 @@ fn spawn_watch(path: PathBuf, tx: Sender<Wake>) {
         // the events missed. That is what makes a recursive watch's blind spot
         // over freshly created directories harmless here.
         while let Some(tick) = watcher.next_tick() {
-            if tx.send(Wake::Tick(tick.newest)).is_err() {
+            if tx.send(Wake::Tick(tick.paths)).is_err() {
                 return;
             }
         }

--- a/crates/vigia/src/render.rs
+++ b/crates/vigia/src/render.rs
@@ -31,7 +31,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::Span as TextSpan;
-use vigia_core::{Class, LineKind, Span};
+use vigia_core::{Class, HISTORY_BUCKETS, LineKind, Recency, Span};
 
 use crate::theme::Theme;
 use crate::view::{Row, View};
@@ -92,6 +92,46 @@ const HINT_RUNGS: [&str; 4] = [
 /// **not** exported for the same reason inverted: a test comparing the rung
 /// table against itself proves nothing, so the rungs are observed by rendering.
 pub const HINT_SEPARATOR: &str = " · ";
+
+/// A churn bucket's height, emptiest first.
+///
+/// The eighth-blocks every sparkline in every terminal is drawn from. They are
+/// outside CP437, like the `▶` the footer has carried since I5, so the legacy
+/// Windows console `SPEC.md` §10 leaves open degrades on both together rather
+/// than on this alone.
+const SPARK_RAMP: [char; 8] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+
+/// A bucket nothing happened in.
+///
+/// A space rather than the lowest block. `▁` would say "a little happened",
+/// which is a different claim from "nothing did", and over eight buckets the
+/// difference is what tells a settling file from a busy one.
+const SPARK_EMPTY: char = ' ';
+
+/// How many buckets a sparkline may show, widest rung first.
+///
+/// A sparkline is **a thing made of items**, so `SPEC.md` §11.1 makes it break
+/// rather than mark an edge: it drops whole buckets, oldest first, and never
+/// draws a partial one. Halving keeps the remaining strip readable as a shape,
+/// where shaving one bucket at a time would leave widths where the picture is
+/// neither the full window nor an obvious fraction of it.
+const SPARK_RUNGS: [usize; 3] = [HISTORY_BUCKETS, HISTORY_BUCKETS / 2, 0];
+
+/// The pulse, widest rung first.
+///
+/// `SPEC.md` §5.1 draws this as a persisting label with a dot rather than a
+/// flash. The mark survives narrowing on its own, for the reason `f follow` is
+/// the last hint standing: it is the one signal on the row that cannot be
+/// recovered from anything else on screen, and one column is what it costs.
+const PULSE_RUNGS: [&str; 3] = ["● just changed", "●", ""];
+
+/// Columns a path keeps before any glance element is allowed to exist.
+///
+/// A heading whose path has been elided past this is a row that has stopped
+/// naming its own file, which is exactly the "truncated to useless" shape I6
+/// forbids. Twelve leaves `…engine/watch.rs` legible at forty columns, where the
+/// counters and the pulse together already want twenty.
+const MIN_PATH_WIDTH: usize = 12;
 
 /// The smallest body a second footer line may leave behind.
 ///
@@ -177,6 +217,50 @@ fn state_rungs(following: bool, position: &str) -> Vec<String> {
     }
     rungs.push(String::new());
     rungs
+}
+
+/// One file heading's parts, gathered so [`Painter::file_row`] takes a shape
+/// rather than seven positional arguments that a caller could transpose.
+struct Heading<'r> {
+    kind: char,
+    path: &'r str,
+    from: Option<&'r str>,
+    churn: Option<(u32, u32)>,
+    spark: &'r [u16; HISTORY_BUCKETS],
+    recency: Recency,
+}
+
+/// Columns something of `width` costs on the right-hand side of a row.
+///
+/// One more than it measures, because [`Painter::put_right`] leaves a gap so the
+/// right-hand text never touches what is drawn from the left. Written once
+/// rather than as a `+ 1` at each call site: the two places that reserve space
+/// and the one that draws it have to agree, and a `+ 1` remembered in two of
+/// three is a row that overwrites its own path at one width in twenty.
+fn reserved(width: usize) -> usize {
+    if width == 0 { 0 } else { width + 1 }
+}
+
+/// A path's buckets as glyphs, or `None` when it has no churn to draw.
+///
+/// `peak` is the busiest bucket **anywhere on the screen**, so two rows drawn
+/// side by side can be compared by height. A bucket with anything in it is never
+/// blank: it takes the lowest block, because "one write" and "no writes" are the
+/// distinction the strip exists to make and rounding the first down to nothing
+/// would erase it.
+fn spark_of(buckets: &[u16; HISTORY_BUCKETS], peak: u16) -> Option<[char; HISTORY_BUCKETS]> {
+    if peak == 0 || buckets.iter().all(|&count| count == 0) {
+        return None;
+    }
+    let mut glyphs = [SPARK_EMPTY; HISTORY_BUCKETS];
+    for (glyph, &count) in glyphs.iter_mut().zip(buckets.iter()) {
+        if count == 0 {
+            continue;
+        }
+        let scaled = (usize::from(count) * SPARK_RAMP.len()).div_ceil(usize::from(peak));
+        *glyph = SPARK_RAMP[scaled.clamp(1, SPARK_RAMP.len()) - 1];
+    }
+    Some(glyphs)
 }
 
 /// The widest rung of `ladder` that fits in `room`.
@@ -558,7 +642,20 @@ impl Painter<'_> {
                     from,
                     kind,
                     churn,
-                } => self.file_row(Rect { y, ..area }, *kind, path, from.as_deref(), *churn),
+                    spark,
+                    recency,
+                } => self.file_row(
+                    Rect { y, ..area },
+                    &Heading {
+                        kind: *kind,
+                        path,
+                        from: from.as_deref(),
+                        churn: *churn,
+                        spark,
+                        recency: *recency,
+                    },
+                    view.peak,
+                ),
                 Row::Hunk {
                     old_start,
                     old_lines,
@@ -591,33 +688,78 @@ impl Painter<'_> {
         }
     }
 
-    /// `M src/frame.rs                             +12 -3`
-    fn file_row(
-        &mut self,
-        area: Rect,
-        kind: char,
-        path: &str,
-        from: Option<&str>,
-        churn: Option<(u32, u32)>,
-    ) {
-        let counts = churn
+    /// `M src/frame.rs        ● just changed  ▁▃█▅▂▁▁▁      +12 -3`
+    ///
+    /// Everything to the right of the path is placed right to left, and the
+    /// order it is *allocated* in is not the order it is drawn in. Allocation is
+    /// priority: the counters first because they are the row's content, then the
+    /// pulse, then the sparkline. The pulse outranks the strip for the same
+    /// reason `f follow` is the last hint standing, and because its narrow rung
+    /// costs one column against the strip's four.
+    ///
+    /// Nothing is allowed to take the path below [`MIN_PATH_WIDTH`]. A glance
+    /// element that cost a reader the name of the file would be spending the
+    /// content to decorate it.
+    fn file_row(&mut self, area: Rect, heading: &Heading<'_>, peak: u16) {
+        let mut right = area;
+
+        let counts = heading
+            .churn
             .map(|(added, removed)| format!("+{added} -{removed}"))
             .unwrap_or_default();
-        let taken = self.put_right(area, &counts, self.theme.chrome_dim);
-        let mut room = usize::from(area.width).saturating_sub(taken);
+        let taken = self.put_right(right, &counts, self.theme.chrome_dim);
+        right.width = right.width.saturating_sub(taken as u16);
 
-        let letter = format!("{kind} ");
+        // What is left after the kind letter and the path's floor. Saturating,
+        // so a row too narrow to hold both simply has no glance budget at all.
+        let mut budget = usize::from(right.width).saturating_sub(2 + MIN_PATH_WIDTH);
+
+        let pulse = if heading.recency == Recency::Pulse {
+            widest_fitting(&PULSE_RUNGS, budget)
+        } else {
+            ""
+        };
+        budget = budget.saturating_sub(reserved(width_of(pulse)));
+
+        // Drawn right to left, so each block knows where the one outside it
+        // ended. The strip drawn is the **tail** of the window: dropping buckets
+        // means dropping the oldest, and the oldest are on the left.
+        if let Some(strip) = spark_of(heading.spark, peak) {
+            let buckets = SPARK_RUNGS
+                .iter()
+                .copied()
+                .find(|&rung| reserved(rung) <= budget)
+                .unwrap_or(0);
+            if buckets > 0 {
+                let tail: String = strip[HISTORY_BUCKETS - buckets..].iter().collect();
+                let taken = self.put_right(right, &tail, self.theme.spark);
+                right.width = right.width.saturating_sub(taken as u16);
+            }
+        }
+        if !pulse.is_empty() {
+            let taken = self.put_right(right, pulse, self.theme.pulse);
+            right.width = right.width.saturating_sub(taken as u16);
+        }
+
+        let mut room = usize::from(right.width);
+        let letter = format!("{} ", heading.kind);
         let x = self.put(area.x, area.y, &letter, room, self.theme.kind);
         room = room.saturating_sub(usize::from(x - area.x));
 
-        let mut label = path.to_owned();
-        if let Some(from) = from {
+        let mut label = heading.path.to_owned();
+        if let Some(from) = heading.from {
             // Which file it *was* is the whole content of a rename, so it is
             // part of the label rather than something to reveal on a keypress.
             label.push_str(" ← ");
             label.push_str(from);
         }
-        self.put(x, area.y, &elide_head(&label, room), room, self.theme.path);
+        self.put(
+            x,
+            area.y,
+            &elide_head(&label, room),
+            room,
+            self.theme.recency(heading.recency),
+        );
     }
 
     /// `  128 +    let value = 1;`

--- a/crates/vigia/src/theme.rs
+++ b/crates/vigia/src/theme.rs
@@ -9,7 +9,7 @@
 //! that work attaches to, not an attempt at it.
 
 use ratatui::style::{Color, Modifier, Style};
-use vigia_core::Class;
+use vigia_core::{Class, Recency};
 
 /// Every colour the shell draws with.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -18,8 +18,20 @@ pub struct Theme {
     pub chrome: Style,
     /// Secondary text on those lines: key hints, counts.
     pub chrome_dim: Style,
-    /// A changed file's path.
+    /// A changed file's path, at the recency the reader should read it as.
+    ///
+    /// Three styles rather than one, because `SPEC.md` §5 makes intensity carry
+    /// recency: the mockup's dimmed `Cargo.toml` is how the eye finds what moved
+    /// without reading anything. Resolved through [`Theme::recency`].
     pub path: Style,
+    /// A path that changed inside the glance window but not in the last tick.
+    pub path_live: Style,
+    /// A path nothing has written since `vigia` started watching.
+    pub path_cold: Style,
+    /// The `● just changed` label on a file that moved in the last tick.
+    pub pulse: Style,
+    /// A churn sparkline's blocks.
+    pub spark: Style,
     /// The letter naming what happened to a file.
     pub kind: Style,
     /// A hunk's `@@` header.
@@ -56,6 +68,24 @@ pub struct Theme {
 }
 
 impl Theme {
+    /// The style a file heading is drawn in at `recency`.
+    ///
+    /// **Three steps, not a fade, and that is a loss rather than a design.**
+    /// `SPEC.md` §5.1 asks for a recency *gradient*, and sixteen foreground-only
+    /// colours have exactly three intensities to spend: bold, plain and dim.
+    /// A real gradient needs the truecolour ramp that
+    /// [#11](https://github.com/breferrari/vigia/issues/11) brings, and this is
+    /// the seam it attaches to. Recorded out loud for the same reason §11.1
+    /// records the diff signal narrowing to the sigil column: §5 makes shape and
+    /// colour the whole differentiator, so spending some of it is worth saying.
+    pub fn recency(&self, recency: Recency) -> Style {
+        match recency {
+            Recency::Pulse => self.path,
+            Recency::Live => self.path_live,
+            Recency::Cold => self.path_cold,
+        }
+    }
+
     /// The style a run of `class` is drawn in.
     ///
     /// [`Class::Plain`] takes [`Theme::context`] whatever line it lands on, and
@@ -86,7 +116,20 @@ impl Default for Theme {
         Self {
             chrome: Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
             chrome_dim: Style::new().fg(Color::DarkGray),
+            // Three rungs of one ramp: bright and bold, bright, then plain.
+            // `Gray` rather than `DarkGray` for the coldest, deliberately. Every
+            // file in an already-dirty worktree is cold until something writes
+            // to it, so this is what the **first** frame of a session looks
+            // like, and a path drawn in the same near-invisible grey as a
+            // comment would open the tool on a screen nobody can read.
             path: Style::new().fg(Color::White).add_modifier(Modifier::BOLD),
+            path_live: Style::new().fg(Color::White),
+            path_cold: Style::new().fg(Color::Gray),
+            // Cyan rather than a diff colour. The pulse says *when*, and green
+            // or red beside a path would read as *what*, which the sigil column
+            // already means two rows below.
+            pulse: Style::new().fg(Color::Cyan),
+            spark: Style::new().fg(Color::Cyan),
             kind: Style::new().fg(Color::Yellow),
             hunk: Style::new().fg(Color::Blue),
             gutter: Style::new().fg(Color::DarkGray),

--- a/crates/vigia/src/view.rs
+++ b/crates/vigia/src/view.rs
@@ -26,7 +26,10 @@
 //! [`vigia_core::FileChange`] cannot be constructed outside its crate, so a view
 //! assembled by hand is the only version of one a snapshot test can reach.
 
-use vigia_core::{ChangeKind, FileDiff, Frame, Highlighter, LineKind, Pass, Result, Span};
+use vigia_core::{
+    ChangeKind, FileDiff, Frame, HISTORY_BUCKETS, Highlighter, History, LineKind, Pass, Recency,
+    Result, Span,
+};
 
 /// What a row of the body is.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -41,6 +44,19 @@ pub enum Row {
         kind: char,
         /// Lines added and removed, or `None` when there is no line-level diff.
         churn: Option<(u32, u32)>,
+        /// This file's churn over the glance window, oldest bucket first.
+        ///
+        /// Raw counts rather than heights. Which glyph a count becomes is the
+        /// renderer's, the same way a [`Row::Line`] carries its spans as classes
+        /// and lets the renderer pick the colour: the scale is shared across the
+        /// screen and lives on [`View::peak`].
+        ///
+        /// All zeroes for a file `vigia` has not seen change, which is the
+        /// ordinary case for a worktree that was already dirty at startup.
+        spark: [u16; HISTORY_BUCKETS],
+        /// How recently this file changed, which is what dims a settled row and
+        /// what puts the pulse on one that just moved.
+        recency: Recency,
     },
     /// A hunk boundary, drawn as git's `@@ -a,b +c,d @@`.
     Hunk {
@@ -119,6 +135,17 @@ pub struct View {
     /// Reported so a test can hold the *shell* to I4, not just the core. One,
     /// once the position has settled and a single file fills the screen.
     pub read: usize,
+    /// The busiest bucket any tracked file holds, which every sparkline on this
+    /// screen is drawn against.
+    ///
+    /// One scale for the whole view rather than one per row. The question a
+    /// reader asks down a file list is which file is busiest, and a row scaled
+    /// against its own maximum draws every file at full height the moment it is
+    /// the busiest thing it has ever been, which answers a question nobody asked.
+    ///
+    /// Zero means nothing is tracked, and a renderer must read it as "draw no
+    /// sparkline" rather than dividing by it.
+    pub peak: u16,
 }
 
 /// The letter shown for a kind of change.
@@ -200,9 +227,20 @@ impl View {
     /// `position.file` is clamped rather than trusted, because
     /// [`vigia_core::Frame::diff`] panics on an index that has fallen off the
     /// end, and a scroll position is exactly the index that can.
+    ///
+    /// `history` is read per **drawn** row and never per changed file, so the
+    /// glance elements follow the viewport the way the reads already do. It
+    /// costs no file read, no `stat` and no diff: everything it answers was
+    /// recorded from the filesystem event that woke the loop. That is what
+    /// `tests/reads.rs` asserts by not moving.
+    ///
+    /// No clock is passed in and none is read here. `History` advances on ticks,
+    /// so recency is whatever the last event left it as, which is what keeps I1
+    /// intact and what makes every test over these rows deterministic.
     pub fn collect(
         frame: &mut Frame,
         highlighter: &mut Highlighter,
+        history: &History,
         position: Position,
         height: usize,
     ) -> Result<Self> {
@@ -228,6 +266,7 @@ impl View {
                 row: position.row,
             },
             read: 0,
+            peak: history.peak(),
         };
         if files == 0 {
             // Nothing to point at, so nothing to preserve either.
@@ -271,7 +310,7 @@ impl View {
                 placed = true;
             }
 
-            view.take_file(&change.kind, diff, &mut highlighter, skip, height);
+            view.take_file(&change.kind, diff, &mut highlighter, history, skip, height);
             skip = 0;
             index += 1;
         }
@@ -295,6 +334,7 @@ impl View {
         kind: &ChangeKind,
         diff: &FileDiff,
         highlighter: &mut Pass<'_>,
+        history: &History,
         skip: usize,
         height: usize,
     ) {
@@ -306,6 +346,11 @@ impl View {
                 from: source_of(kind).map(str::to_owned),
                 kind: letter(kind),
                 churn: (note_for(kind, diff).is_none()).then_some((diff.added, diff.removed)),
+                // Asked for only on a row actually pushed, the same rule the
+                // highlighter follows below. A heading scrolled past above the
+                // window costs two hash lookups it would never have drawn.
+                spark: history.churn(&diff.path).unwrap_or([0; HISTORY_BUCKETS]),
+                recency: history.recency(&diff.path),
             });
         }
         n += 1;

--- a/crates/vigia/tests/budgets.rs
+++ b/crates/vigia/tests/budgets.rs
@@ -24,7 +24,7 @@ use std::time::{Duration, Instant};
 
 use ratatui::layout::Rect;
 use vigia::{App, body_height};
-use vigia_core::{CHECKPOINT_STRIDE, Frame, Highlighter, LineKind, Samples};
+use vigia_core::{CHECKPOINT_STRIDE, Frame, Highlighter, History, LineKind, Samples};
 
 use support::{Scratch, budget, delta, exclusively_timed, highlight_delta, settle};
 
@@ -144,6 +144,7 @@ fn frame_budget_at_depth(name: &str, depth: usize) {
 
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let mut history = History::new();
     let height = body(&app, FILES);
 
     if depth > 0 {
@@ -157,7 +158,7 @@ fn frame_budget_at_depth(name: &str, depth: usize) {
         )
         .expect("scroll");
         let view = app
-            .view(&mut frame, &mut highlighter, height)
+            .view(&mut frame, &mut highlighter, &history, height)
             .expect("view");
         assert_eq!(
             view.top.row, depth,
@@ -181,24 +182,36 @@ fn frame_budget_at_depth(name: &str, depth: usize) {
     // the other pane and is deliberately outside the timed region.
     let mut edits = 0usize;
     let mut marker = String::new();
-    let mut next_frame = |frame: &mut Frame, app: &mut App, highlighter: &mut Highlighter| {
-        marker = format!("fn edited_{edits}() {{ let value = {edits}; }}");
-        scratch.edit_line(EDITED_PATH, 0, &marker);
-        edits += 1;
-        time(|| {
-            frame.advance().expect("advance");
-            app.view(frame, highlighter, height).expect("view");
-        })
-    };
+    let mut next_frame =
+        |frame: &mut Frame, app: &mut App, highlighter: &mut Highlighter, history: &mut History| {
+            marker = format!("fn edited_{edits}() {{ let value = {edits}; }}");
+            scratch.edit_line(EDITED_PATH, 0, &marker);
+            edits += 1;
+            time(|| {
+                // Inside the timed region on purpose. `vigia::run` samples the
+                // history on the same wake that advances the frame, so a gate that
+                // recorded outside `time` would be timing a frame path the product
+                // does not have. It is what I10 costs per tick, measured where I9
+                // can see it.
+                history.record([EDITED_PATH], Instant::now());
+                frame.advance().expect("advance");
+                app.view(frame, highlighter, history, height).expect("view");
+            })
+        };
 
     for _ in 0..WARMUP_FRAMES {
-        next_frame(&mut frame, &mut app, &mut highlighter);
+        next_frame(&mut frame, &mut app, &mut highlighter, &mut history);
     }
 
     let before = highlighter.stats();
     let mut frames = Samples::new(SAMPLED_FRAMES);
     for _ in 0..SAMPLED_FRAMES {
-        frames.push(next_frame(&mut frame, &mut app, &mut highlighter));
+        frames.push(next_frame(
+            &mut frame,
+            &mut app,
+            &mut highlighter,
+            &mut history,
+        ));
     }
     let cost = highlight_delta(before, highlighter.stats());
 
@@ -215,7 +228,7 @@ fn frame_budget_at_depth(name: &str, depth: usize) {
     // The screen has to have been full, or a frame that drew two rows would be
     // a cheap frame for a reason that is not the code.
     let view = app
-        .view(&mut frame, &mut highlighter, height)
+        .view(&mut frame, &mut highlighter, &history, height)
         .expect("view");
     assert_eq!(
         view.rows.len(),
@@ -313,6 +326,7 @@ fn the_frame_budget_holds_through_a_bulk_rewrite() {
 
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let mut history = History::new();
     let height = body(&app, FILES);
 
     if !absolute_gates_apply() {
@@ -321,18 +335,20 @@ fn the_frame_budget_holds_through_a_bulk_rewrite() {
 
     let _timed = exclusively_timed();
 
-    let draw = |frame: &mut Frame, app: &mut App, highlighter: &mut Highlighter| {
-        time(|| {
-            frame.advance().expect("advance");
-            app.view(frame, highlighter, height).expect("view");
-        })
-    };
+    let draw =
+        |frame: &mut Frame, app: &mut App, highlighter: &mut Highlighter, history: &mut History| {
+            time(|| {
+                history.record([EDITED_PATH], Instant::now());
+                frame.advance().expect("advance");
+                app.view(frame, highlighter, history, height).expect("view");
+            })
+        };
 
     // Warm up *before* the first rewrite, not after. Warming afterwards would
     // spend the margin this gate exists to measure and leave the samples in the
     // settled state every other gate here already covers.
     for _ in 0..WARMUP_FRAMES {
-        draw(&mut frame, &mut app, &mut highlighter);
+        draw(&mut frame, &mut app, &mut highlighter, &mut history);
     }
 
     // The event, re-established every `REWRITE_EVERY` frames, and the frame that
@@ -358,7 +374,7 @@ fn the_frame_budget_holds_through_a_bulk_rewrite() {
     for at in 0..SAMPLED_FRAMES {
         if at % REWRITE_EVERY == 0 {
             scratch.rewrite_all(FILES, LINES, at / REWRITE_EVERY + 1);
-            draw(&mut frame, &mut app, &mut highlighter);
+            draw(&mut frame, &mut app, &mut highlighter, &mut history);
         }
         // The drawn file, rewritten before each frame. One file rather than a
         // hundred, the idiom the two gates above already use, and the term that
@@ -368,7 +384,7 @@ fn the_frame_budget_holds_through_a_bulk_rewrite() {
             0,
             &format!("fn bulk_edited_{at}() {{ let value = {at}; }}"),
         );
-        frames.push(draw(&mut frame, &mut app, &mut highlighter));
+        frames.push(draw(&mut frame, &mut app, &mut highlighter, &mut history));
     }
     let cost = delta(before, frame.stats());
     let parsed = highlight_delta(highlighted, highlighter.stats());
@@ -421,7 +437,7 @@ fn the_frame_budget_holds_through_a_bulk_rewrite() {
 
     // And the screen has to have been full, for the reason the gate above gives.
     let view = app
-        .view(&mut frame, &mut highlighter, height)
+        .view(&mut frame, &mut highlighter, &history, height)
         .expect("view");
     assert_eq!(
         view.rows.len(),

--- a/crates/vigia/tests/follow.rs
+++ b/crates/vigia/tests/follow.rs
@@ -29,7 +29,7 @@ use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
 use vigia::{Action, App, Position, Row, Theme, body_height, render};
-use vigia_core::{Frame, Highlighter};
+use vigia_core::{Frame, Highlighter, History};
 
 use support::{Scratch, delta};
 
@@ -72,8 +72,13 @@ fn path_at(frame: &Frame, index: usize) -> String {
 /// The oracle for every assertion in this file. Following is a claim about
 /// what the reader sees, so it is checked against what would be drawn rather
 /// than against the position that produced it.
-fn top_file(app: &mut App, frame: &mut Frame, highlighter: &mut Highlighter) -> String {
-    let view = app.view(frame, highlighter, body()).expect("view");
+fn top_file(
+    app: &mut App,
+    frame: &mut Frame,
+    highlighter: &mut Highlighter,
+    history: &History,
+) -> String {
+    let view = app.view(frame, highlighter, history, body()).expect("view");
     match view.rows.first() {
         Some(Row::File { path, .. }) => path.clone(),
         other => panic!("the top row is {other:?}, not a file heading"),
@@ -99,6 +104,7 @@ fn a_change_moves_the_view_to_the_changed_file_with_no_input_at_all() {
     frame.advance().expect("advance");
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     let target = path_at(&frame, TARGET);
     let first = path_at(&frame, 0);
@@ -109,12 +115,15 @@ fn a_change_moves_the_view_to_the_changed_file_with_no_input_at_all() {
         target, first,
         "the fixture put the follow target where the view already was"
     );
-    assert_eq!(top_file(&mut app, &mut frame, &mut highlighter), first);
+    assert_eq!(
+        top_file(&mut app, &mut frame, &mut highlighter, &history),
+        first
+    );
 
     app.follow(&target, &frame);
 
     assert_eq!(
-        top_file(&mut app, &mut frame, &mut highlighter),
+        top_file(&mut app, &mut frame, &mut highlighter, &history),
         target,
         "the view did not move to the file that changed"
     );
@@ -142,6 +151,7 @@ fn a_scripted_edit_sequence_draws_the_file_that_changed_last() {
     let mut frame = worktree.frame();
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     // The script. Each step is an edit and the tick it produces, in the order
     // an agent would make them, and nothing else: no key is pressed anywhere
@@ -159,7 +169,7 @@ fn a_scripted_edit_sequence_draws_the_file_that_changed_last() {
     let area = Rect::new(0, 0, 64, 12);
     let height = body_height(area, &app.chrome("fixture"), frame.files().len());
     let view = app
-        .view(&mut frame, &mut highlighter, height)
+        .view(&mut frame, &mut highlighter, &history, height)
         .expect("view");
     assert_eq!(view.files, 3, "the fixture is not three changed files");
 
@@ -183,11 +193,15 @@ fn scrolling_disengages_follow_and_the_next_change_does_not_move_the_view() {
     frame.advance().expect("advance");
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     let target = path_at(&frame, TARGET);
     let other = path_at(&frame, OTHER);
     app.follow(&target, &frame);
-    assert_eq!(top_file(&mut app, &mut frame, &mut highlighter), target);
+    assert_eq!(
+        top_file(&mut app, &mut frame, &mut highlighter, &history),
+        target
+    );
 
     app.apply(Action::Scroll(1), &mut frame, body())
         .expect("scroll");
@@ -218,6 +232,7 @@ fn f_re_engages_follow_and_jumps_to_the_newest_change() {
     frame.advance().expect("advance");
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     app.apply(Action::Scroll(1), &mut frame, body())
         .expect("scroll");
@@ -243,7 +258,7 @@ fn f_re_engages_follow_and_jumps_to_the_newest_change() {
 
     assert!(app.following(), "`f` did not re-engage follow mode");
     assert_eq!(
-        top_file(&mut app, &mut frame, &mut highlighter),
+        top_file(&mut app, &mut frame, &mut highlighter, &history),
         other,
         "`f` re-armed the view without moving it, so the reader has to wait for \
          another write to see the change they pressed it for"
@@ -266,6 +281,7 @@ fn a_resize_does_not_disengage_follow() {
     frame.advance().expect("advance");
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     app.apply(Action::Redraw, &mut frame, body())
         .expect("redraw");
@@ -274,7 +290,7 @@ fn a_resize_does_not_disengage_follow() {
     let target = path_at(&frame, TARGET);
     app.follow(&target, &frame);
     assert_eq!(
-        top_file(&mut app, &mut frame, &mut highlighter),
+        top_file(&mut app, &mut frame, &mut highlighter, &history),
         target,
         "the view stopped following after a resize"
     );
@@ -383,17 +399,21 @@ fn a_position_survives_the_file_it_points_at_being_committed() {
     frame.advance().expect("advance");
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     let last = path_at(&frame, FILES - 1);
     app.follow(&last, &frame);
-    assert_eq!(top_file(&mut app, &mut frame, &mut highlighter), last);
+    assert_eq!(
+        top_file(&mut app, &mut frame, &mut highlighter, &history),
+        last
+    );
 
     scratch.commit_all("the agent in the other pane commits");
     frame.advance().expect("advance");
     assert_eq!(frame.files().len(), 0, "the commit left changes behind");
 
     let view = app
-        .view(&mut frame, &mut highlighter, body())
+        .view(&mut frame, &mut highlighter, &history, body())
         .expect("a shrunken list must not panic");
     assert!(view.rows.is_empty(), "a clean worktree drew rows");
     assert_eq!(

--- a/crates/vigia/tests/legibility.rs
+++ b/crates/vigia/tests/legibility.rs
@@ -24,7 +24,7 @@ use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
 use ratatui::text::Span;
 use vigia::{Chrome, HINT_SEPARATOR, Position, Row, Theme, View, body_height, render};
-use vigia_core::LineKind;
+use vigia_core::{HISTORY_BUCKETS, LineKind, Recency};
 
 /// The mark meaning "this continues past the right edge".
 const CONTINUES: char = '›';
@@ -150,6 +150,8 @@ fn every_row_kind() -> View {
                 from: None,
                 kind: 'M',
                 churn: Some((3, 1)),
+                spark: [0; HISTORY_BUCKETS],
+                recency: Recency::Cold,
             },
             Row::Hunk {
                 old_start: 258,
@@ -169,6 +171,8 @@ fn every_row_kind() -> View {
                 from: None,
                 kind: 'M',
                 churn: None,
+                spark: [0; HISTORY_BUCKETS],
+                recency: Recency::Cold,
             },
             Row::Note("binary"),
             Row::File {
@@ -176,11 +180,14 @@ fn every_row_kind() -> View {
                 from: Some("crates/vigia/src/main.rs".to_owned()),
                 kind: 'R',
                 churn: Some((0, 0)),
+                spark: [0; HISTORY_BUCKETS],
+                recency: Recency::Cold,
             },
         ],
         files: 3,
         top: Position::default(),
         read: 3,
+        peak: 0,
     }
 }
 
@@ -194,6 +201,8 @@ fn awkward() -> View {
                 from: None,
                 kind: 'M',
                 churn: Some((12, 3)),
+                spark: [0; HISTORY_BUCKETS],
+                recency: Recency::Cold,
             },
             line(LineKind::Added, 1, "見出し a 見出し b 見出し c"),
             line(LineKind::Added, 2, "🙂🙂🙂 tail"),
@@ -201,6 +210,7 @@ fn awkward() -> View {
         files: 1,
         top: Position::default(),
         read: 1,
+        peak: 0,
     }
 }
 
@@ -210,6 +220,7 @@ fn empty() -> View {
         files: 0,
         top: Position::default(),
         read: 0,
+        peak: 0,
     }
 }
 
@@ -234,6 +245,7 @@ fn numbered(n: usize, files: usize) -> View {
         files,
         top: Position::default(),
         read: 1,
+        peak: 0,
     }
 }
 
@@ -277,7 +289,56 @@ fn cases() -> Vec<(&'static str, View, Chrome)> {
         ("awkward content, following", awkward(), following()),
         ("clean worktree, following", empty(), following()),
         ("clean worktree, idle", empty(), chrome()),
+        // Added to the *shared* list rather than given gates of its own, which
+        // is the point: every structural rule already swept here now covers the
+        // glance elements too. A sparkline and a pulse are new things competing
+        // for the same row as the path and the counters, so "no row
+        // over-occupies" and "a label that lost characters says so" are exactly
+        // the assertions they can break.
+        ("glance elements, idle", glancing(), chrome()),
+        ("glance elements, following", glancing(), following()),
     ]
+}
+
+/// A file heading at each rung of the recency ladder, with churn behind it.
+///
+/// **Every bucket is non-zero on purpose.** An empty bucket draws as a space, so
+/// a fixture with gaps in it makes the strip's *width* unobservable from the
+/// rendered row, and the ladder gate below could not tell four buckets from
+/// eight. The counts still differ, so the shared scale is exercised as well.
+fn glancing() -> View {
+    View {
+        rows: vec![
+            Row::File {
+                path: "crates/vigia-core/src/watch.rs".to_owned(),
+                from: None,
+                kind: 'M',
+                churn: Some((42, 7)),
+                spark: [1, 2, 4, 6, 8, 9, 11, 12],
+                recency: Recency::Pulse,
+            },
+            Row::File {
+                path: "crates/vigia/src/render.rs".to_owned(),
+                from: None,
+                kind: 'M',
+                churn: Some((11, 3)),
+                spark: [1, 1, 2, 2, 1, 3, 2, 1],
+                recency: Recency::Live,
+            },
+            Row::File {
+                path: "Cargo.toml".to_owned(),
+                from: None,
+                kind: 'M',
+                churn: Some((2, 0)),
+                spark: [0; HISTORY_BUCKETS],
+                recency: Recency::Cold,
+            },
+        ],
+        files: 3,
+        top: Position::default(),
+        read: 3,
+        peak: 12,
+    }
 }
 
 #[test]
@@ -662,6 +723,7 @@ fn a_label_cut_at_the_right_edge_says_so() {
         files: 1,
         top: Position::default(),
         read: 1,
+        peak: 0,
     };
     let long_name = Chrome {
         worktree: "a-worktree-with-a-very-long-name-indeed".to_owned(),
@@ -778,6 +840,7 @@ fn a_clipped_content_line_says_it_continues() {
         files: 1,
         top: Position::default(),
         read: 1,
+        peak: 0,
     };
 
     let mut saw_fit = false;
@@ -805,5 +868,91 @@ fn a_clipped_content_line_says_it_continues() {
     assert!(
         saw_fit && saw_cut,
         "the sweep did not cover both directions"
+    );
+}
+
+/// `SPEC.md` §11.1's rule, applied to the newest thing on the row.
+///
+/// > A thing made of items breaks, a thing made of characters marks its edge,
+/// > and content is neither.
+///
+/// A sparkline is made of items, so it drops **whole buckets** and never draws a
+/// partial one. Observable because [`glancing`]'s buckets are all non-zero: an
+/// empty bucket is a space, so a fixture with gaps would make the strip's width
+/// unreadable from the row and this gate would be asserting about nothing.
+///
+/// The rungs are read off the screen rather than imported. A test comparing the
+/// renderer's ladder against the renderer's own constant would agree with itself
+/// at every width, which is the failure the hint-bar gate already documents.
+#[test]
+fn the_sparkline_drops_whole_buckets_and_never_half_of_one() {
+    let ramp = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+    let mut seen = std::collections::BTreeSet::new();
+
+    for (name, view, chrome) in cases() {
+        for width in WIDTHS {
+            for row in rows_at(width, 6, &view, &chrome) {
+                let buckets = row.chars().filter(|c| ramp.contains(c)).count();
+                assert!(
+                    buckets <= 8,
+                    "{name}: {buckets} buckets at {width} columns, over the eight \
+                     the window holds: {row:?}"
+                );
+                if buckets > 0 {
+                    seen.insert(buckets);
+                }
+            }
+        }
+    }
+
+    // Whole rungs only. Any count between them is a strip that was squeezed
+    // rather than shortened, which is the shape the rule forbids.
+    assert_eq!(
+        seen,
+        [4usize, 8].into_iter().collect(),
+        "the sparkline was drawn at bucket counts {seen:?}; only whole rungs are \
+         legal, and both of them have to be reachable or the ladder has a rung \
+         no width can produce"
+    );
+}
+
+/// The pulse may take room from the path. It may not take the path.
+///
+/// `MIN_PATH_WIDTH` is the floor, and this is the assertion that makes it load
+/// bearing: at every width from one to a hundred and twenty, a heading either
+/// names its file or says which end it lost. A glance element that reduced a row
+/// to `M …` would have spent the content to decorate it.
+#[test]
+fn the_pulse_label_never_pushes_a_path_off_its_own_row() {
+    let view = glancing();
+    let mut narrowest_named = u16::MAX;
+
+    for width in WIDTHS {
+        let rows = rows_at(width, 6, &view, &following());
+        let heading = &rows[1];
+        // The pulse is whole or absent: it is a ladder, so it never appears cut.
+        let dotted = heading.contains('●');
+        assert!(
+            !dotted || heading.contains("● just changed") || !heading.contains("just"),
+            "at {width} columns the pulse is drawn part-way: {heading:?}"
+        );
+
+        // And the row still names its file, by tail or by mark.
+        let tail = "watch.rs";
+        if heading.contains(tail) {
+            narrowest_named = narrowest_named.min(width);
+        } else {
+            assert!(
+                width < 20,
+                "at {width} columns the heading no longer contains {tail:?}: \
+                 {heading:?}"
+            );
+        }
+    }
+
+    assert!(
+        narrowest_named <= 24,
+        "the heading only named its file from {narrowest_named} columns up, so a \
+         glance element is eating the path well before the pane gets small"
     );
 }

--- a/crates/vigia/tests/reads.rs
+++ b/crates/vigia/tests/reads.rs
@@ -19,9 +19,11 @@
 #[path = "../../vigia-core/tests/support/mod.rs"]
 mod support;
 
+use std::time::Instant;
+
 use ratatui::layout::Rect;
-use vigia::{App, Position, body_height};
-use vigia_core::{FrameStats, HighlightStats, Highlighter};
+use vigia::{App, Position, Row, body_height};
+use vigia_core::{FrameStats, HighlightStats, Highlighter, History, Recency};
 
 use support::{Scratch, delta, materialise, settle};
 
@@ -80,9 +82,10 @@ fn one_screen(name: &str, files: usize) -> Screen {
 
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
     let before = frame.stats();
     let view = app
-        .view(&mut frame, &mut highlighter, body())
+        .view(&mut frame, &mut highlighter, &history, body())
         .expect("view");
 
     Screen {
@@ -201,6 +204,7 @@ fn scrolling_for_a_long_time_does_not_grow_the_highlight_cache() {
 
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
     let height = body();
 
     let mut most = 0usize;
@@ -208,7 +212,7 @@ fn scrolling_for_a_long_time_does_not_grow_the_highlight_cache() {
         app.apply(vigia::Action::Page(1), &mut frame, height)
             .expect("page down");
         let view = app
-            .view(&mut frame, &mut highlighter, height)
+            .view(&mut frame, &mut highlighter, &history, height)
             .expect("view");
 
         // Non-vacuity per screen: a scroll that ran off the end would draw a
@@ -291,9 +295,10 @@ fn a_redraw_with_nothing_changed_reads_nothing() {
 
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
     let before = frame.stats();
     let view = app
-        .view(&mut frame, &mut highlighter, body())
+        .view(&mut frame, &mut highlighter, &history, body())
         .expect("view");
     let cost = delta(before, frame.stats());
 
@@ -378,6 +383,7 @@ fn bulk_rewrite_window(name: &str, files: usize) -> Margin {
 
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
     let height = body();
 
     let before = frame.stats();
@@ -390,7 +396,7 @@ fn bulk_rewrite_window(name: &str, files: usize) -> Margin {
         }
         frame.advance().expect("advance");
         let view = app
-            .view(&mut frame, &mut highlighter, height)
+            .view(&mut frame, &mut highlighter, &history, height)
             .expect("view");
         read = view.read;
         rows = view.rows.len();
@@ -489,6 +495,7 @@ fn resolving_the_scroll_position_is_paid_once_and_not_every_frame() {
 
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
     // Each file here is one rewritten line: a file row, a hunk row and two
     // content rows. Scrolling by forty files' worth of rows lands well inside the
     // list rather than at either end.
@@ -502,7 +509,7 @@ fn resolving_the_scroll_position_is_paid_once_and_not_every_frame() {
     .expect("scroll");
 
     let crossing = app
-        .view(&mut frame, &mut highlighter, body())
+        .view(&mut frame, &mut highlighter, &history, body())
         .expect("view");
     assert_eq!(
         crossing.top,
@@ -519,7 +526,7 @@ fn resolving_the_scroll_position_is_paid_once_and_not_every_frame() {
     // and it is still a file the frame had to be asked for.
     let drawn = body().div_ceil(span);
     let settled = app
-        .view(&mut frame, &mut highlighter, body())
+        .view(&mut frame, &mut highlighter, &history, body())
         .expect("view");
     assert_eq!(settled.top, crossing.top, "the position drifted while idle");
     assert_eq!(
@@ -542,10 +549,11 @@ fn a_taller_screen_reads_more_files_and_a_shorter_one_reads_fewer() {
 
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
     let span = 4;
     for height in [span, span * 2, span * 5] {
         let view = app
-            .view(&mut frame, &mut highlighter, height)
+            .view(&mut frame, &mut highlighter, &history, height)
             .expect("view");
         assert_eq!(
             view.read,
@@ -555,4 +563,91 @@ fn a_taller_screen_reads_more_files_and_a_shorter_one_reads_fewer() {
         );
         assert_eq!(view.rows.len(), height);
     }
+}
+
+#[test]
+fn a_full_history_costs_the_frame_no_read_and_no_probe() {
+    // I10 sits on the frame path now: every drawn heading asks the store what
+    // that file's churn and recency are. This is the assertion that the answer
+    // is free.
+    //
+    // It has to be free rather than cheap. I2a's whole claim is that a
+    // revalidated frame reads **zero** bytes, and I4's is that the shell touches
+    // only the files it draws. A store that answered by `stat`-ing, or by
+    // reading, would break both while looking like a rendering detail, and the
+    // failure would be invisible to every gate above: they all run with an empty
+    // history, where a lookup that costs something is never made.
+    //
+    // Compared against the same frame drawn with an empty store rather than
+    // against a literal, so the two runs differ in exactly one thing.
+    let scratch = Scratch::large_diff("shell-reads-history", FEW_FILES, LINES);
+    let worktree = scratch.worktree();
+    let mut frame = worktree.frame();
+    settle(&mut frame);
+
+    let mut app = App::new();
+    let mut highlighter = Highlighter::new();
+
+    let empty = History::new();
+    let before = frame.stats();
+    let cold = app
+        .view(&mut frame, &mut highlighter, &empty, body())
+        .expect("view");
+    let without = delta(before, frame.stats());
+
+    // Every path in the diff, recorded, so every drawn heading resolves to a
+    // real entry rather than falling out of the store as untracked. A history
+    // that answered `None` everywhere would be the cheap case, not the measured
+    // one.
+    let mut full = History::new();
+    let paths: Vec<String> = frame
+        .files()
+        .iter()
+        .map(|change| change.path.clone())
+        .collect();
+    full.record(paths.iter().map(String::as_str), Instant::now());
+    assert!(full.tracked() > 0, "the store recorded nothing");
+
+    let before = frame.stats();
+    let warm = app
+        .view(&mut frame, &mut highlighter, &full, body())
+        .expect("view");
+    let with = delta(before, frame.stats());
+
+    assert_eq!(cold.rows.len(), body(), "the screen did not fill");
+    assert_eq!(
+        warm.rows.len(),
+        cold.rows.len(),
+        "the two frames drew different screens, so their costs are not comparable"
+    );
+    assert_eq!(
+        (with.bytes, with.probes, with.computed),
+        (without.bytes, without.probes, without.computed),
+        "a populated history changed the frame's cost from {without:?} to \
+         {with:?}, so glance state is being answered from the filesystem"
+    );
+    assert_eq!(with.bytes, 0, "the frame read {} bytes", with.bytes);
+
+    // Non-vacuity: the store has to have actually been consulted, or this
+    // compares two identical empty lookups. The drawn headings carry the
+    // recency the store holds, and with every path just recorded that is the
+    // pulse.
+    let pulsing = warm
+        .rows
+        .iter()
+        .filter(|row| {
+            matches!(
+                row,
+                Row::File {
+                    recency: Recency::Pulse,
+                    ..
+                }
+            )
+        })
+        .count();
+    assert!(
+        pulsing > 0,
+        "no drawn heading took its recency from the store, so this gate compared \
+         two frames that never consulted one"
+    );
 }

--- a/crates/vigia/tests/render.rs
+++ b/crates/vigia/tests/render.rs
@@ -27,7 +27,7 @@
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 use vigia::{Chrome, Position, Row, Theme, View, body_height, render};
-use vigia_core::{Class, LineKind, Span};
+use vigia_core::{Class, HISTORY_BUCKETS, LineKind, Recency, Span};
 
 /// The mark the renderer writes where a row runs past its edge.
 ///
@@ -122,6 +122,7 @@ fn highlighted(kind: LineKind, text: &str, spans: Vec<Span>) -> View {
         files: 1,
         top: Position::default(),
         read: 1,
+        peak: 0,
     }
 }
 
@@ -143,6 +144,8 @@ fn file(kind: char, path: &str, added: u32, removed: u32) -> Row {
         from: None,
         kind,
         churn: Some((added, removed)),
+        spark: [0; HISTORY_BUCKETS],
+        recency: Recency::Cold,
     }
 }
 
@@ -177,6 +180,7 @@ fn one_file() -> View {
         files: 1,
         top: Position::default(),
         read: 1,
+        peak: 0,
     }
 }
 
@@ -213,6 +217,7 @@ fn a_clean_worktree_says_so_rather_than_showing_nothing() {
         files: 0,
         top: Position::default(),
         read: 0,
+        peak: 0,
     };
     insta::assert_snapshot!(screen(40, 6, &view, &chrome()));
 }
@@ -226,6 +231,8 @@ fn a_file_with_no_line_diff_says_why() {
                 from: None,
                 kind: 'M',
                 churn: None,
+                spark: [0; HISTORY_BUCKETS],
+                recency: Recency::Cold,
             },
             Row::Note("binary"),
             Row::File {
@@ -233,6 +240,8 @@ fn a_file_with_no_line_diff_says_why() {
                 from: None,
                 kind: 'U',
                 churn: None,
+                spark: [0; HISTORY_BUCKETS],
+                recency: Recency::Cold,
             },
             Row::Note("unresolved conflict"),
             Row::File {
@@ -240,11 +249,14 @@ fn a_file_with_no_line_diff_says_why() {
                 from: Some("crates/vigia/src/main.rs".to_owned()),
                 kind: 'R',
                 churn: Some((0, 0)),
+                spark: [0; HISTORY_BUCKETS],
+                recency: Recency::Cold,
             },
         ],
         files: 3,
         top: Position::default(),
         read: 3,
+        peak: 0,
     };
     insta::assert_snapshot!(screen(60, 8, &view, &chrome()));
 }
@@ -264,6 +276,7 @@ fn a_path_too_long_to_fit_keeps_the_end_that_names_the_file() {
         files: 1,
         top: Position::default(),
         read: 1,
+        peak: 0,
     };
     insta::assert_snapshot!(screen(40, 4, &view, &chrome()));
 }
@@ -291,6 +304,7 @@ fn a_hunk_covering_one_line_is_written_git_s_way() {
         files: 1,
         top: Position::default(),
         read: 1,
+        peak: 0,
     };
     let rendered = format!("{}", screen(40, 6, &view, &chrome()));
     assert!(
@@ -362,6 +376,7 @@ fn tabs_become_columns_and_control_characters_become_visible() {
         files: 1,
         top: Position::default(),
         read: 1,
+        peak: 0,
     };
     let backend = screen(60, 5, &view, &chrome());
     let rendered = format!("{backend}");
@@ -389,6 +404,7 @@ fn a_double_width_character_is_never_cut_in_half() {
         files: 1,
         top: Position::default(),
         read: 1,
+        peak: 0,
     };
 
     for width in 6..48u16 {
@@ -433,6 +449,7 @@ fn the_gutter_gives_way_before_the_text_does() {
         files: 1,
         top: Position::default(),
         read: 1,
+        peak: 0,
     };
 
     let wide = format!("{}", screen(40, 3, &view, &chrome()));
@@ -706,5 +723,157 @@ fn a_tab_counts_its_columns_from_the_line_rather_than_from_its_span() {
          stop at four, and only a counter that restarted at the span boundary \
          would put it anywhere else",
         b - a
+    );
+}
+
+/// The three rungs of the recency ladder on one screen, with churn behind them.
+///
+/// Deliberately the mockup's own three files and counts: `assets/preview.svg`
+/// draws `watch.rs +42 −7` bright, `frame.rs +11 −3` below it and `Cargo.toml
+/// +2 −0` visibly fainter than either. `SPEC.md` §5.1 reads that dimmed row as a
+/// recency gradient, so a fixture that invented its own files would be checking
+/// the renderer against nothing in particular.
+///
+/// The buckets are chosen so the two live files disagree about their own peak
+/// and agree about the screen's, which is what makes the scale assertion below
+/// able to fail.
+fn glancing() -> View {
+    View {
+        rows: vec![
+            Row::File {
+                path: "src/engine/watch.rs".to_owned(),
+                from: None,
+                kind: 'M',
+                churn: Some((42, 7)),
+                spark: [0, 0, 1, 3, 8, 5, 9, 12],
+                recency: Recency::Pulse,
+            },
+            Row::File {
+                path: "src/render/frame.rs".to_owned(),
+                from: None,
+                kind: 'M',
+                churn: Some((11, 3)),
+                spark: [0, 0, 0, 2, 1, 0, 0, 0],
+                recency: Recency::Live,
+            },
+            Row::File {
+                path: "Cargo.toml".to_owned(),
+                from: None,
+                kind: 'M',
+                churn: Some((2, 0)),
+                spark: [0; HISTORY_BUCKETS],
+                recency: Recency::Cold,
+            },
+        ],
+        files: 3,
+        top: Position::default(),
+        read: 3,
+        peak: 12,
+    }
+}
+
+/// Everything on row `y`, as the reader sees it.
+fn row_text(backend: &TestBackend, y: u16) -> String {
+    let buffer = backend.buffer();
+    (0..buffer.area.width)
+        .map(|x| buffer[(x, y)].symbol().to_owned())
+        .collect()
+}
+
+#[test]
+fn the_glance_elements_at_eighty_columns() {
+    insta::assert_snapshot!(screen(80, 5, &glancing(), &chrome()));
+}
+
+#[test]
+fn the_glance_elements_at_forty_columns() {
+    insta::assert_snapshot!(screen(40, 5, &glancing(), &chrome()));
+}
+
+#[test]
+fn a_file_that_just_changed_says_so_and_the_rest_dim() {
+    // Two claims, and the second is invisible to every snapshot in this file
+    // because `TestBackend`'s `Display` drops styles: the pulse label belongs to
+    // exactly one row, and the three rungs have to be three *different*
+    // intensities or the gradient `SPEC.md` §5.1 asks for is not being drawn.
+    let theme = Theme::default();
+    let backend = screen(80, 5, &glancing(), &chrome());
+
+    // Body rows start at y = 1; the header is y = 0.
+    let pulsing = row_text(&backend, 1);
+    assert!(
+        pulsing.contains("just changed"),
+        "the file named by the newest tick carries no pulse: {pulsing:?}"
+    );
+    for y in [2, 3] {
+        let row = row_text(&backend, y);
+        assert!(
+            !row.contains("just changed"),
+            "row {y} carries the pulse too, so it marks more than the newest \
+             tick: {row:?}"
+        );
+    }
+
+    // The path's own cell, past the kind letter and its space. Compared on
+    // foreground and modifiers rather than on the whole `Style`, because a cell
+    // carries the buffer's own defaults for everything the theme left alone.
+    let path_x = 2;
+    let drawn = |y: u16| {
+        let style = backend.buffer()[(path_x, y)].style();
+        (style.fg, style.add_modifier)
+    };
+    let want = |recency| {
+        let style = theme.recency(recency);
+        (style.fg, style.add_modifier)
+    };
+    let rungs = [Recency::Pulse, Recency::Live, Recency::Cold];
+    for (y, recency) in (1..=3).zip(rungs) {
+        assert_eq!(
+            drawn(y),
+            want(recency),
+            "row {y} is not drawn as {recency:?}"
+        );
+    }
+    // Three rungs have to be three *different* intensities, or the gradient
+    // `SPEC.md` §5.1 asks for is being claimed rather than drawn.
+    assert!(
+        drawn(1) != drawn(2) && drawn(2) != drawn(3) && drawn(1) != drawn(3),
+        "two rungs of the recency ladder are drawn identically: {:?}",
+        [drawn(1), drawn(2), drawn(3)]
+    );
+}
+
+#[test]
+fn a_sparkline_scales_against_the_busiest_file_not_itself() {
+    // The whole reason `View::peak` exists. Scaled per file, both rows below
+    // would top out at the full block and the eye would read two files of very
+    // different activity as equally busy. Scaled against the screen, only the
+    // busiest one reaches the top.
+    let backend = screen(80, 5, &glancing(), &chrome());
+    let busiest = row_text(&backend, 1);
+    let quieter = row_text(&backend, 2);
+
+    assert!(
+        busiest.contains('█'),
+        "the busiest file's tallest bucket is not the top of the ramp: \
+         {busiest:?}"
+    );
+    assert!(
+        !quieter.contains('█'),
+        "a file whose busiest bucket is 2 against a screen peak of 12 reached \
+         the top of the ramp, so each row is being scaled against itself: \
+         {quieter:?}"
+    );
+    assert!(
+        quieter.contains('▁'),
+        "the quieter file drew no bucket at all, so a bucket with something in \
+         it is rounding down to nothing: {quieter:?}"
+    );
+    // A file nothing has written since startup has no strip, rather than an
+    // empty one taking columns from its own path.
+    let cold = row_text(&backend, 3);
+    assert!(
+        !cold.contains('▁') && !cold.contains('█'),
+        "a file with no churn drew a sparkline: {cold:?}"
     );
 }

--- a/crates/vigia/tests/rows.rs
+++ b/crates/vigia/tests/rows.rs
@@ -22,7 +22,7 @@ use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
 use vigia::{App, Position, Row, Theme, View, body_height, render};
-use vigia_core::{Highlighter, LineKind};
+use vigia_core::{Highlighter, History, LineKind};
 
 use support::Scratch;
 
@@ -83,8 +83,9 @@ fn every_line_number_names_the_line_it_is_on() {
     frame.advance().expect("advance");
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
     let view = app
-        .view(&mut frame, &mut highlighter, ALL_ROWS)
+        .view(&mut frame, &mut highlighter, &history, ALL_ROWS)
         .expect("view");
 
     let mut counts = [0usize; 3];
@@ -162,8 +163,9 @@ fn a_file_is_its_heading_then_its_hunks() {
     frame.advance().expect("advance");
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
     let view = app
-        .view(&mut frame, &mut highlighter, ALL_ROWS)
+        .view(&mut frame, &mut highlighter, &history, ALL_ROWS)
         .expect("view");
 
     let mut headings = 0usize;
@@ -230,8 +232,9 @@ fn each_kind_of_change_gets_its_own_letter() {
     frame.advance().expect("advance");
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
     let view = app
-        .view(&mut frame, &mut highlighter, ALL_ROWS)
+        .view(&mut frame, &mut highlighter, &history, ALL_ROWS)
         .expect("view");
 
     let mut seen: Vec<(char, String, Option<String>)> = view
@@ -302,10 +305,12 @@ fn a_window_into_a_file_is_the_same_rows_the_whole_file_would_give() {
     let mut frame = worktree.frame();
     frame.advance().expect("advance");
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     let whole = View::collect(
         &mut frame,
         &mut highlighter,
+        &history,
         Position { file: 0, row: 0 },
         ALL_ROWS,
     )
@@ -326,6 +331,7 @@ fn a_window_into_a_file_is_the_same_rows_the_whole_file_would_give() {
         let window = View::collect(
             &mut frame,
             &mut highlighter,
+            &history,
             Position {
                 file: 0,
                 row: offset,
@@ -378,12 +384,13 @@ fn a_real_repository_draws() {
     frame.advance().expect("advance");
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     let mut terminal = Terminal::new(TestBackend::new(64, 18)).expect("terminal");
     let area = Rect::new(0, 0, 64, 18);
     let height = body_height(area, &app.chrome("fixture"), frame.files().len());
     let view = app
-        .view(&mut frame, &mut highlighter, height)
+        .view(&mut frame, &mut highlighter, &history, height)
         .expect("view");
     // Non-vacuity: the fixture has to have produced something to draw, or the
     // snapshot below is a picture of an empty pane.
@@ -415,8 +422,9 @@ fn a_binary_file_gets_a_reason_instead_of_hunks() {
     frame.advance().expect("advance");
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
     let view = app
-        .view(&mut frame, &mut highlighter, ALL_ROWS)
+        .view(&mut frame, &mut highlighter, &history, ALL_ROWS)
         .expect("view");
 
     assert!(

--- a/crates/vigia/tests/scroll.rs
+++ b/crates/vigia/tests/scroll.rs
@@ -18,7 +18,7 @@ mod support;
 
 use ratatui::layout::Rect;
 use vigia::{Action, App, Position, Row, body_height};
-use vigia_core::{Frame, Highlighter};
+use vigia_core::{Frame, Highlighter, History};
 
 use support::{Scratch, materialise};
 
@@ -49,10 +49,13 @@ fn after(
     app: &mut App,
     frame: &mut Frame,
     highlighter: &mut Highlighter,
+    history: &History,
     action: Action,
 ) -> Position {
     app.apply(action, frame, body()).expect("apply");
-    app.view(frame, highlighter, body()).expect("view").top
+    app.view(frame, highlighter, history, body())
+        .expect("view")
+        .top
 }
 
 #[test]
@@ -86,13 +89,20 @@ fn scrolling_down_and_back_up_returns_to_where_it_started() {
     materialise(&mut frame);
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     for rows in [1, 3, SPAN as isize, 17, (SPAN * 12) as isize] {
         let start = app
-            .view(&mut frame, &mut highlighter, body())
+            .view(&mut frame, &mut highlighter, &history, body())
             .expect("view")
             .top;
-        let moved = after(&mut app, &mut frame, &mut highlighter, Action::Scroll(rows));
+        let moved = after(
+            &mut app,
+            &mut frame,
+            &mut highlighter,
+            &history,
+            Action::Scroll(rows),
+        );
         assert_ne!(
             moved, start,
             "scrolling {rows} rows from {start:?} moved nowhere"
@@ -101,6 +111,7 @@ fn scrolling_down_and_back_up_returns_to_where_it_started() {
             &mut app,
             &mut frame,
             &mut highlighter,
+            &history,
             Action::Scroll(-rows),
         );
         assert_eq!(
@@ -122,6 +133,7 @@ fn scrolling_off_the_end_of_a_file_continues_into_the_next_one() {
     materialise(&mut frame);
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     let mut seen = Vec::new();
     for _ in 0..(SPAN * 3) {
@@ -129,6 +141,7 @@ fn scrolling_off_the_end_of_a_file_continues_into_the_next_one() {
             &mut app,
             &mut frame,
             &mut highlighter,
+            &history,
             Action::Scroll(1),
         ));
     }
@@ -162,12 +175,14 @@ fn scrolling_up_walks_file_boundaries_the_same_way_down_does() {
     materialise(&mut frame);
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     let start = SPAN * 3;
     let landed = after(
         &mut app,
         &mut frame,
         &mut highlighter,
+        &history,
         Action::Scroll(start as isize),
     );
     assert_eq!(
@@ -182,6 +197,7 @@ fn scrolling_up_walks_file_boundaries_the_same_way_down_does() {
             &mut app,
             &mut frame,
             &mut highlighter,
+            &history,
             Action::Scroll(-1),
         ));
     }
@@ -213,11 +229,13 @@ fn the_bottom_of_the_diff_is_content_rather_than_blank() {
     materialise(&mut frame);
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     let landed = after(
         &mut app,
         &mut frame,
         &mut highlighter,
+        &history,
         Action::Scroll((SPAN * FILES * 4) as isize),
     );
     assert_eq!(
@@ -230,7 +248,7 @@ fn the_bottom_of_the_diff_is_content_rather_than_blank() {
     );
 
     let view = app
-        .view(&mut frame, &mut highlighter, body())
+        .view(&mut frame, &mut highlighter, &history, body())
         .expect("view");
     assert_eq!(
         view.rows.len(),
@@ -257,16 +275,29 @@ fn home_and_end_go_to_the_first_and_last_file() {
     materialise(&mut frame);
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     assert_eq!(
-        after(&mut app, &mut frame, &mut highlighter, Action::Bottom),
+        after(
+            &mut app,
+            &mut frame,
+            &mut highlighter,
+            &history,
+            Action::Bottom
+        ),
         Position {
             file: FILES - 1,
             row: 0
         }
     );
     assert_eq!(
-        after(&mut app, &mut frame, &mut highlighter, Action::Top),
+        after(
+            &mut app,
+            &mut frame,
+            &mut highlighter,
+            &history,
+            Action::Top
+        ),
         Position { file: 0, row: 0 }
     );
 }
@@ -282,9 +313,16 @@ fn a_page_keeps_one_row_of_overlap() {
     materialise(&mut frame);
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     let rows = body();
-    let landed = after(&mut app, &mut frame, &mut highlighter, Action::Page(1));
+    let landed = after(
+        &mut app,
+        &mut frame,
+        &mut highlighter,
+        &history,
+        Action::Page(1),
+    );
     let absolute = landed.file * SPAN + landed.row;
     assert_eq!(
         absolute,
@@ -293,7 +331,13 @@ fn a_page_keeps_one_row_of_overlap() {
     );
 
     assert_eq!(
-        after(&mut app, &mut frame, &mut highlighter, Action::Page(-1)),
+        after(
+            &mut app,
+            &mut frame,
+            &mut highlighter,
+            &history,
+            Action::Page(-1)
+        ),
         Position { file: 0, row: 0 },
         "paging back did not return to the top"
     );
@@ -311,8 +355,15 @@ fn a_position_survives_the_file_it_pointed_into_disappearing() {
     materialise(&mut frame);
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
-    let far = after(&mut app, &mut frame, &mut highlighter, Action::Bottom);
+    let far = after(
+        &mut app,
+        &mut frame,
+        &mut highlighter,
+        &history,
+        Action::Bottom,
+    );
     assert_eq!(
         far.file,
         FILES - 1,
@@ -327,7 +378,7 @@ fn a_position_survives_the_file_it_pointed_into_disappearing() {
     assert_eq!(frame.files().len(), FILES / 2, "the fixture did not shrink");
 
     let view = app
-        .view(&mut frame, &mut highlighter, body())
+        .view(&mut frame, &mut highlighter, &history, body())
         .expect("view");
     assert_eq!(
         view.top.file,
@@ -345,7 +396,7 @@ fn a_position_survives_the_file_it_pointed_into_disappearing() {
     assert_eq!(frame.files().len(), 0, "the worktree is not clean");
 
     let view = app
-        .view(&mut frame, &mut highlighter, body())
+        .view(&mut frame, &mut highlighter, &history, body())
         .expect("view");
     assert_eq!(view.files, 0);
     assert_eq!(view.top, Position::default());
@@ -363,6 +414,7 @@ fn a_screen_with_no_room_for_a_body_still_resolves() {
     materialise(&mut frame);
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    let history = History::new();
 
     // Scroll somewhere first, or the assertion below cannot tell a preserved
     // position from a reset one: they are both (0, 0) at the top of the diff.
@@ -370,6 +422,7 @@ fn a_screen_with_no_room_for_a_body_still_resolves() {
         &mut app,
         &mut frame,
         &mut highlighter,
+        &history,
         Action::Scroll((SPAN * 7 + 2) as isize),
     );
     assert_eq!(
@@ -380,7 +433,7 @@ fn a_screen_with_no_room_for_a_body_still_resolves() {
 
     for height in [0, 1] {
         let view = app
-            .view(&mut frame, &mut highlighter, height)
+            .view(&mut frame, &mut highlighter, &history, height)
             .expect("view");
         assert_eq!(view.rows.len(), height);
         assert_eq!(view.files, FILES);
@@ -398,7 +451,7 @@ fn a_screen_with_no_room_for_a_body_still_resolves() {
     // And the position survives being dragged short and back, which is the whole
     // sequence a reader actually performs.
     let view = app
-        .view(&mut frame, &mut highlighter, body())
+        .view(&mut frame, &mut highlighter, &history, body())
         .expect("view");
     assert_eq!(view.rows.len(), body());
     assert_eq!(

--- a/crates/vigia/tests/snapshots/render__the_glance_elements_at_eighty_columns.snap
+++ b/crates/vigia/tests/snapshots/render__the_glance_elements_at_eighty_columns.snap
@@ -1,0 +1,10 @@
+---
+source: crates/vigia/tests/render.rs
+assertion_line: 785
+expression: "screen(80, 5, &glancing(), &chrome())"
+---
+"vigia                                                                    3 files"
+"M src/engine/watch.rs                             ● just changed   ▁▂▆▄▆█ +42 -7"
+"M src/render/frame.rs                                               ▂▁    +11 -3"
+"M Cargo.toml                                                               +2 -0"
+"q quit · f follow · jk scroll                                                1/3"

--- a/crates/vigia/tests/snapshots/render__the_glance_elements_at_forty_columns.snap
+++ b/crates/vigia/tests/snapshots/render__the_glance_elements_at_forty_columns.snap
@@ -1,0 +1,10 @@
+---
+source: crates/vigia/tests/render.rs
+assertion_line: 790
+expression: "screen(40, 5, &glancing(), &chrome())"
+---
+"vigia                            3 files"
+"M …engine/watch.rs ● just changed +42 -7"
+"M src/render/frame.rs       ▂▁    +11 -3"
+"M Cargo.toml                       +2 -0"
+"q quit · f follow · jk scroll        1/3"

--- a/crates/vigia/tests/soak.rs
+++ b/crates/vigia/tests/soak.rs
@@ -41,7 +41,10 @@ use std::time::{Duration, Instant};
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use vigia::{Action, App, Row, Theme, View, body_height, render};
-use vigia_core::{FrameStats, HighlightStats, Highlighter, WatchOptions, Worktree};
+use vigia_core::{
+    FrameStats, HISTORY_PATHS, HISTORY_WINDOW, HighlightStats, Highlighter, History, HistoryStats,
+    WatchOptions, Worktree,
+};
 
 use support::{Scratch, generated};
 
@@ -287,6 +290,8 @@ struct Sample {
     tracked_diffs: usize,
     /// Hunk parses [`vigia_core::Highlighter`] is holding between frames.
     tracked_hunks: usize,
+    /// Paths [`vigia_core::History`] is holding, which is I10's own number.
+    tracked_history: usize,
     /// Changed files in the whole worktree at that moment.
     files: usize,
     /// Body height of the last frame drawn, which is what bounds the hunk
@@ -324,6 +329,7 @@ struct Report {
     closest_hunk_bound: Option<(usize, usize)>,
     frame: FrameStats,
     highlight: HighlightStats,
+    history: HistoryStats,
 }
 
 impl Report {
@@ -349,6 +355,14 @@ impl Report {
         self.samples
             .iter()
             .map(|s| s.tracked_hunks)
+            .max()
+            .unwrap_or(0)
+    }
+
+    fn max_tracked_history(&self) -> usize {
+        self.samples
+            .iter()
+            .map(|s| s.tracked_history)
             .max()
             .unwrap_or(0)
     }
@@ -395,6 +409,15 @@ impl Report {
             self.samples.iter().map(|s| s.body).max().unwrap_or(0),
             self.closest_hunk_bound,
             self.paths()
+        );
+        println!(
+            "soak: tracked history max {} of cap {}; recorded {}, evicted {} by \
+             cap and {} by window",
+            self.max_tracked_history(),
+            HISTORY_PATHS,
+            self.history.recorded,
+            self.history.evicted_by_cap,
+            self.history.evicted_by_window
         );
         println!(
             "soak: frame computed {}, reused {}, evicted {}, probes {}, {:.1} MiB read",
@@ -624,7 +647,7 @@ const NAME: &str = "soak";
 
 /// Run the soak and report what it did.
 fn soak(scratch: &Scratch, files: usize, lines: usize, window: Duration) -> Report {
-    let (tx, rx) = mpsc::channel::<Option<String>>();
+    let (tx, rx) = mpsc::channel::<Vec<String>>();
     let root = scratch.root().to_path_buf();
 
     // The product's own shape: the watcher owns its repository on its own
@@ -637,7 +660,7 @@ fn soak(scratch: &Scratch, files: usize, lines: usize, window: Duration) -> Repo
             .watch(WatchOptions::default())
             .expect("arm the watch");
         while let Some(tick) = watcher.next_tick() {
-            if tx.send(tick.newest).is_err() {
+            if tx.send(tick.paths).is_err() {
                 return;
             }
         }
@@ -660,7 +683,7 @@ fn drive(
     scratch: &Scratch,
     fixture_files: usize,
     window: Duration,
-    rx: &mpsc::Receiver<Option<String>>,
+    rx: &mpsc::Receiver<Vec<String>>,
     rounds: &AtomicU64,
     created: &AtomicU64,
 ) -> Report {
@@ -670,6 +693,10 @@ fn drive(
 
     let mut app = App::new();
     let mut highlighter = Highlighter::new();
+    // The third retained cache, and the one this run exists to bound now: it is
+    // the only one that deliberately outlives the diff, so a soak that left it
+    // out would be measuring I3 against two thirds of what the process keeps.
+    let mut history = History::new();
     let theme = Theme::default();
     let mut area = Rect::new(0, 0, AREAS[0].0, AREAS[0].1);
     let mut buffer = Buffer::empty(area);
@@ -695,6 +722,7 @@ fn drive(
                 fds: open_files(),
                 tracked_diffs: frame.tracked(),
                 tracked_hunks: highlighter.tracked(),
+                tracked_history: history.tracked(),
                 files: frame.files().len(),
                 body,
             });
@@ -710,15 +738,20 @@ fn drive(
                     "the watch thread ended after {frames} frames, so the rest of this window would measure a process with nothing to do"
                 )
             }
-            Ok(newest) => {
+            Ok(paths) => {
                 ticks += 1;
+                // Sampled on the wake, before the walk, exactly where
+                // `vigia::run` samples it. I10 is a claim about a store fed one
+                // tick at a time, so a soak feeding it any other way would bound
+                // something the product never builds.
+                history.record(paths.iter().map(String::as_str), Instant::now());
                 // Advance first, follow second: the path is looked up in the
                 // file list, and before the walk that list is the previous
                 // frame's. `vigia::run` says why.
                 match frame.advance() {
                     Ok(()) => {
-                        if let Some(path) = newest {
-                            app.follow(&path, &frame);
+                        if let Some(path) = paths.last() {
+                            app.follow(path, &frame);
                         }
                     }
                     Err(e) => {
@@ -746,7 +779,7 @@ fn drive(
 
         let chrome = app.chrome(NAME);
         body = body_height(area, &chrome, frame.files().len());
-        match app.view(&mut frame, &mut highlighter, body) {
+        match app.view(&mut frame, &mut highlighter, &history, body) {
             Ok(fresh) => {
                 view = fresh;
                 // Every hunk that put a line on this screen, which is exactly
@@ -793,6 +826,7 @@ fn drive(
         closest_hunk_bound,
         frame: frame.stats(),
         highlight: highlighter.stats(),
+        history: history.stats(),
     }
 }
 
@@ -882,9 +916,11 @@ impl Report {
             self.samples.len()
         );
 
-        // The two retained caches, each against the thing that is supposed to
+        // The three retained caches, each against the thing that is supposed to
         // bound it. `Frame` is bounded by the current diff; `Highlighter` is
-        // bounded by the screen, which is the stronger claim.
+        // bounded by the screen, which is the stronger claim; `History` is
+        // bounded by a fixed cap, which is I10 and is the only one of the three
+        // that has to keep holding a path *after* it has left the diff.
         for (at, sample) in self.samples.iter().enumerate() {
             assert!(
                 sample.tracked_diffs <= sample.files,
@@ -895,7 +931,17 @@ impl Report {
                 sample.tracked_diffs,
                 sample.files
             );
+            assert!(
+                sample.tracked_history <= HISTORY_PATHS,
+                "I10: sample {at} at {:?} tracked {} paths against a cap of \
+                 {HISTORY_PATHS}, so glance history is bounded by what the \
+                 session did rather than by anything fixed",
+                sample.at,
+                sample.tracked_history
+            );
         }
+
+        self.gate_history();
 
         let (held, bound) = self
             .closest_hunk_bound
@@ -968,6 +1014,55 @@ impl Report {
             "I3: descriptors went from {baseline} after warmup to {peak}, over \
              the {FD_HEADROOM} of headroom a transient open needs, so something \
              is holding handles open"
+        );
+    }
+
+    /// I10's eviction, which a short window cannot reach.
+    ///
+    /// The bound itself is asserted per sample in [`Report::gate`] and always
+    /// holds. **That assertion on its own is decorative**, and this is what
+    /// makes it mean something: a store nothing ever filled satisfies a cap the
+    /// way an empty room satisfies a fire code.
+    ///
+    /// Neither of I10's two eviction rules is reachable in a short run. The cap
+    /// is [`HISTORY_PATHS`] and the default window invents about eighty paths;
+    /// the time rule is [`vigia_core::HISTORY_WINDOW`] and the default window is
+    /// shorter than it. So this refuses to assert rather than passing on a
+    /// question it never asked, exactly as [`Report::gate_drift`] does and for
+    /// exactly the reason `SPEC.md` §7 gives about gates that cannot say no.
+    ///
+    /// The scheduled runs reach both comfortably: four hours at this rate is
+    /// tens of thousands of paths and a window turned over more than a hundred
+    /// times. And the *deterministic* proof of both rules is
+    /// `crates/vigia-core/tests/history.rs`, which drives ten thousand paths in
+    /// every `cargo test` rather than waiting for a long window to happen to
+    /// produce them. This gate is the one that says the same thing about the
+    /// real process.
+    fn gate_history(&self) {
+        let pressure = self.paths() > HISTORY_PATHS as u64;
+        let aged = self.window > HISTORY_WINDOW;
+        if !pressure && !aged {
+            println!(
+                "note: I10's eviction is not gated by a {:?} window: {} distinct \
+                 paths changed against a cap of {HISTORY_PATHS}, and the window \
+                 is under the {HISTORY_WINDOW:?} a path needs to age out. Run \
+                 with {SECS}={} to enforce it.",
+                self.window,
+                self.paths(),
+                HISTORY_WINDOW.as_secs() + 1
+            );
+            return;
+        }
+
+        assert!(
+            self.history.evicted_by_cap > 0 || self.history.evicted_by_window > 0,
+            "I10: {} path samples were recorded over {} distinct paths in a {:?} \
+             window and nothing was ever evicted, so the store grew with the \
+             session and the per-sample cap above held for a reason that is not \
+             the code",
+            self.history.recorded,
+            self.paths(),
+            self.window
         );
     }
 


### PR DESCRIPTION
Closes #38. Splits #10 first, which `ROADMAP.md` had blocked the phase on in writing.

`assets/preview.svg` promised a per-file churn sparkline, a recency gradient and a `● just changed` pulse. All three read from one thing that did not exist: history that survives a file settling. `SPEC.md` §5.2 named it as **proposed I10** and kept it out of the §3 table deliberately, because that table is for invariants with a failing test. It has one now.

## What the phase looked like once #10 was split

Four children along the seams §5.2 names rather than along what the elements look like: **#38** history-backed (this PR), **#39** whole-file-backed (heat strip), **#40** chrome (mode word, mode set, empty state), **#41** self-measuring (frame time and RSS readouts).

Two of #10's own rows turned out to be already done. Per-file `+42 −7` counters ship today and §5.1 has said "Covered" for them all along, because a file has to be diffed to be drawn. And `ROADMAP.md` listed the key-hint bar as "untracked entirely" when #7 landed it with I6. Both corrected.

§5.2's central claim held up: **this is not a rendering phase.** Most of this diff is `vigia-core`.

## I10

> Churn history is bounded by a fixed window and a fixed cap on tracked paths, independent of how many files the session changed. A path that ages out of the window is dropped entirely.

Budget: **256 paths, 120 seconds**, whatever the session changed. Structural, so it takes no slack.

`History` is a bounded per-path churn store with two eviction rules, both tested: by window, and by cap dropping the least recently changed path. Ten thousand distinct paths leave it sitting exactly at the cap.

## Three things this turned up that the spec did not predict

**The store had to be fed from the watch, not from the frame path.** A burst that saves twelve files has to record twelve, and `Tick` named only the last one because that is all follow mode ever needed. It now carries the whole set, capped at the same 256 so a bulk operation cannot make a tick expensive before the store gets a chance to bound it. The cap may never refuse the *newest* path: losing that loses follow mode's answer at the exact moment it had one. `Tick::newest` became a method over that list rather than a second field holding the same fact.

**The decay the mockup asks for is an I1 question, not a rendering one.** §5.1 draws the pulse as a label that persists and fades. A fade against a wall clock has to be *seen* fading, which needs a redraw nothing schedules, and inventing a timer to get one is exactly what I1 forbids. So the window stayed real time and the sampling became event-driven: the store advances once per coalesced tick, on the wake that was already going to redraw. The top rung is therefore *named by the newest tick* rather than *within N seconds*, which is also what keeps it honest on a quiet tree: the label sits on the file that really is the newest change instead of freezing a clock mid-count. The dimmed row and the label are one ladder read once, which §5.1 demanded and which two clocks would have broken.

**A bound is only evidence when something reached it.** The per-commit soak window touches about eighty distinct paths against a cap of 256 and never turns the 120-second window over, so a per-sample `tracked <= 256` is satisfied there by a store nothing ever filled. The soak now refuses to assert eviction in a window that reached neither rule and prints why, exactly as the drift gate does. `SPEC.md` §7 carries the rule.

## The screen

```
vigia                                                                    3 files
M src/engine/watch.rs                             ● just changed   ▁▂▆▄▆█ +42 -7
M src/render/frame.rs                                               ▂▁    +11 -3
M Cargo.toml                                                               +2 -0
q quit · f follow · jk scroll                                                1/3
```

Heights are scaled against the busiest bucket **on screen** rather than per row: a row scaled against its own maximum draws every file at full height the moment it is the busiest thing it has ever been, which destroys the one comparison a file list is for. A sparkline is a thing made of items, so under §11.1 it drops whole buckets rather than being squeezed, and nothing may take a heading below twelve columns of path.

At sixteen foreground-only colours the recency gradient is three steps rather than a fade. Same loss §11.1 already records for the diff signal narrowing to the sigil column, and the same issue fixes both: #11.

## Verification

Code diff, so the full suite ran rather than the docs carve-out. `Cargo.toml` untouched: no new dependency.

- `cargo test --workspace`: **211 passed, 0 failed**, up from 178 on `main`.
- `cargo test --workspace --release`: **211 passed, 0 failed**, so every absolute budget gate ran.
- I9 against its 16ms budget, release, on the 100-file 100k-line fixture: a real shell frame with highlighting **7.66ms p99** (p50 6.76, max 8.20); the same frame four screenfuls down **6.67ms p99**; a frame inside the settle margin after a bulk rewrite **6.90ms p99**. The core frame path is **6.96ms p99**, against the 6.97ms `SPEC.md` §10 records before any of this existed.
- `crates/vigia/tests/reads.rs` byte counts did not move, and a new gate says why they cannot: a fully populated store changes the frame's bytes, probes and recomputes by nothing at all, compared against the same frame drawn with an empty one.
- Soak, structural tier, in every `cargo test`. Driven at 300 files to prove the new gate can say yes: **256 tracked at the cap, 207 evicted by cap over 359 distinct paths.**
- `cargo bench --workspace --no-run`, `cargo fmt --all --check`, `cargo clippy --all-targets` with `-D warnings`: clean.
- **Mutation pass, seven mutants, all killed by a named test, no survivors.** Cap eviction disabled, window eviction disabled, the pulse rung disabled, a burst reduced to its newest path, the sparkline ladder set to drop one bucket at a time, per-row scaling instead of shared, and `MIN_PATH_WIDTH` set to zero.

**One mutant survived the first pass and that is the most useful thing in this PR.** Breaking window eviction left the whole suite green, because a gap of a whole window or more takes a shortcut that clears the store outright, and every gate jumped a full window to reach the aging case. The ordinary path, the one a monitor beside a working agent takes on every tick, was never run by anything. `a_path_ages_out_through_ordinary_ticks_and_not_only_through_one_long_gap` closes it, in its own commit.

## Plan fidelity

The plan is on #38, written before any code. Every promise delivered, with **one deviation, taken and justified at the time rather than at audit**: I10's budget gate lives in `crates/vigia-core/tests/history.rs` rather than in `tests/budgets.rs` as the plan said. Every gate in `budgets.rs` is a ratio between two fixtures or a duration, and I10's budget is a count whose fixture is ten thousand paths. `budgets.rs` carries a pointer so nobody concludes it is ungated, and §3's proof column names the file the way I6's row names `legibility.rs`.

Everything the plan put out of scope stayed out: #39, #40, #41, truecolour theming, a wall-clock decay, and §11.2's stale "these gate Phase 2" heading, which is real drift and belongs to #40 where B3 is ruled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
