### PR TITLE
process: the leak rule gets its hook, and the capture step gets a fallback

### DIFF
--- a/.claude/scripts/leak-guard.mjs
+++ b/.claude/scripts/leak-guard.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// PreToolUse guard: block a `gh pr|issue|release create|edit|comment` whose body
+// carries an agent-session artifact, before it reaches a PUBLIC repo. The rule
+// this enforces already lived in CLAUDE.md; this is the part that does not
+// depend on a session remembering it. Exit 2 blocks the call; anything the
+// guard cannot parse or read fails OPEN (exit 0) — a guard must never block
+// work by breaking.
+//
+// Classes checked (each is a class of artifact, not one incident):
+//   - claude.ai session URLs and Claude-Session: trailers
+//   - local absolute paths (machine layout + username)
+//   - a --body-file whose newlines were destroyed (PowerShell array-join
+//     flattening: one giant line where a document should be)
+
+import { readFileSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+const PATTERNS = [
+	["agent session URL", /claude\.ai\/code\/session[_/][A-Za-z0-9_-]+/i],
+	["Claude-Session trailer", /^\s*Claude-Session:/im],
+	["local absolute path", /(?:^|[\s"'=])[A-Za-z]:\\(?:Users|Dev)\\[^\s"']+/],
+];
+
+let input = "";
+try {
+	input = readFileSync(0, "utf8");
+} catch {
+	process.exit(0);
+}
+
+let command = "";
+try {
+	command = JSON.parse(input)?.tool_input?.command ?? "";
+} catch {
+	process.exit(0);
+}
+if (typeof command !== "string" || !/\bgh\s+(pr|issue|release)\s+(create|edit|comment)\b/.test(command)) {
+	process.exit(0);
+}
+
+const block = (what, hits) => {
+	console.error(
+		`BLOCKED: ${what} is not safe to publish from this PUBLIC repo.\n` +
+			hits.map((h) => `  - ${h}`).join("\n") +
+			`\nFix the content, then re-run. (House rule #1 in CLAUDE.md; this hook is its enforcement.)`,
+	);
+	process.exit(2);
+};
+
+const inlineHits = PATTERNS.filter(([, re]) => re.test(command)).map(([label]) => label);
+if (inlineHits.length > 0) block("this command's inline body", inlineHits);
+
+const m = /--body-file[= ]\s*(?:"([^"]+)"|'([^']+)'|(\S+))/.exec(command);
+if (!m) process.exit(0);
+const bodyFile = m[1] ?? m[2] ?? m[3];
+
+let body = "";
+try {
+	const path = isAbsolute(bodyFile) ? bodyFile : resolve(process.env.CLAUDE_PROJECT_DIR ?? process.cwd(), bodyFile);
+	body = readFileSync(path, "utf8");
+} catch {
+	process.exit(0);
+}
+
+const hits = PATTERNS.filter(([, re]) => re.test(body)).map(([label]) => label);
+if (body.length > 300 && !body.trim().includes("\n")) {
+	hits.push("flattened body: one line where a document should be (PowerShell array-join; use [System.IO.File]::WriteAllText with a `n join)");
+}
+if (hits.length > 0) block(bodyFile, hits);
+process.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+	"hooks": {
+		"PreToolUse": [
+			{
+				"matcher": "Bash",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/scripts/leak-guard.mjs\""
+					}
+				]
+			}
+		]
+	}
+}

--- a/.claude/skills/take-next/SKILL.md
+++ b/.claude/skills/take-next/SKILL.md
@@ -209,7 +209,7 @@ search   the decision you are about to touch
 recall   accumulated constraints — empty early, and empty is not evidence of none
 ```
 
-**Consulting the vault is deliberate, not reflexive.** Reaching for it when the answer is in `SPEC.md` wastes a call; reaching for it out of habit while writing a *public* commit message loads strategic context that must never land in one. That direction is the one with a hook guarding it, because a squash commit merged to a public `main` stays reachable by SHA forever. Know which of the three you are asking for before you ask.
+**Consulting the vault is deliberate, not reflexive.** Reaching for it when the answer is in `SPEC.md` wastes a call; reaching for it out of habit while writing a *public* commit message loads strategic context that must never land in one. This repo's own PreToolUse hook (`.claude/scripts/leak-guard.mjs`) blocks a `gh` publish whose body carries a session artifact, but **commit messages have no automatic guard here** — that discipline is yours, and a squash commit merged to a public `main` stays reachable by SHA forever. Know which of the three you are asking for before you ask.
 
 ## 3. Plan it, in plan mode, before touching code
 
@@ -458,6 +458,17 @@ Skipping any of these is how the next session loses time.
 4. **The vault**, through the MCP:
    - `record_work` for what happened here: changes, decisions, what was learned, what is still open, how it was verified.
    - `remember` for anything that would help someone on a **different** project. A `gix` limitation that would bite any Rust project is a `remember`. "Landed the watch engine" is a `record_work`. Both, when both are true.
+
+   **This is the loop's least reliable step, so it carries a fallback and a check.**
+   The write guard has refused a legitimate record nine calls running (the #15
+   record was filed by hand), and one record returned success while writing its
+   sections into the note as raw tool markup, which sat corrupted for two days.
+   So: if `record_work` refuses or errors after a couple of honest rephrasings,
+   **file the note by hand** in the vault (`projects/vigia/notes/`, matching the
+   dated-note shape) and say so in the report — the record is the requirement,
+   the tool is only the route. And after any success, **read the note back**
+   (`search` for it) and confirm the sections landed as markdown; a success
+   return is not evidence of a clean write.
 
 ## 9. Report
 


### PR DESCRIPTION
## What

House rule #1 (no agent-session artifacts in anything that lands in this repo) finally gets enforcement that lives where the risk does: a `PreToolUse` hook that inspects every `gh pr|issue|release create|edit|comment` and blocks the call when the body carries a session URL, a `Claude-Session:` trailer, a local absolute path, or a body flattened to a single line.

Also, `take-next` step 8 gains the fallback the capture step was missing: when the vault's `record_work` refuses a legitimate record, file the note by hand and say so in the report — and after any success, read the note back, because one record returned success while writing its sections as raw markup.

## Why now

The rule existed only as prose here, while the sole enforcing hook lived in a different working directory — so a session working from this checkout was unguarded exactly where the repo is public. `take-next` even asserted "that direction is the one with a hook guarding it", which was not true from this cwd; the sentence is rewritten to say precisely what is and is not covered (commit messages remain unguarded — that discipline stays manual).

## Verification

- Guard red-tested on all four artifact classes (session URL, trailer, absolute path, flattened body): each blocks with exit 2 and a named reason.
- Clean body, non-`gh` commands, and unparseable stdin all pass through (fail-open by design — a guard must never block work by breaking).
- `sh .claude/skills/take-next/selftest.sh`: all 18 checks pass, including the SKILL.md drift assertions.

Docs + tooling only; no Rust code touched, so the suite and budget gates did not run (the repo's own docs-diff carve-out, logged here per step 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
