### PR TITLE
CLAUDE.md carries how to release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,20 @@ So, when a reader asks for something:
 
 Refusals deserve more scrutiny than builds, not less: a bad build is loud and a bad refusal is silent, so the mistake that survives longest here is the one no gate can see.
 
+## Releasing
+
+**Dispatch the `bump and release` workflow.** That is the whole procedure:
+
+```sh
+gh workflow run "bump and release" -f bump=<patch|minor|major> -f rehearse=false
+```
+
+It raises the version, commits it to `main`, builds the four target artifacts, creates the GitHub release, publishes the Homebrew formula, and runs `cargo publish --workspace`. Nothing else starts a release: `git tag && git push --tags` was removed as a trigger, and a tag pushed by a workflow cannot fire another one anyway.
+
+Pick the level from the diff. On `0.x` a new feature **and** a breaking public API change both go in the **minor**; `patch` is for fixes that change no signature. `rehearse=true` runs the whole path and publishes nothing, which is the way to check a change to the release machinery itself.
+
+**`RELEASE-SMOKE.md` is not this procedure and reading it as one wastes a session.** It is a human pre-flight against a built artifact: most of its boxes need a person at a terminal on three platforms, killing the process from another pane and looking at what the terminal does next. An agent cannot tick them. It is worth reading before a release that changes packaging, installation or the takeover; it is not a gate to clear before every dispatch, and it is not where the release is performed.
+
 ## House rules
 
 - **No agent-session artifacts in anything that lands in the repo.** No `claude.ai/code/session_*` URL, no `Claude-Session:` trailer, no local absolute path — not in commit messages, PR or issue bodies, or files. `Co-Authored-By:` is fine and wanted.

--- a/RELEASE-SMOKE.md
+++ b/RELEASE-SMOKE.md
@@ -1,5 +1,17 @@
 # Release smoke — run against the built artifact, before the release is dispatched
 
+> [!IMPORTANT]
+> **This is not how a release is performed.** The release is one command, and it
+> lives in `CLAUDE.md`: dispatch the `bump and release` workflow. This file is
+> the **human pre-flight** that goes with it, and most of its boxes need a person
+> at a terminal on three platforms, killing the process from another pane and
+> watching what the terminal does next. Nothing here can be ticked by an agent.
+>
+> Read it before a release that changes packaging, installation or the terminal
+> takeover. It is not a gate to clear before every dispatch, and treating it as
+> the procedure has cost a session: it is the only release-shaped document in the
+> repository root, so it is what a reader finds first.
+
 CI green is necessary and not sufficient. A sibling project shipped two
 consecutive patches with a green matrix that broke the flagship install on day
 one, and its fix was this checklist's ancestor.


### PR DESCRIPTION
Asked to cut a release, a session goes to `RELEASE-SMOKE.md`: it is the only release-shaped document in the repository root, and its own text says its sections run "before the dispatch". So it reads as the procedure.

It is not. It is a **human pre-flight**. Most of its boxes need a person at a terminal on three platforms, killing the process from another pane and watching what the terminal does next. An agent cannot tick them, and reading it as a gate before every dispatch has cost a session.

## The fix is routing, in the file that gets read

`CLAUDE.md` loads every session; a document in the root is read only when someone opens it. So it now carries the release **routing**, not the content:

- the one command, `gh workflow run "bump and release" -f bump=<level>`
- how to pick the level: on `0.x` a new feature **and** a breaking public API change both go in the **minor**
- `rehearse=true` for checking the release machinery itself
- and a blunt line that `RELEASE-SMOKE.md` is not the procedure

## It is not deletable, and that is worth recording

The obvious next thought is to remove it. Three things break:

- `package.rs::the_spec_names_every_test_that_escapes_the_package` asserts its content, as one of three documents that must state the same count.
- `the_packaged_artifact_carries_no_tests` names it as the fallback when the registry index is unreachable, so the skip would cover nothing.
- `SPEC.md` §9 names it as what runs against `dist build` output before the tag.

And what it covers is genuinely outside CI: a real terminal after an external kill, an install on three platforms, no mouse-report residue when the pointer moves afterwards.

It keeps everything it had, and gains a callout saying what it is not so it cannot mislead from its own side either.

Docs only.