### PR TITLE
I10: say why there is no separate expire, which the plan promised

### DIFF
--- a/crates/vigia-core/src/history.rs
+++ b/crates/vigia-core/src/history.rs
@@ -250,6 +250,15 @@ impl History {
     /// diff drawn, but nothing on disk moved, so the file the reader is watching
     /// keeps its label.
     ///
+    /// That is also **why there is no separate `expire`**, which the plan for
+    /// [#38](https://github.com/breferrari/vigia/issues/38) named as a second
+    /// public method. Aging the window is not a thing a caller ever wants on its
+    /// own: it happens on a tick or it does not happen, because a tick is the
+    /// only clock this type has (see the module docs on I1). A public `expire`
+    /// would have been exactly `record` with no paths, and two entry points into
+    /// one rule are two things a caller can get out of step. `vigia::run` calls
+    /// this once per wake and nothing else, which is the whole contract.
+    ///
     /// Called once per tick and never on a timer. See the module docs: the
     /// window is real time and the sampling is event-driven, which is what keeps
     /// I1 intact.


### PR DESCRIPTION
A plan-fidelity correction on top of #42, no behaviour change.

The plan on #38 sketched `History::expire(now)` as a second public method. The shipped type folds it into `record`, so an empty tick rolls the window and nothing else does. That is the right API, but it is a deviation from something written down and the code never named it: the reasoning was there, at the point where an empty tick is explained, without ever saying *why the method a reader is looking for does not exist*.

It says so now. Aging the window is not something a caller ever wants on its own, because a tick is the only clock this type has, and a public `expire` would have been exactly `record` with no paths: two entry points into one rule are two things a caller can get out of step.

Doc comment only. `cargo test -p vigia-core --lib` 53 passed, `cargo fmt --all --check` and `cargo clippy --all-targets` with `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)