### PR TITLE
The diff's scrollbar was painted under the row washes

### DIFF
--- a/assets/preview.svg
+++ b/assets/preview.svg
@@ -189,13 +189,6 @@
     </g>
     <circle cx="862" cy="197" r="4" fill="#39c5cf"/>
 
-    <!-- diff scrollbar: file-granular plus the fraction within the current
-         file, which is all SPEC.md 11.1 lets it know without reading every
-         file's height. The pinned list above has no bar because all three of
-         its rows are on screen. -->
-    <rect x="872" y="190" width="6" height="250" rx="3" fill="#21262d"/>
-    <rect x="872" y="190" width="6" height="82" rx="3" fill="#8b949e"/>
-
     <!-- diff -->
     <!-- Indentation is carried by explicit x offsets, never by leading spaces:
          xml:space="preserve" is honoured inconsistently and leading whitespace
@@ -241,6 +234,25 @@
       <text class="m faint" x="60" y="420" text-anchor="end">45</text>
       <text class="m fg" x="88" y="420">}</text>
     </g>
+
+    <!-- diff scrollbar: file-granular plus the fraction within the current
+         file, which is all SPEC.md 11.1 lets it know without reading every
+         file's height. The pinned list above has no bar because all three of
+         its rows are on screen.
+
+         **Drawn after the diff, and that is load bearing rather than tidy.**
+         SVG paints in document order, and a row wash spans x=8 width=884, which
+         reaches x=892 and therefore covers this bar's x=872..878. Sitting where
+         it used to, above the diff group, the washes buried it: the track showed
+         on context rows and vanished on every added and removed one, so the bar
+         read as dashes rather than as a column. Reported from the picture.
+
+         A terminal cannot express the same mistake, because a cell holds one
+         thing: the shell draws the bar and then hands the *narrowed* rect to the
+         content. What it can express is the wash reaching into the bar's columns
+         and overwriting cells already drawn, which is what #214 is open about. -->
+    <rect x="872" y="190" width="6" height="250" rx="3" fill="#21262d"/>
+    <rect x="872" y="190" width="6" height="82" rx="3" fill="#8b949e"/>
 
     <!-- status bar -->
     <rect x="8" y="432" width="884" height="30" fill="#161b22"/>


### PR DESCRIPTION
Reported from the picture: the scrollbar beside the diff is buried by the row washes and reads as a dashed line rather than a column.

## The cause

SVG paints in document order. A row wash spans `x=8 width=884`, which reaches `x=892` and therefore covers the bar's `x=872..878`. The bar was drawn **before** the diff group, so every added and removed row painted over it. The track survived only on the context rows, which is why it looked dashed rather than absent.

Moved after the diff group so it paints last, with a comment saying why the order is load bearing. Nothing else would say so: the file parses and renders either way, and the defect only shows on rows that happen to carry a wash.

## Where it transfers, and where it does not

A terminal **cannot** make this mistake. A cell holds one thing, and `Painter::with_bar` hands the content a rect the bar's columns are already outside of.

What a terminal **can** do is let a wash reach into those columns and overwrite cells that were already drawn, which is exactly what [#214](https://github.com/breferrari/vigia/issues/214) is open about and still undiagnosed. Same boundary, two artifacts, two different mechanisms. The picture now states the intent that #214 has to be settled against: the bar is on top.

## Scope

`assets/preview.svg` alone, verified with `git diff --name-only`. No code, no test, no manifest, so the suite and the budget gates are not run. The one check that applies is that the file still parses, and it does.