### PR TITLE
The token guard attempts a write, because the one it replaced did not

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -111,16 +111,46 @@ jobs:
             exit 1
           fi
 
-          push=$(curl -sS -H "Authorization: Bearer ${HOMEBREW_TAP_TOKEN}" \
+          # **A real write, then undo it.** `.permissions.push` was the first
+          # spelling and it is a proxy that does not predict the thing: it
+          # reported `true` for the very token whose `git push` had been denied
+          # 403 during v0.1.0, because for a fine-grained token that field
+          # reflects the user's role on the repository rather than the grants on
+          # the token. A guard that passes for the token that already failed is
+          # not a guard, and shipping one is worse than shipping none.
+          #
+          # So this creates a branch in the tap and deletes it. It goes through
+          # the same auth path a formula commit does, so it asserts the
+          # capability itself rather than a report about it, and it leaves
+          # nothing behind. The tap holds no workflows, so a ref existing for a
+          # second triggers nothing.
+          head=$(curl -sS -H "Authorization: Bearer ${HOMEBREW_TAP_TOKEN}" \
+            "https://api.github.com/repos/${tap}/git/ref/heads/main" | jq -r '.object.sha // empty')
+          if [ -z "$head" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN cannot even read ${tap}"
+            exit 1
+          fi
+
+          probe="refs/heads/release-preflight-${GITHUB_RUN_ID}"
+          code=$(curl -sS -o probe.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer ${HOMEBREW_TAP_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${tap}" | jq -r '.permissions.push // false')
-          if [ "$push" != "true" ]; then
-            echo "::error::HOMEBREW_TAP_TOKEN cannot push to ${tap} (permissions.push=${push})."
-            echo "::error::It may still be able to read it, which is what let this reach a release once before."
+            "https://api.github.com/repos/${tap}/git/refs" \
+            -d "{\"ref\":\"${probe}\",\"sha\":\"${head}\"}")
+
+          if [ "$code" != "201" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN cannot write to ${tap}: HTTP ${code}"
+            echo "::error::$(jq -r '.message // empty' probe.json)"
+            echo "::error::It can read ${tap}, which proves nothing: reading a public repo needs no grant."
             echo "::error::Fine-grained token: Contents must be Read and write, and ${tap} must be in its repository list."
             exit 1
           fi
-          echo "::notice::both tokens present; ${tap} is writable"
+
+          curl -sS -o /dev/null -X DELETE \
+            -H "Authorization: Bearer ${HOMEBREW_TAP_TOKEN}" \
+            "https://api.github.com/repos/${tap}/git/${probe}" \
+            || echo "::warning::left ${probe} in ${tap}; harmless, delete at leisure"
+          echo "::notice::both tokens present; a real write to ${tap} succeeded and was undone"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -1189,9 +1189,24 @@ fn the_release_button_reaches_the_release() {
         preflight.contains(r#"-z "${HOMEBREW_TAP_TOKEN"#),
         "the pre-flight does not check the tap token is set, and that is the          one that failed a release: {preflight}"
     );
+    // **An actual write, not a report about one.** The first version read
+    // `.permissions.push` from the API, and that is a proxy which does not
+    // predict the thing: it answered `true` for the very token whose `git push`
+    // had been denied 403, because for a fine-grained token that field reflects
+    // the user's role on the repository rather than the token's grants. So the
+    // check creates a ref in the tap and deletes it, and this asserts that
+    // shape rather than any wording.
     assert!(
-        preflight.contains(".permissions.push"),
-        "the tap check must read `.permissions.push` from the API, not merely          mention it: a read-only token reads a public repo and then fails the          release. {preflight}"
+        preflight.contains("-X POST") && preflight.contains("/git/refs"),
+        "the tap check must attempt a real write. Reading the repository, or          reading a permissions field about it, both pass for a token that          cannot push: {preflight}"
+    );
+    assert!(
+        preflight.contains("-X DELETE"),
+        "the write probe must undo itself, or every rehearsal leaves a branch          in the tap: {preflight}"
+    );
+    assert!(
+        preflight.contains("201"),
+        "the probe must check the create actually succeeded; curl exits 0 on a          403 body: {preflight}"
     );
 
     // And it has to run before the commit, or it reports a problem the version


### PR DESCRIPTION
Follow-up to #139, which shipped a guard that does not guard.

## What happened

#139 added a pre-flight asserting `.permissions.push` on the tap before the version moves. I dispatched a rehearsal to watch it catch the real, still-unfixed token, and **it went green** — against the very token whose `git push` had been denied `403` during v0.1.0.

That is the only outcome that tells you a guard is not one, and it is worth naming plainly: I shipped a check, claimed in its PR that it asserted the right thing, and it did not.

## Why the proxy fails

For a fine-grained token, `permissions` on the repository response reflects **the user's role on the repository**, not the grants on the token. A repository owner therefore reads `push: true` whatever the token can actually do. Reading a permissions field *about* a write is not a write.

## What replaces it

The check creates a branch in the tap through the same auth path a formula commit uses, asserts the create returned `201`, and deletes it.

- It is the capability itself rather than a report about it.
- It leaves nothing behind, and the tap holds no workflows, so a ref existing for a second triggers nothing.
- The explicit `201` matters: `curl` exits 0 on a `403` body, so checking the exit code alone would repeat the same class of mistake one level down.

## Gate

Follows the mechanism, not the wording: a `POST` to `/git/refs`, the `201` check, and the `DELETE` that undoes it. Three mutations red — reverting to a read, dropping the status check, dropping the cleanup.

## What this still does not tell us

Whether v0.1.0's `403` was the token or something else. The next rehearsal answers that for real instead of me guessing: if the probe fails, the token needs fixing; if it passes, the 403 had another cause and #137 needs reopening with it. Either way the answer arrives before a release rather than during one.

## Verification

- `cargo test --workspace`: **552 passed**, 0 failed.
- fmt and clippy clean under `-D warnings`.
- `bump.yml` parses, 12 steps.
