### PR TITLE
The churn band's heights get a gate (#225)

### DIFF
--- a/crates/vigia/tests/masthead.rs
+++ b/crates/vigia/tests/masthead.rs
@@ -74,6 +74,19 @@ fn drawn_ink(row: &str) -> usize {
     row.chars().filter(|glyph| !glyph.is_whitespace()).count()
 }
 
+/// Blank columns before a drawn row's first glyph, which is the pane's inset.
+///
+/// **Named because two gates recover it and one of them had hand-ported the
+/// other.** What counts as blank is one definition, and a copy adapted from
+/// `&str` to `&[char]` is the surface it drifts across: change it in the gate
+/// that reads the band's left edge and the gate that locates a column by index
+/// keeps the old answer, reading the wrong cell without failing.
+fn drawn_inset(row: &str) -> usize {
+    row.chars()
+        .take_while(|glyph| glyph.is_whitespace())
+        .count()
+}
+
 /// Changed files in every fixture here, which is what `assets/preview.svg` draws.
 const FILES: usize = 3;
 
@@ -397,11 +410,7 @@ fn the_band_reaches_both_edges_of_its_slot() {
         // precisely where the scrollbar's reserve begins. Counted in `char`s on
         // both sides, since a byte length would disagree the moment a glyph is
         // not ASCII.
-        let last = rows.last().expect("a band row");
-        let inset = last
-            .chars()
-            .take_while(|glyph| glyph.is_whitespace())
-            .count();
+        let inset = drawn_inset(rows.last().expect("a band row"));
         assert_eq!(
             widest,
             usize::from(width) - BAR_COLUMNS,
@@ -418,18 +427,28 @@ fn the_band_reaches_both_edges_of_its_slot() {
 /// and flattening the stack changes nothing, so it passed against the very
 /// mutation it was written for.
 ///
-/// `Churn::projected` maps column `c` onto samples `[c * 8, (c + 1) * 8)` at
-/// [`GRAPH_COLUMNS`], so one sample per column is enough to set that column's
-/// total: the first is the peak and the second is a **quarter** of it.
+/// `Churn::projected` maps a column onto its own share of the samples, so one
+/// sample per column is enough to set that column's total: the first is the peak
+/// and the second is a **quarter** of it. The index is that share rather than the
+/// eight it happens to be, since a change to either constant would otherwise
+/// slide the quarter into a neighbouring column and leave the fixture reading a
+/// bar it was not written for.
 const QUARTERED: [u32; HISTORY_SAMPLES] = {
     let mut s = [0; HISTORY_SAMPLES];
     s[0] = 16;
-    s[8] = 4;
+    s[HISTORY_SAMPLES / GRAPH_COLUMNS] = 4;
     s
 };
 
 /// The eighth-block ramp, restated for [`GRAPH_COLUMNS`]'s reason.
 const RAMP: [char; 8] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+
+/// Rows of churn the band draws, restated for [`GRAPH_COLUMNS`]'s reason.
+///
+/// Load bearing in the gate below rather than incidental: two rows of an
+/// eight-rung ramp is a sixteen-level scale, which is what makes a quarter of the
+/// peak land on the ramp's fourth rung exactly.
+const GRAPH_ROWS: usize = 2;
 
 #[test]
 fn the_band_stacks_its_rows_from_the_bottom() {
@@ -439,7 +458,11 @@ fn the_band_stacks_its_rows_from_the_bottom() {
     // pane could stack arbitrarily and only an eye would catch it. Three
     // mutations survived the whole suite on that.
     let rows = band_strip(WIDE, QUARTERED);
-    assert_eq!(rows.len(), 2, "the band drew {} rows, not two", rows.len());
+    // The precondition the rungs below are derived from, asserted rather than
+    // assumed: a third row would make a quarter of the peak level six of
+    // twenty-four and every expected glyph here wrong.
+    assert_eq!(rows.len(), GRAPH_ROWS, "the band drew the wrong row count");
+    let strip = rows.join("\n");
     // `band` draws bottom up, so `row` counts from the baseline while the buffer
     // counts down from the top: the last string is the baseline.
     let upper: Vec<char> = rows[0].chars().collect();
@@ -448,27 +471,17 @@ fn the_band_stacks_its_rows_from_the_bottom() {
     // Derived from the drawn row rather than restated, the way
     // `the_band_reaches_both_edges_of_its_slot` already derives it: the band
     // runs from the pane's inset to where the scrollbar's reserve begins.
-    let inset = base
-        .iter()
-        .take_while(|glyph| glyph.is_whitespace())
-        .count();
-    let span = usize::from(WIDE) - BAR_COLUMNS - inset;
-    let at = |column: usize| inset + column * span / GRAPH_COLUMNS;
+    let span = usize::from(WIDE) - BAR_COLUMNS - drawn_inset(&rows[1]);
+    let at = |column: usize| drawn_inset(&rows[1]) + column * span / GRAPH_COLUMNS;
 
     // The peak column fills both rows, which is what makes the assertions below
     // about the quarter column mean something: a band that drew nothing at all
-    // would satisfy "the row above is blank" on its own.
+    // would satisfy "the row above is blank" on its own. Compared as a pair so a
+    // failure prints both halves rather than stopping at the first.
     assert_eq!(
-        base[at(0)],
-        RAMP[7],
-        "the tallest column did not reach the ramp's top on the baseline:\n{}",
-        rows.join("\n")
-    );
-    assert_eq!(
-        upper[at(0)],
-        RAMP[7],
-        "the tallest column did not fill the row above the baseline:\n{}",
-        rows.join("\n")
+        (base[at(0)], upper[at(0)]),
+        (RAMP[7], RAMP[7]),
+        "the tallest column did not fill both rows:\n{strip}"
     );
 
     // A quarter of the peak over two rows of an eight-rung ramp is level four of
@@ -479,12 +492,10 @@ fn the_band_stacks_its_rows_from_the_bottom() {
     assert_eq!(
         base[at(1)],
         RAMP[3],
-        "a column at a quarter of the peak drew the wrong rung:\n{}",
-        rows.join("\n")
+        "a column at a quarter of the peak drew the wrong rung:\n{strip}"
     );
     assert!(
         upper[at(1)].is_whitespace(),
-        "a column at a quarter of the peak spilled into the row above it:\n{}",
-        rows.join("\n")
+        "a column at a quarter of the peak spilled into the row above it:\n{strip}"
     );
 }

--- a/crates/vigia/tests/masthead.rs
+++ b/crates/vigia/tests/masthead.rs
@@ -409,3 +409,82 @@ fn the_band_reaches_both_edges_of_its_slot() {
         );
     }
 }
+
+/// Two columns of known height against one peak, which is what #225 needed.
+///
+/// **Mixed rather than uniform, and that is the whole point of the fixture.**
+/// The gate withdrawn during [#159](https://github.com/breferrari/vigia/issues/159)
+/// used a series that was full everywhere, where every row sits at its ceiling
+/// and flattening the stack changes nothing, so it passed against the very
+/// mutation it was written for.
+///
+/// `Churn::projected` maps column `c` onto samples `[c * 8, (c + 1) * 8)` at
+/// [`GRAPH_COLUMNS`], so one sample per column is enough to set that column's
+/// total: the first is the peak and the second is a **quarter** of it.
+const QUARTERED: [u32; HISTORY_SAMPLES] = {
+    let mut s = [0; HISTORY_SAMPLES];
+    s[0] = 16;
+    s[8] = 4;
+    s
+};
+
+/// The eighth-block ramp, restated for [`GRAPH_COLUMNS`]'s reason.
+const RAMP: [char; 8] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+
+#[test]
+fn the_band_stacks_its_rows_from_the_bottom() {
+    // **[#225](https://github.com/breferrari/vigia/issues/225).** Every other
+    // band gate reads presence, row count, run count or blankness, and none of
+    // them reads what a drawn column's glyph *is*, so the hero element of the
+    // pane could stack arbitrarily and only an eye would catch it. Three
+    // mutations survived the whole suite on that.
+    let rows = band_strip(WIDE, QUARTERED);
+    assert_eq!(rows.len(), 2, "the band drew {} rows, not two", rows.len());
+    // `band` draws bottom up, so `row` counts from the baseline while the buffer
+    // counts down from the top: the last string is the baseline.
+    let upper: Vec<char> = rows[0].chars().collect();
+    let base: Vec<char> = rows[1].chars().collect();
+
+    // Derived from the drawn row rather than restated, the way
+    // `the_band_reaches_both_edges_of_its_slot` already derives it: the band
+    // runs from the pane's inset to where the scrollbar's reserve begins.
+    let inset = base
+        .iter()
+        .take_while(|glyph| glyph.is_whitespace())
+        .count();
+    let span = usize::from(WIDE) - BAR_COLUMNS - inset;
+    let at = |column: usize| inset + column * span / GRAPH_COLUMNS;
+
+    // The peak column fills both rows, which is what makes the assertions below
+    // about the quarter column mean something: a band that drew nothing at all
+    // would satisfy "the row above is blank" on its own.
+    assert_eq!(
+        base[at(0)],
+        RAMP[7],
+        "the tallest column did not reach the ramp's top on the baseline:\n{}",
+        rows.join("\n")
+    );
+    assert_eq!(
+        upper[at(0)],
+        RAMP[7],
+        "the tallest column did not fill the row above the baseline:\n{}",
+        rows.join("\n")
+    );
+
+    // A quarter of the peak over two rows of an eight-rung ramp is level four of
+    // sixteen, so it draws the ramp's fourth rung on the baseline and **nothing
+    // at all** above it. Both halves are load bearing: the glyph catches a ramp
+    // shifted by one, and the blank catches a stack that climbs by a level
+    // instead of by a whole ramp.
+    assert_eq!(
+        base[at(1)],
+        RAMP[3],
+        "a column at a quarter of the peak drew the wrong rung:\n{}",
+        rows.join("\n")
+    );
+    assert!(
+        upper[at(1)].is_whitespace(),
+        "a column at a quarter of the peak spilled into the row above it:\n{}",
+        rows.join("\n")
+    );
+}


### PR DESCRIPTION
Closes #225.

## What survived

Three mutations to `band_cell` and the arithmetic feeding it survived the entire suite:

- `level.saturating_sub(row * SPARK_RAMP.len())` becomes `saturating_sub(row)`, so the band's rows stop stacking by a ramp's worth each and start stacking by one level.
- `filled.min(SPARK_RAMP.len()) - 1` becomes `filled.min(SPARK_RAMP.len() - 1)`, which shifts every rung by one.
- `level_of`'s `rows * SPARK_RAMP.len()` becomes `+ 1`.

No gate read a height off the band. Every existing one checks that it is present, how many rows it is given, that it yields to the list and the diff, and that an empty column draws nothing.

## Why the earlier attempt was withdrawn

A gate was tried during #159 and pulled. Its first version used a series that was full everywhere, where every row sits at its ceiling and flattening the stack changes nothing, so it passed against the very mutation it was written for. Its second could not get the band drawn at all: `render` clamps the body to `view.list.len()`, so a view carrying diff rows and an empty list draws no masthead however tall the pane. #223 built that fixture, which is what makes this landable.

## What this adds

One gate, `the_band_stacks_its_rows_from_the_bottom`, over a **mixed** series: `QUARTERED` puts the peak in the first drawn column and a quarter of it in the second.

- The peak column fills both rows, which is what stops the assertions below being satisfied by a band that drew nothing.
- The quarter column draws the ramp's fourth rung on the baseline (level four of sixteen) and **nothing at all** above it. The glyph catches a ramp shifted by one; the blank catches a stack that climbs by a level instead of by a ramp.

Column spans are derived from the drawn row, the way `the_band_reaches_both_edges_of_its_slot` already derives them, rather than copied out of a failure message.

## Verification

- `cargo test --workspace --no-fail-fast`: **701 passing, 0 failing**, from 700.
- `cargo fmt --check` clean, `cargo clippy --all-targets --all-features` under `RUSTFLAGS=-D warnings` clean.
- **Mutations: all three killed**, and the unmutated control was checked in the other direction and reported as surviving, so the harness is honest both ways.

Scope: one test file, 76 lines, no `src` change. Docs carve-out does not apply; `cargo bench` and the budget gates are not run because nothing on the frame path moved.
