### PR TITLE
The release checks its tokens before it moves the version

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -74,6 +74,57 @@ jobs:
         env:
           DEFAULT: ${{ github.event.repository.default_branch }}
 
+      # **Both tokens, checked here, before the version moves.**
+      #
+      # v0.1.0 is why this step exists. `HOMEBREW_TAP_TOKEN` could read the tap
+      # and not write to it, and nothing found out until the release was already
+      # public: the formula job checked out the tap successfully and then failed
+      # `git push` with a 403. Everything else had shipped by then, including the
+      # irreversible half.
+      #
+      # **A read-only token passes a checkout**, which is the whole trap, so the
+      # assertion is `push` specifically rather than that the token works at all.
+      # Reading a *public* repository needs no grant, so a token scoped to
+      # entirely the wrong repository still reads this one successfully.
+      #
+      # The registry token is only checked for presence, which is all that can be
+      # checked without spending a publish. `publish-crates-io.yml` checks the
+      # same thing again at its own start, and that is not redundant: this job
+      # can be skipped, and that one is the last line before the permanent step.
+      - name: the tokens can do what the release will ask of them
+        run: |
+          set -euo pipefail
+          if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            echo "::error::CARGO_REGISTRY_TOKEN is not set; the release would build everything and never claim the version"
+            exit 1
+          fi
+          if [ -z "${HOMEBREW_TAP_TOKEN:-}" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN is not set; the formula would never reach the tap"
+            exit 1
+          fi
+
+          # The tap's name comes from the release config rather than a copy here,
+          # on the same rule as the no-C-toolchain job's target list.
+          tap=$(cargo metadata --no-deps --format-version 1 | jq -r '.metadata.dist.tap')
+          if [ -z "$tap" ] || [ "$tap" = "null" ]; then
+            echo "::error::[workspace.metadata.dist] names no tap, but the homebrew publisher is enabled"
+            exit 1
+          fi
+
+          push=$(curl -sS -H "Authorization: Bearer ${HOMEBREW_TAP_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${tap}" | jq -r '.permissions.push // false')
+          if [ "$push" != "true" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN cannot push to ${tap} (permissions.push=${push})."
+            echo "::error::It may still be able to read it, which is what let this reach a release once before."
+            echo "::error::Fine-grained token: Contents must be Read and write, and ${tap} must be in its repository list."
+            exit 1
+          fi
+          echo "::notice::both tokens present; ${tap} is writable"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
       - name: work out the next version
         id: version
         run: |

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -1161,6 +1161,51 @@ fn the_release_button_reaches_the_release() {
         "release.yml no longer compares the tag against `dry-run`, so the \
          rehearsal in bump.yml may now publish"
     );
+
+    // **Both tokens are checked before the version moves, and the tap one is
+    // checked for `push`.** This is v0.1.0's actual failure written down as a
+    // gate. `HOMEBREW_TAP_TOKEN` could read the tap and not write to it; the
+    // formula job checked the tap out successfully and then failed `git push`
+    // with a 403, by which point the GitHub release and the crates.io publish
+    // had both already happened.
+    //
+    // Asserting `permissions.push` rather than merely that a check exists is
+    // the point. A check that only proves the token *works* passes against a
+    // read-only one, because reading a public repository needs no grant at all,
+    // so a token scoped to entirely the wrong repository reads this one fine.
+    let preflight = commands
+        .iter()
+        .find(|command| command.contains(r#"-z "${CARGO_REGISTRY_TOKEN"#))
+        .expect(
+            "bump.yml must guard on the registry token being empty before it              bumps anything. Finding the *name* is not enough: it appears in              this step's own error message and in its `env:` block, so a              search for it passes against a check that has been disabled",
+        );
+    // Each assertion names a form only the *check* has, never one an error
+    // message or an `env:` entry also carries. Both of these were written the
+    // loose way first and both survived mutation: deleting the tap presence
+    // check left `HOMEBREW_TAP_TOKEN` in the curl and the env block, and
+    // replacing the jq path left `permissions.push` in the failure message.
+    // That is the fourth time in this file a mention has stood in for the thing.
+    assert!(
+        preflight.contains(r#"-z "${HOMEBREW_TAP_TOKEN"#),
+        "the pre-flight does not check the tap token is set, and that is the          one that failed a release: {preflight}"
+    );
+    assert!(
+        preflight.contains(".permissions.push"),
+        "the tap check must read `.permissions.push` from the API, not merely          mention it: a read-only token reads a public repo and then fails the          release. {preflight}"
+    );
+
+    // And it has to run before the commit, or it reports a problem the version
+    // has already moved past.
+    let checked_at = bump
+        .find(r#"-z "${CARGO_REGISTRY_TOKEN"#)
+        .expect("checked immediately above");
+    let committed_at = bump
+        .find("git commit")
+        .expect("bump.yml commits the version it raised");
+    assert!(
+        checked_at < committed_at,
+        "the token pre-flight runs after the commit, so a bad token would be          found only once main already carries the new version"
+    );
 }
 
 /// The tarball cargo would actually upload carries no tests.


### PR DESCRIPTION
Closes #137.

## The tap is fixed now

`Formula/vigia.rb` is [in the tap](https://github.com/breferrari/homebrew-tap/blob/main/Formula/vigia.rb), so **`brew install breferrari/tap/vigia` works**. Committed by hand from the release artifact rather than regenerated, with all three sha256 values verified against the published `.sha256` files first, and the musl archive confirmed fetchable (HTTP 200, byte count matching the release asset exactly).

## This PR is the other half

v0.1.0's Homebrew job was denied `403`. The tap token could read the tap and not write to it, and nothing found out until the release was already public: the job checked the tap out successfully, then failed `git push`.

`bump.yml` now checks both tokens **before it touches the version**, so a token problem costs a dispatch rather than a release.

The tap check asserts `.permissions.push`, not that the token works, and that distinction is the whole finding: **a read-only token passes a checkout.** Reading a public repository needs no grant at all, so a token scoped to entirely the wrong repository reads this one fine. That is exactly what let the problem reach a release.

The registry token is checked for presence only, which is all that can be checked without spending a publish. `publish-crates-io.yml` still checks it again at its own start, which is not redundant: this job can be skipped, and that one is the last line before the permanent step.

## The gate took four attempts, and all four failures were the same mistake

A mention standing in for the thing, which this file has now done four times:

1. Matched the tap token's **name**, which survives in the curl and the `env:` block.
2. Matched `permissions.push`, which survives in the failure **message**.
3. Found `CARGO_REGISTRY_TOKEN`, which survives in its own **error string**, so the registry check could be disabled with the gate green.

Every assertion now names a form only the check itself has: the `-z` guard on each token, and `.permissions.push` with its leading dot. Three mutations disabling each check individually are red.

Two mutations along the way **tested nothing**, and are named in the commit because a mutation that does not create the condition is not evidence: one put `git commit` in a comment, which `without_comments` correctly strips, and one renamed an `env:` key without moving anything.

## Verification

- `cargo test --workspace`: **552 passed**, 0 failed.
- fmt and clippy clean under `-D warnings`; `dist generate --check` clean.
- `bump.yml` parses as YAML, 12 steps.
- Rules-bite: registry check disabled, tap check disabled, push assertion weakened to something that always answers. All three red.
