### PR TITLE
Track the gestures sheet's space defect (#220)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -450,6 +450,7 @@ Milestone: [Phase 8](https://github.com/breferrari/vigia/milestone/8)
 | ✅ | decision: the keymap outgrew the hint bar, so does it get an overlay | [#167](https://github.com/breferrari/vigia/issues/167) |
 | ✅ | Build B12: `?` toggles a centred gestures sheet over the pane | [#206](https://github.com/breferrari/vigia/issues/206) |
 | ✅ | The sheet keeps the diff colours it covers, and its close control never brightens | [#211](https://github.com/breferrari/vigia/issues/211) |
+| ⬜ | The sheet is 56 by 19 whatever the pane is, and a short one drops thirteen gestures in silence | [#220](https://github.com/breferrari/vigia/issues/220) |
 | ✅ | Attribute a wall-clock overshoot with thread CPU time | [#212](https://github.com/breferrari/vigia/issues/212) |
 | ✅ | The status sigil sits two columns apart between the list and the diff's headings | [#173](https://github.com/breferrari/vigia/issues/173) |
 | ✅ | The header stands against the first list row, the one boundary drawn with nothing | [#174](https://github.com/breferrari/vigia/issues/174) |


### PR DESCRIPTION
Files [#220](https://github.com/breferrari/vigia/issues/220) into the Phase 8 table, beside the two sheet rows it follows from, so `take-next` step 1 and pre-flight comparison 7 can both see it.

Docs-only diff (`ROADMAP.md`, one row), so per step 5's carve-out no `cargo test`, no `cargo bench` and no budget gates were run. Nothing under `.github/`, no manifest and no lockfile is touched.

The issue itself carries the mocks and the constraints (B12 rules a box rather than a full-pane sheet, and `assets/preview.svg` stays untouched until this is ruled).