### PR TITLE
The scrollbar's track and its buttons were invisible, at 1.24:1

### DIFF
--- a/crates/vigia/src/theme.rs
+++ b/crates/vigia/src/theme.rs
@@ -588,13 +588,44 @@ impl Theme {
             // does is that green already means addition two rows down, and a churn
             // sparkline is about *when*, not *what*.
             spark: rgb(0x39, 0xc5, 0xcf),
-            // One step above `heat_track`'s `#21262d`, for the field's own
-            // reason: a stroke needs more contrast than a block to read as the
-            // same weight, and `#21262d` on this background is a block colour.
-            spark_track: rgb(0x30, 0x36, 0x3d),
+            // **One step above `heat_track`, which is the rule this field always
+            // had and could not satisfy while the thing it was a step above was
+            // itself invisible.** A stroke needs more contrast than a block to
+            // read as the same weight: `_` is one line in a cell where `▄` is
+            // half of one. With `heat_track` at 2.96:1 this is 4.12:1, and it was
+            // `#30363d` at **1.55:1** until 2026-08-16, which is below even the
+            // block it was supposed to outrank.
+            //
+            // Found by the gate rather than by eye, which is the point of having
+            // one: nobody reported the sparkline, and an empty bucket is exactly
+            // the case `SPEC.md` §5.1 rules has to draw a track, so a launched
+            // worktree with no history behind it was drawing the blank column
+            // [#78](https://github.com/breferrari/vigia/issues/78) exists to remove.
+            spark_track: rgb(0x6e, 0x76, 0x81),
             bar: rgb(0x8b, 0x94, 0x9e),
-            bar_track: rgb(0x21, 0x26, 0x2d),
-            heat_track: rgb(0x21, 0x26, 0x2d),
+            // **`#57606a`, and it was `#21262d` until 2026-08-16, which was
+            // invisible.** Reported from use: the scrollbar's track and its step
+            // buttons could not be seen at all, and a button appeared only while
+            // it was pressed, because a press draws in `bar` above and everything
+            // else on that column drew in this.
+            //
+            // Measured rather than adjusted by eye: `#21262d` on `#0d1117` is
+            // **1.24:1**, where 1.0 is the background exactly. It was never a
+            // subtle colour, it was an absent one, and the same value made the
+            // empty heat bucket `SPEC.md` §5.1 promises a track for draw nothing.
+            //
+            // The earlier reading was that the value was right and the defect
+            // belonged to the sixteen-colour rung, because these were taken off
+            // `assets/preview.svg` where they do read. That is the picture-versus-
+            // cell-grid distinction §5.1 already draws: a 1.24:1 edge over many
+            // pixels of SVG is perceptible and the same ratio in one terminal cell
+            // is not. The mockup is not wrong; reading a cell colour off it is.
+            //
+            // `#57606a` is **2.96:1**, against the thumb's 6.15:1. Both visible,
+            // and the gap between them is what keeps the ruling one line up true:
+            // the track is context and the thumb is the reading.
+            bar_track: rgb(0x57, 0x60, 0x6a),
+            heat_track: rgb(0x57, 0x60, 0x6a),
             heat_added: rgb(0x3f, 0xb9, 0x50),
             heat_added_warm: rgb(0x56, 0xd3, 0x64),
             heat_added_hot: rgb(0x7e, 0xe7, 0x87),
@@ -685,11 +716,17 @@ impl Theme {
             // and not a second one: both move one step *towards* the foreground,
             // and on a light background that direction is down. `#d0d7de` is a
             // block colour on white and a stroke drawn in it is barely there.
-            spark_track: rgb(0xaf, 0xb8, 0xc1),
+            // One step above `heat_track` for the reason `Theme::dark`'s carries;
+            // `#afb8c1` was 2.01:1, under the block it is meant to outrank.
+            spark_track: rgb(0x7d, 0x85, 0x90),
             bar: rgb(0x59, 0x63, 0x6e),
-            bar_track: rgb(0xd0, 0xd7, 0xde),
+            // `#8c959f` at 3.04:1 on white, where `#d0d7de` was **1.45:1** and
+            // invisible for the same reason the dark palette's was. See the note
+            // on `Theme::dark`'s `bar_track`; the two were wrong together and are
+            // fixed together, and the gap below `bar`'s 6.11:1 matches.
+            bar_track: rgb(0x8c, 0x95, 0x9f),
             // Light enough to read as a track on white, dark enough to be visible.
-            heat_track: rgb(0xd0, 0xd7, 0xde),
+            heat_track: rgb(0x8c, 0x95, 0x9f),
             heat_added: rgb(0x4a, 0xc2, 0x6b),
             heat_added_warm: rgb(0x2d, 0xa4, 0x4e),
             heat_added_hot: rgb(0x11, 0x63, 0x29),

--- a/crates/vigia/tests/palette.rs
+++ b/crates/vigia/tests/palette.rs
@@ -1373,3 +1373,116 @@ fn the_ramp_collapses_to_two_stops_where_it_must_and_says_so_in_the_palette() {
     // so a hot slice is still distinguishable from a quiet one.
     assert_ne!(two[0], two[1]);
 }
+
+/// The reference background each truecolour palette is designed against.
+///
+/// **A terminal does not tell this program its background**, which is why the
+/// `ansi` palette exists and why `theme.rs` opens by saying a tint has to assume
+/// one. So this is an assumption, stated rather than smuggled: it is the
+/// background `assets/preview.svg` paints and the one each palette's greys were
+/// picked against. A colour that vanishes on the background it was designed for
+/// has no chance on any other.
+const DARK_PANE: (u8, u8, u8) = (0x0d, 0x11, 0x17);
+const LIGHT_PANE: (u8, u8, u8) = (0xff, 0xff, 0xff);
+
+/// WCAG relative luminance.
+fn luminance((r, g, b): (u8, u8, u8)) -> f64 {
+    fn channel(v: u8) -> f64 {
+        let v = f64::from(v) / 255.0;
+        if v <= 0.03928 {
+            v / 12.92
+        } else {
+            ((v + 0.055) / 1.055).powf(2.4)
+        }
+    }
+    0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+}
+
+/// WCAG contrast ratio: 1.0 for two identical colours, 21.0 for black on white.
+fn contrast(a: (u8, u8, u8), b: (u8, u8, u8)) -> f64 {
+    let (x, y) = (luminance(a), luminance(b));
+    (x.max(y) + 0.05) / (x.min(y) + 0.05)
+}
+
+/// The channels of a truecolour style's foreground.
+fn rgb_of(style: ratatui::style::Style) -> (u8, u8, u8) {
+    match style.fg.expect("a foreground") {
+        Color::Rgb(r, g, b) => (r, g, b),
+        other => panic!("expected a truecolour foreground, found {other:?}"),
+    }
+}
+
+/// The floor a mark meant to be *seen but subordinate* has to clear.
+///
+/// Well under WCAG's 4.5:1 for text, deliberately: none of these is text, and a
+/// track that competed with its own thumb would break the ruling that the track
+/// is context and the thumb is the reading. What it rules out is the case that
+/// actually shipped, which is not a subtle colour but an **absent** one.
+const TRACK_FLOOR: f64 = 2.0;
+
+#[test]
+fn a_track_is_visible_against_the_pane_it_is_drawn_on() {
+    // **Reported from use, and the numbers say why nothing was visible.** The
+    // scrollbar's track and its step buttons drew in `bar_track`, which was
+    // `#21262d` on `#0d1117`: **1.24:1**, where 1.0 is the background exactly.
+    // Only the thumb and a *pressed* button could be seen, because those draw in
+    // `bar` at 6.15:1. The light palette had the same defect at 1.45:1, and this
+    // gate then found a third nobody had reported: the sparkline's own track at
+    // 1.55:1, which is the empty bucket §5.1 rules must draw something.
+    //
+    // **The gate that existed could not see any of it.** The sparkline tests
+    // below assert a track is not the *same palette colour* as the background,
+    // which was true of every one of these while all three were invisible.
+    // Identity is not visibility, and the difference is this test.
+    //
+    // The earlier reading was that these truecolour values were right because
+    // they are read off `assets/preview.svg`, and that the defect belonged to
+    // the sixteen-colour rung. That is the picture-versus-cell-grid distinction
+    // `SPEC.md` §5.1 already draws: a 1.24:1 edge across many pixels of SVG is
+    // perceptible, and the same ratio inside one terminal cell is not.
+    for (name, theme, pane) in [
+        ("dark", Theme::dark().resolve(Depth::Truecolor), DARK_PANE),
+        (
+            "light",
+            Theme::light().resolve(Depth::Truecolor),
+            LIGHT_PANE,
+        ),
+    ] {
+        for (element, style) in [
+            ("bar_track", theme.bar_track),
+            ("heat_track", theme.heat_track),
+            ("spark_track", theme.spark_track),
+        ] {
+            let ratio = contrast(rgb_of(style), pane);
+            assert!(
+                ratio >= TRACK_FLOOR,
+                "{name}'s {element} is {ratio:.2}:1 against the pane it is drawn \
+                 on, under the {TRACK_FLOOR}:1 a mark needs to be seen at all. \
+                 1.00:1 is the background exactly"
+            );
+        }
+
+        // **And a stroke outranks a block**, which is the rule `spark_track`'s
+        // own docblock always stated and could not satisfy while the block it
+        // was a step above was itself invisible.
+        let stroke = contrast(rgb_of(theme.spark_track), pane);
+        let block = contrast(rgb_of(theme.heat_track), pane);
+        assert!(
+            stroke > block,
+            "{name}'s sparkline track is {stroke:.2}:1 against the heat track's \
+             {block:.2}:1, so the one-line glyph is dimmer than the half-block \
+             it has to read level with"
+        );
+
+        // **And still subordinate to what it is a track for.** A track that
+        // reached its own thumb would satisfy the floor above and destroy the
+        // reading it exists to support.
+        let thumb = contrast(rgb_of(theme.bar), pane);
+        let track = contrast(rgb_of(theme.bar_track), pane);
+        assert!(
+            thumb > track * 1.5,
+            "{name}'s thumb is {thumb:.2}:1 and its track {track:.2}:1, which is \
+             not enough separation for the thumb to read as the lit one"
+        );
+    }
+}


### PR DESCRIPTION
Reported from use: **the arrows cannot be seen unless clicked, and there is no visible line behind the thumb.**

Both symptoms are one cause, and it measures. The track and the step buttons draw in `bar_track`; the thumb and a *pressed* button draw in `bar`. `bar_track` was `#21262d` on `#0d1117`, which is **1.24:1**, where 1.00:1 is the background exactly. It was never a subtle colour, it was an absent one, and clicking made a button appear because that is the one state drawn in the other style.

## Three were wrong, and the third nobody had reported

| | before | after | |
|---|---|---|---|
| dark `bar_track` / `heat_track` | 1.24:1 | **2.96:1** | `#57606a` |
| dark `spark_track` | 1.55:1 | **4.12:1** | `#6e7681` |
| light `bar_track` / `heat_track` | 1.45:1 | **3.04:1** | `#8c959f` |
| light `spark_track` | 2.01:1 | **3.73:1** | `#7d8590` |

`heat_track` carried the same value as `bar_track`, so the empty heat bucket `SPEC.md` §5.1 rules *must* draw a track was drawing nothing either. And `spark_track`'s own docblock has always said it sits one step above `heat_track`, because a stroke needs more contrast than a block to read at the same weight. It could not, while the block it outranked was itself invisible. That one was found **by the new gate**, not by eye.

The light value is `#7d8590` rather than something darker so it still resolves to `Gray` at sixteen colours, leaving the arrangement two other tests document carefully untouched.

## Why it survived this long

The recorded reading was that these truecolour values were *right* because they are read off `assets/preview.svg`, and that the defect belonged to the sixteen-colour rung. That is the picture-versus-cell-grid distinction §5.1 already draws: a 1.24:1 edge across many pixels of SVG is perceptible, and the same ratio inside one terminal cell is not. The mockup is not wrong; reading a cell colour off it is.

## The gate that was missing

`a_track_is_visible_against_the_pane_it_is_drawn_on` computes WCAG contrast against the reference background each palette is designed for, stated as an assumption rather than smuggled, since a terminal never reports its background.

The sparkline tests beside it assert a track is not the *same palette colour* as the background. That stayed true of all three colours while all three were invisible. **Identity is not visibility**, and that gap is the whole reason this shipped.

It also asserts a stroke outranks a block, and that the thumb keeps clear separation above its own track, so the ruling that the track is context and the thumb is the reading survives the change rather than being traded for legibility.

604 tests, clippy and fmt clean.