### PR TITLE
Track the churn band's sampling period (#223)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -451,6 +451,7 @@ Milestone: [Phase 8](https://github.com/breferrari/vigia/milestone/8)
 | ✅ | Build B12: `?` toggles a centred gestures sheet over the pane | [#206](https://github.com/breferrari/vigia/issues/206) |
 | ✅ | The sheet keeps the diff colours it covers, and its close control never brightens | [#211](https://github.com/breferrari/vigia/issues/211) |
 | ⬜ | The sheet is 56 by 19 whatever the pane is, and a short one drops thirteen gestures in silence | [#220](https://github.com/breferrari/vigia/issues/220) |
+| ⬜ | The churn band samples once a second, so a bursty worktree draws scatter | [#223](https://github.com/breferrari/vigia/issues/223) |
 | ✅ | Attribute a wall-clock overshoot with thread CPU time | [#212](https://github.com/breferrari/vigia/issues/212) |
 | ✅ | The status sigil sits two columns apart between the list and the diff's headings | [#173](https://github.com/breferrari/vigia/issues/173) |
 | ✅ | The header stands against the first list row, the one boundary drawn with nothing | [#174](https://github.com/breferrari/vigia/issues/174) |


### PR DESCRIPTION
Files [#223](https://github.com/breferrari/vigia/issues/223) into the Phase 8 table so `take-next` step 1 and pre-flight comparison 7 can both see it.

Reported from a live pane during the #159 pass. The issue carries the diagnosis: `HISTORY_WINDOW` is 120s over 120 samples and `Churn::projected` clamps the drawn width to the sample count, so at 120 columns or wider one column is one second, and an instantaneous save occupies exactly one of them. The per-file sparkline aggregates fifteen samples per bucket, which is the whole difference between the two elements.

Docs-only diff (`ROADMAP.md`, one row), so per step 5's carve-out no `cargo test`, no `cargo bench` and no budget gates were run. No manifest, lockfile or workflow is touched.