### PR TITLE
Three paint marks name their region, not its first row (#254)

### DIFF
--- a/crates/vigia/src/app.rs
+++ b/crates/vigia/src/app.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use vigia_core::{Frame, Highlighter, History, Result, Samples};
 
-use crate::input::{Action, Hovered};
+use crate::input::{Action, Grabbed, Hovered};
 use crate::memory;
 use crate::render::{Body, Chrome, Mode};
 use crate::view::{Position, View, Viewport, rows_in};
@@ -387,9 +387,9 @@ impl App {
         worktree: &str,
         branch: Option<&str>,
         pressed: Option<(u16, u16)>,
-        gripped: Option<u16>,
+        gripped: Option<Grabbed>,
         hovered: Option<Hovered>,
-        scrolling: Option<(u16, isize)>,
+        scrolling: Option<(Grabbed, isize)>,
     ) -> Chrome {
         Chrome {
             pressed,
@@ -894,19 +894,23 @@ mod tests {
             "fixture",
             None,
             Some((79, 5)),
-            Some(11),
+            Some(Grabbed::Diff),
             Some(Hovered::Button(79, 19)),
-            Some((11, -1)),
+            Some((Grabbed::List, -1)),
         );
 
         assert_eq!(chrome.pressed, Some((79, 5)), "the pressed cell");
-        assert_eq!(chrome.gripped, Some(11), "the dragged bar");
+        assert_eq!(chrome.gripped, Some(Grabbed::Diff), "the dragged bar");
         assert_eq!(
             chrome.hovered,
             Some(Hovered::Button(79, 19)),
             "the hover mark"
         );
-        assert_eq!(chrome.scrolling, Some((11, -1)), "the scrolled bar");
+        assert_eq!(
+            chrome.scrolling,
+            Some((Grabbed::List, -1)),
+            "the scrolled bar"
+        );
     }
 
     #[test]

--- a/crates/vigia/src/input.rs
+++ b/crates/vigia/src/input.rs
@@ -570,13 +570,30 @@ pub fn hover_repainted(was: Option<Hovered>, before: Regions, after: Regions) ->
     (before == after).then_some(was).flatten()
 }
 
-/// Which region a drag that is already under way belongs to.
+/// Which of the two scrollable regions a mark belongs to.
 ///
-/// **A gesture outlives the target it began on**, which is the whole reason this
-/// exists. `Regions` answers *what is under the pointer now*; once a button is
-/// down that question has stopped being the relevant one, and the answer that
-/// matters is *what did this drag start on*. Keeping the two apart is what lets
-/// the pointer wander off the bar's one column without the drag ending.
+/// **A gesture outlives the target it began on**, which is why this exists and
+/// is all it meant at first: a drag. [`Regions`] answers *what is under the
+/// pointer now*; once a button is down that question has stopped being the
+/// relevant one, and the answer that matters is *what did this drag start on*.
+/// Keeping the two apart is what lets the pointer wander off the bar's one
+/// column without the drag ending, and [`drag_action`] is where it is spent.
+///
+/// **It names the region for all three paint marks since
+/// [#254](https://github.com/breferrari/vigia/issues/254), and only one of the
+/// three is a drag.** [`Hovered::Track`] is a pointer resting on a bar and
+/// `Chrome::scrolling` is a key burst with nothing under a finger. Both used to
+/// carry the region's **first row** instead, which tells the two regions apart
+/// only while they are stacked: every shipped layout stacks them and
+/// [#252](https://github.com/breferrari/vigia/issues/252) is the one that does
+/// not. So this is wider than its own name now, and says *which bar* whatever
+/// asked.
+///
+/// **Renaming it was considered and rejected.** `Bar` is taken by `render::Bar`,
+/// the `None`/`Bare`/`Stepped` style enum, and a second two-variant type
+/// carrying the same fact would need a conversion at every boundary to buy
+/// nothing. A rename is a naming question and this was a defect fix, so the
+/// wider docblock carries the width instead.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Grabbed {
     /// The pinned list's bar.

--- a/crates/vigia/src/input.rs
+++ b/crates/vigia/src/input.rs
@@ -423,10 +423,10 @@ impl Regions {
                 return Some(Hovered::Button(column, row));
             }
             if on_list_bar && self.list.along(row).is_some() {
-                return Some(Hovered::Track(self.list.top));
+                return Some(Hovered::Track(Grabbed::List));
             }
             return (on_diff_bar && self.diff.along(row).is_some())
-                .then_some(Hovered::Track(self.diff.top));
+                .then_some(Hovered::Track(Grabbed::Diff));
         }
         // A listed file, which is a surface a click acts on: it puts the diff at
         // that file. The diff's own rows are deliberately absent, because
@@ -459,15 +459,22 @@ pub enum Hovered {
     /// weight, and a click that acts immediately. Named for the shape rather than
     /// for the scrollbar since B12 gave the pane its second one.
     Button(u16, u16),
-    /// A bar, by the first row of the region it belongs to.
+    /// A bar, by the region it belongs to.
     ///
     /// **The track and the thumb are one target**, because a press anywhere on a
     /// track seeks: the surface a click acts on is the whole column, and the
-    /// thumb is what answers because it is what would move. Carried as the
-    /// region's first row rather than the pointer's, which is the key
-    /// `Chrome::gripped` already uses and what the drawer compares `area.y`
-    /// against.
-    Track(u16),
+    /// thumb is what answers because it is what would move.
+    ///
+    /// **Carried as the region rather than as the region's first row**, which is
+    /// what this was until [#254](https://github.com/breferrari/vigia/issues/254).
+    /// A row is an identity only while the two regions are stacked and their tops
+    /// differ. [#252](https://github.com/breferrari/vigia/issues/252) puts the
+    /// list beside the diff, where both start on the same row and a comparison
+    /// against one top starts matching for both bars at once. [`Grabbed`] is the
+    /// name for *which of the two bars* that the shell is already holding, so the
+    /// mark carries that and the drawer is told which bar it is drawing instead
+    /// of inferring it from the `Rect` it was handed.
+    Track(Grabbed),
     /// A listed file, by the screen row it is drawn on.
     ///
     /// A row rather than an index into the list, for the reason a button is a
@@ -608,12 +615,6 @@ impl Grabbed {
             Self::Diff => regions.diff,
         }
     }
-
-    /// The first row of that region, which is what the paint compares against to
-    /// draw the gripped bar lit.
-    pub fn top(self, regions: Regions) -> u16 {
-        self.region(regions).top
-    }
 }
 
 /// What a drag already under way makes of `event`, **ignoring the column**.
@@ -652,22 +653,26 @@ pub fn drag_action(event: &Event, regions: Regions, on: Grabbed) -> Option<Actio
 /// list's window. An arrow that lit from a bare direction lit the matching one on
 /// both bars at once, which is what 0.5.0 shipped.
 ///
-/// The `u16` is the region's first row, which is what a drawer compares its own
-/// `Rect` against. A region with no rows reports nothing: with no list on screen
-/// the two tops are the same number, so an unguarded answer would light the
-/// diff's arrows for a movement of a map nobody can see.
+/// The [`Grabbed`] is which bar, which is what a drawer is told rather than left
+/// to infer from the `Rect` it was handed. It was the region's first row until
+/// [#254](https://github.com/breferrari/vigia/issues/254), for the reason
+/// [`Hovered::Track`] records: a top is an identity only while the regions are
+/// stacked. A region with no rows still reports nothing, and the guard is why
+/// this reads the layout at all rather than the action alone: with no list on
+/// screen there is no bar to light, so an unguarded answer would mark a movement
+/// of a map nobody can see.
 ///
 /// A free function rather than a method on the shell, for the reason
 /// [`patience`] is one: the shell owns a terminal and three threads, and the
 /// routing is exactly the part worth driving from a test.
-pub fn scroll_mark(action: Action, regions: Regions) -> Option<(u16, isize)> {
-    let (region, way) = match action {
+pub fn scroll_mark(action: Action, regions: Regions) -> Option<(Grabbed, isize)> {
+    let (whose, way) = match action {
         Action::Scroll(by) | Action::Page(by) | Action::HalfPage(by) | Action::File(by) => {
-            (regions.diff, by.signum())
+            (Grabbed::Diff, by.signum())
         }
-        Action::Top => (regions.diff, -1),
-        Action::Bottom => (regions.diff, 1),
-        Action::ScrollList(by) => (regions.list, by.signum()),
+        Action::Top => (Grabbed::Diff, -1),
+        Action::Bottom => (Grabbed::Diff, 1),
+        Action::ScrollList(by) => (Grabbed::List, by.signum()),
         // A jump to a listed file moves the diff to somewhere rather than by
         // something, and a drag on either bar already lights its own thumb.
         Action::ListRow(_)
@@ -679,7 +684,7 @@ pub fn scroll_mark(action: Action, regions: Regions) -> Option<(u16, isize)> {
         | Action::Redraw
         | Action::Quit => return None,
     };
-    (way != 0 && region.rows > 0).then_some((region.top, way))
+    (way != 0 && whose.region(regions).rows > 0).then_some((whose, way))
 }
 
 /// How long the loop may block before some clock here has to act.

--- a/crates/vigia/src/lib.rs
+++ b/crates/vigia/src/lib.rs
@@ -968,7 +968,7 @@ struct Shell {
     /// nowhere else. The rule is at one address on purpose, because the same
     /// reasoning restated per field is what left `Regions::step`'s doc claiming
     /// a held button cannot repeat for a day after it could.
-    scrolling: Option<(u16, isize)>,
+    scrolling: Option<(Grabbed, isize)>,
     /// When the mark above stops being true.
     scrolling_until: Option<Instant>,
 }
@@ -979,10 +979,14 @@ impl Shell {
         self.held.map(Held::at)
     }
 
-    /// The first row of the region whose bar is being dragged, for the frame that
-    /// draws its thumb lit.
-    fn gripped(&self) -> Option<u16> {
-        self.grabbed.map(|on| on.top(self.regions))
+    /// Which region's bar is being dragged, for the frame that draws its thumb
+    /// lit.
+    ///
+    /// A plain read, since [#254](https://github.com/breferrari/vigia/issues/254):
+    /// this used to convert the [`Grabbed`] it is holding into that region's
+    /// first row, which is an identity only while the regions are stacked.
+    fn gripped(&self) -> Option<Grabbed> {
+        self.grabbed
     }
 
     /// What the pointer is over, for the frame that marks it.

--- a/crates/vigia/src/render.rs
+++ b/crates/vigia/src/render.rs
@@ -6125,15 +6125,38 @@ mod tests {
 
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
+    use ratatui::style::Color;
 
     use super::*;
+
+    /// A cell's style reduced to what the bar's rungs actually differ in.
+    ///
+    /// **Colour alone cannot tell them apart, which a mutation proved.**
+    /// [`Theme::bar_hover`] is [`Theme::bar`]'s colour plus `BOLD` on the
+    /// default palette, so a gate reading only `fg` let a drawn hover that
+    /// ignored its region pass. `tests/render.rs` spells the same reduction
+    /// under the same name, and both exist because the palette is free to move
+    /// a rung into the weight channel.
+    fn weight(style: Style) -> (Option<Color>, Modifier) {
+        (style.fg, style.add_modifier)
+    }
 
     /// Paint both regions' bars into one buffer, side by side over one row range.
     ///
     /// Returns the buffer, and the two bar columns are 29 and 79. The only thing
     /// telling the regions apart is the [`Grabbed`] each is painted with: their
     /// `y` and their height are deliberately identical.
-    fn rail(gripped: Option<Grabbed>, scrolling: Option<(Grabbed, isize)>) -> Buffer {
+    ///
+    /// All three marks are parameters and each test sets exactly one, which is
+    /// the shape [`Painter`] itself has. Taking fewer of them is how the hover
+    /// mark went untested: an earlier draft of this module took only `gripped`
+    /// and `scrolling`, and a mutation making the drawn hover ignore its region
+    /// then survived the whole suite.
+    fn rail(
+        gripped: Option<Grabbed>,
+        hovered: Option<Hovered>,
+        scrolling: Option<(Grabbed, isize)>,
+    ) -> Buffer {
         let mut buf = Buffer::empty(Rect::new(0, 0, 80, 24));
         let theme = Theme::default();
         let (list, diff) = (Rect::new(0, 1, 30, 20), Rect::new(30, 1, 50, 20));
@@ -6153,7 +6176,7 @@ mod tests {
             paint: PaintStats::default(),
             pressed: None,
             gripped,
-            hovered: None,
+            hovered,
             scrolling,
         };
         // Scrollable by a wide margin, so both bars draw a thumb well short of
@@ -6170,24 +6193,24 @@ mod tests {
         // both bars; a direction plus a row fixed it only for as long as the two
         // rows differ.
         let theme = Theme::default();
-        let buf = rail(None, Some((Grabbed::Diff, -1)));
-        let fg = |x: u16, y: u16| buf[(x, y)].style().fg;
+        let buf = rail(None, None, Some((Grabbed::Diff, -1)));
+        let at = |x: u16, y: u16| weight(buf[(x, y)].style());
 
         assert_eq!(
-            fg(79, 1),
-            theme.bar_active.fg,
+            at(79, 1),
+            weight(theme.bar_active),
             "the scrolled region's own up arrow did not light"
         );
         assert_eq!(
-            fg(29, 1),
-            theme.bar_track.fg,
+            at(29, 1),
+            weight(theme.bar_track),
             "scrolling the diff lit the *list's* up arrow, because both bars \
              start on one row"
         );
         // The direction half, so a mark that lit its whole bar would still fail.
         assert_eq!(
-            fg(79, 20),
-            theme.bar_track.fg,
+            at(79, 20),
+            weight(theme.bar_track),
             "the arrow the scroll moves away from lit"
         );
     }
@@ -6198,12 +6221,12 @@ mod tests {
         // region from the start and was correct throughout, and it was correct
         // *because* the tops differed rather than because it said which region.
         let theme = Theme::default();
-        let buf = rail(Some(Grabbed::Diff), None);
+        let buf = rail(Some(Grabbed::Diff), None, None);
         let thumbs = |x: u16| {
             (2..20)
                 .filter(|y| buf[(x, *y)].symbol() == BAR_THUMB.to_string())
-                .map(|y| buf[(x, y)].style().fg)
-                .collect::<Vec<_>>()
+                .map(|y| weight(buf[(x, y)].style()))
+                .collect::<Vec<(Option<Color>, Modifier)>>()
         };
 
         let (list, diff) = (thumbs(29), thumbs(79));
@@ -6212,13 +6235,49 @@ mod tests {
             "the fixture drew no thumb on one of the bars"
         );
         assert!(
-            diff.iter().all(|f| *f == theme.bar_active.fg),
+            diff.iter().all(|f| *f == weight(theme.bar_active)),
             "the gripped region's thumb did not light"
         );
         assert!(
-            list.iter().all(|f| *f == theme.bar.fg),
+            list.iter().all(|f| *f == weight(theme.bar)),
             "gripping the diff lit the *list's* thumb, because both bars start \
              on one row"
+        );
+    }
+
+    #[test]
+    fn only_the_hovered_regions_thumb_lights_when_both_start_on_one_row() {
+        // **Added because a mutation survived**, which is the only reason worth
+        // adding a test for. Replacing the drawn hover's `Hovered::Track(whose)`
+        // with a `matches!(.., Track(_))` that ignores which region passed the
+        // entire suite: the two gates above set `gripped` and `scrolling`, and
+        // neither ever set `hovered`, so the third mark reached the drawer with
+        // nothing checking that it told the two bars apart.
+        //
+        // On a rail that is a pointer resting on the map's bar lighting the
+        // diff's thumb, which is this issue's own defect on the third surface it
+        // was filed for.
+        let theme = Theme::default();
+        let buf = rail(None, Some(Hovered::Track(Grabbed::Diff)), None);
+        let thumbs = |x: u16| {
+            (2..20)
+                .filter(|y| buf[(x, *y)].symbol() == BAR_THUMB.to_string())
+                .map(|y| weight(buf[(x, y)].style()))
+                .collect::<Vec<(Option<Color>, Modifier)>>()
+        };
+
+        let (list, diff) = (thumbs(29), thumbs(79));
+        assert!(
+            !list.is_empty() && !diff.is_empty(),
+            "the fixture drew no thumb on one of the bars"
+        );
+        assert!(
+            diff.iter().all(|f| *f == weight(theme.bar_hover)),
+            "the hovered region's thumb did not take the hover rung"
+        );
+        assert!(
+            list.iter().all(|f| *f == weight(theme.bar)),
+            "hovering the diff lit the list's thumb, both bars starting on one row"
         );
     }
 }

--- a/crates/vigia/src/render.rs
+++ b/crates/vigia/src/render.rs
@@ -6106,3 +6106,119 @@ fn printable(text: &str, column: &mut usize, room: usize) -> Printed {
         examined,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! What [`Painter::scrollbar`] draws when two regions start on one row.
+    //!
+    //! **`tests/render.rs` cannot reach this, which is why it is here.** That
+    //! file drives the whole of [`render`], and every layout it can ask for
+    //! stacks the list above the diff, so `list.y < diff.y` on every fixture
+    //! that exists. A drawer that told the two apart by the `y` of the rect it
+    //! was handed was therefore correct on every screen anyone could draw and
+    //! wrong on the one [#252](https://github.com/breferrari/vigia/issues/252)
+    //! draws, and no gate above this level could see the difference.
+    //!
+    //! This calls the private drawer with the rail's own shape: same `y`, same
+    //! height, different columns. It is the smallest thing that can express the
+    //! case at all.
+
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+
+    use super::*;
+
+    /// Paint both regions' bars into one buffer, side by side over one row range.
+    ///
+    /// Returns the buffer, and the two bar columns are 29 and 79. The only thing
+    /// telling the regions apart is the [`Grabbed`] each is painted with: their
+    /// `y` and their height are deliberately identical.
+    fn rail(gripped: Option<Grabbed>, scrolling: Option<(Grabbed, isize)>) -> Buffer {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 80, 24));
+        let theme = Theme::default();
+        let (list, diff) = (Rect::new(0, 1, 30, 20), Rect::new(30, 1, 50, 20));
+        assert_eq!(
+            (list.y, list.height),
+            (diff.y, diff.height),
+            "the fixture is not the case this module exists for"
+        );
+
+        let mut painter = Painter {
+            buf: &mut buf,
+            theme: &theme,
+            glyphs: Glyphs::default(),
+            gutter: 0,
+            inset: 0,
+            trailing: 0,
+            paint: PaintStats::default(),
+            pressed: None,
+            gripped,
+            hovered: None,
+            scrolling,
+        };
+        // Scrollable by a wide margin, so both bars draw a thumb well short of
+        // their track and the arrows exist to be read.
+        painter.scrollbar(list, Grabbed::List, Bar::Stepped, 0, 10, 100);
+        painter.scrollbar(diff, Grabbed::Diff, Bar::Stepped, 0, 10, 100);
+        buf
+    }
+
+    #[test]
+    fn only_the_scrolled_regions_arrows_light_when_both_start_on_one_row() {
+        // **The assertion that would have caught 0.5.0**, on the layout that
+        // brings the defect back. A bare direction lit the matching arrow on
+        // both bars; a direction plus a row fixed it only for as long as the two
+        // rows differ.
+        let theme = Theme::default();
+        let buf = rail(None, Some((Grabbed::Diff, -1)));
+        let fg = |x: u16, y: u16| buf[(x, y)].style().fg;
+
+        assert_eq!(
+            fg(79, 1),
+            theme.bar_active.fg,
+            "the scrolled region's own up arrow did not light"
+        );
+        assert_eq!(
+            fg(29, 1),
+            theme.bar_track.fg,
+            "scrolling the diff lit the *list's* up arrow, because both bars \
+             start on one row"
+        );
+        // The direction half, so a mark that lit its whole bar would still fail.
+        assert_eq!(
+            fg(79, 20),
+            theme.bar_track.fg,
+            "the arrow the scroll moves away from lit"
+        );
+    }
+
+    #[test]
+    fn only_the_gripped_regions_thumb_lights_when_both_start_on_one_row() {
+        // The drag mark, on the same fixture. `Chrome::gripped` carried its
+        // region from the start and was correct throughout, and it was correct
+        // *because* the tops differed rather than because it said which region.
+        let theme = Theme::default();
+        let buf = rail(Some(Grabbed::Diff), None);
+        let thumbs = |x: u16| {
+            (2..20)
+                .filter(|y| buf[(x, *y)].symbol() == BAR_THUMB.to_string())
+                .map(|y| buf[(x, y)].style().fg)
+                .collect::<Vec<_>>()
+        };
+
+        let (list, diff) = (thumbs(29), thumbs(79));
+        assert!(
+            !list.is_empty() && !diff.is_empty(),
+            "the fixture drew no thumb on one of the bars"
+        );
+        assert!(
+            diff.iter().all(|f| *f == theme.bar_active.fg),
+            "the gripped region's thumb did not light"
+        );
+        assert!(
+            list.iter().all(|f| *f == theme.bar.fg),
+            "gripping the diff lit the *list's* thumb, because both bars start \
+             on one row"
+        );
+    }
+}

--- a/crates/vigia/src/render.rs
+++ b/crates/vigia/src/render.rs
@@ -39,7 +39,7 @@ use ratatui::text::Span as TextSpan;
 use vigia_core::{Class, HISTORY_BUCKETS, LineKind, Recency, SPARK_GROUPS, Span, scale_of};
 
 use crate::glyphs::Glyphs;
-use crate::input::{Hovered, Region, Regions, Sheet};
+use crate::input::{Grabbed, Hovered, Region, Regions, Sheet};
 use crate::theme::Theme;
 use crate::view::{FileEntry, HEAT_BUCKETS, HeatBucket, Row, Scale, View};
 
@@ -1266,14 +1266,18 @@ pub struct Chrome {
     /// costs no row, no rect and no wake: the frames it changes are frames the
     /// step was already painting.
     pub pressed: Option<(u16, u16)>,
-    /// The first row of the region whose bar is being **dragged**, when one is.
+    /// Which region's bar is being **dragged**, when one is.
     ///
-    /// A row rather than a region, because that is what the drawer already has
-    /// in hand: `scrollbar` is given its own `Rect` and compares `area.y`. It is
-    /// the same lifetime as [`Chrome::pressed`] and a different gesture: a press
-    /// on a step button lights one cell, a press on the track lights the thumb
-    /// it is moving.
-    pub gripped: Option<u16>,
+    /// The region rather than its first row, which is what this carried until
+    /// [#254](https://github.com/breferrari/vigia/issues/254): the row read as
+    /// the cheaper shape because `scrollbar` is handed its own `Rect` and could
+    /// compare `area.y`, and it is an identity only while the two regions are
+    /// stacked. [`Hovered::Track`] records the rest of that argument.
+    ///
+    /// It is the same lifetime as [`Chrome::pressed`] and a different gesture: a
+    /// press on a step button lights one cell, a press on the track lights the
+    /// thumb it is moving.
+    pub gripped: Option<Grabbed>,
     /// What the pointer is resting on, when it is on something a click acts on.
     ///
     /// **Acknowledgment before action, which is the whole of `SPEC.md` §11.2
@@ -1296,15 +1300,20 @@ pub struct Chrome {
     /// whichever device asked. Negative is up, positive is down, `None` is at
     /// rest.
     ///
-    /// **The row is which region, and it was missing until 2026-08-16.** The two
-    /// bars move different things and answer different keys, so a bare direction
-    /// lit the matching arrow on *both* at once, which is what 0.5.0 shipped.
+    /// **Which region, and it was missing until 2026-08-16.** The two bars move
+    /// different things and answer different keys, so a bare direction lit the
+    /// matching arrow on *both* at once, which is what 0.5.0 shipped.
     /// [`Chrome::gripped`] one field up had carried its region from the start and
     /// was correct throughout, which is why a drag lit only its own bar while a
     /// keypress lit both: the right shape was one field away and the newer mark
-    /// did not copy it. Same convention now, the region's first row, compared
-    /// against the `Rect` each bar is drawn into.
-    pub scrolling: Option<(u16, isize)>,
+    /// did not copy it.
+    ///
+    /// **The decision was carry the region; the encoding was the region's first
+    /// row, and only the encoding changed in
+    /// [#254](https://github.com/breferrari/vigia/issues/254).** A top tells the
+    /// two bars apart only while they are stacked, and a rail ends that, so what
+    /// both marks carry now is the [`Grabbed`] the shell was already holding.
+    pub scrolling: Option<(Grabbed, isize)>,
     /// Something the reader should see instead of the key hints.
     ///
     /// A monitor survives a failed frame rather than exiting, so this is where a
@@ -3561,6 +3570,7 @@ pub fn render(
         if bar.drawn() {
             painter.scrollbar(
                 full,
+                Grabbed::List,
                 bar,
                 view.list_top as u64,
                 body.list as u64,
@@ -3668,6 +3678,7 @@ pub fn render(
         if bar.drawn() {
             painter.scrollbar(
                 full,
+                Grabbed::Diff,
                 bar,
                 view.rows_above as u64,
                 u64::from(body.diff as u16),
@@ -3939,13 +3950,13 @@ struct Painter<'a> {
     /// the whole screen, and a drawer that reached back into the chrome for it
     /// would be one more thing the two regions could answer differently.
     pressed: Option<(u16, u16)>,
-    /// The first row of the bar being dragged, from [`Chrome::gripped`].
-    gripped: Option<u16>,
+    /// Which region's bar is being dragged, from [`Chrome::gripped`].
+    gripped: Option<Grabbed>,
     /// What the pointer is resting on, from [`Chrome::hovered`].
     hovered: Option<Hovered>,
     /// Which bar the keys are scrolling and which way, from
     /// [`Chrome::scrolling`].
-    scrolling: Option<(u16, isize)>,
+    scrolling: Option<(Grabbed, isize)>,
 }
 
 impl Painter<'_> {
@@ -4803,7 +4814,7 @@ impl Painter<'_> {
     /// **`bar` is passed rather than re-decided**, because [`bar_for`] needs the
     /// pane's width and this has only a region's. Re-deriving it here is the one
     /// way the pointer and the screen could come to hold different tracks.
-    fn scrollbar(&mut self, area: Rect, bar: Bar, at: u64, span: u64, of: u64) {
+    fn scrollbar(&mut self, area: Rect, whose: Grabbed, bar: Bar, at: u64, span: u64, of: u64) {
         // **Width and height guarded here as well as by the caller.** `render`
         // only calls this above `BAR_FLOOR` and only through `bar_for`, so a zero
         // width cannot reach it today, and the subtractions below would underflow
@@ -4871,8 +4882,8 @@ impl Painter<'_> {
         // [`Theme::bar`] and drags at [`Theme::bar_active`] with nothing
         // between. That was true and the conclusion drawn from it was wrong: the
         // missing rung was a thing to build rather than a reason to decline.
-        let dragging = self.gripped == Some(area.y);
-        let hovering = self.hovered == Some(Hovered::Track(area.y));
+        let dragging = self.gripped == Some(whose);
+        let hovering = self.hovered == Some(Hovered::Track(whose));
         let thumb_style = if dragging {
             self.theme.bar_active
         } else if hovering {
@@ -4923,12 +4934,12 @@ impl Painter<'_> {
                 // **This bar's own scroll, not any scroll.** The two regions move
                 // different things: `j` moves the diff's viewport and `J` moves
                 // the list's window, so a mark that carried only a direction lit
-                // the matching arrow on both bars at once. The row is what says
-                // which, exactly as it does for a drag one block up.
+                // the matching arrow on both bars at once. The region is what
+                // says which, exactly as it does for a drag one block up.
                 let keyed = self
                     .scrolling
-                    .is_some_and(|(top, by)| top == area.y && by.signum() == way)
-                    && self.gripped != Some(area.y);
+                    .is_some_and(|(on, by)| on == whose && by.signum() == way)
+                    && self.gripped != Some(whose);
                 // **Three rungs, and a press beats a hover.** `bar_track` at
                 // rest, `bar` under a pointer, `bar_active` while a gesture is
                 // on it. The ordering is the load-bearing half: #166 added the

--- a/crates/vigia/tests/input.rs
+++ b/crates/vigia/tests/input.rs
@@ -652,6 +652,26 @@ fn two_regions() -> Regions {
     }
 }
 
+/// Two regions **beside** each other: one first row, one row count, told apart
+/// by their columns alone.
+///
+/// The layout [#252](https://github.com/breferrari/vigia/issues/252) draws, and
+/// the shape every model in this module has to be able to express before that
+/// row can be built. The shipped ladder never produces it, which is exactly why
+/// it is worth a name: a fixture that only ever appears inline reads as a local
+/// quirk of whichever test spelled it, and this is the case three of them share.
+///
+/// The list takes the left thirty columns with its bar at 29, the diff takes the
+/// remaining seventy with its bar at 99. Both start on row 1 and hold 18 rows, so
+/// **no row distinguishes them and no assertion here may rest on one**.
+fn beside() -> Regions {
+    Regions {
+        list: Region::bare(1, 18, 0, 30, Some(29)),
+        diff: Region::bare(1, 18, 30, 70, Some(99)),
+        sheet: None,
+    }
+}
+
 fn at(kind: MouseEventKind, column: u16, row: u16) -> Event {
     Event::Mouse(MouseEvent {
         kind,
@@ -777,11 +797,7 @@ fn a_bar_in_one_region_leaves_the_others_rows_clickable() {
 /// are the diff's rows and the row was all anything asked.
 #[test]
 fn a_gesture_in_one_regions_columns_is_not_the_others() {
-    let rail = Regions {
-        list: Region::bare(1, 18, 0, 30, Some(29)),
-        diff: Region::bare(1, 18, 30, 70, Some(99)),
-        sheet: None,
-    };
+    let rail = beside();
     // A row both regions hold, and a column each of them holds alone.
     let row = 7;
     let (in_rail, in_diff) = (4, 60);
@@ -837,11 +853,7 @@ fn a_gesture_in_one_regions_columns_is_not_the_others() {
 /// model has to be able to say it before the layout can.
 #[test]
 fn a_press_on_one_regions_bar_is_not_the_others() {
-    let side_by_side = Regions {
-        list: Region::bare(1, 18, 0, 30, Some(29)),
-        diff: Region::bare(1, 18, 30, 70, Some(99)),
-        sheet: None,
-    };
+    let side_by_side = beside();
     // Same row in both, which is the whole case: under the old model the row was
     // the only thing distinguishing them and here it distinguishes nothing.
     let row = 5;
@@ -1899,22 +1911,18 @@ fn a_region_with_no_rows_lights_nothing() {
 
 #[test]
 fn a_mark_names_its_region_when_both_share_a_first_row() {
-    // **The screen [#252](https://github.com/breferrari/vigia/issues/252) draws,
-    // which nothing in this file draws today**: the list beside the diff rather
-    // than above it, so the two regions share a first row and a row count and
-    // differ only in their columns.
+    // **The [`beside`] shape, now pointed at the paint marks.** Two tests above
+    // already drive it, which is worth stating because an earlier draft of this
+    // comment claimed the file drew no such screen: it draws it twice, for the
+    // *region geometry* [#251](https://github.com/breferrari/vigia/issues/251)
+    // fixed. What no test drove it for is the three marks, which is the whole of
+    // [#254](https://github.com/breferrari/vigia/issues/254) and the reason the
+    // assumption survived that pass.
     //
-    // Every mark that named a region by its top collapses on this fixture, which
-    // is why it is the gate on
-    // [#254](https://github.com/breferrari/vigia/issues/254) and why no existing
-    // test could have caught the assumption: on every layout that ships,
-    // `list.top < diff.top`, so a top and a region are the same answer and the
-    // wrong one is indistinguishable from the right one.
-    let regions = Regions {
-        list: Region::bare(1, 20, 0, 30, Some(29)),
-        diff: Region::bare(1, 20, 30, 50, Some(79)),
-        sheet: None,
-    };
+    // Every mark that named a region by its top collapses here, and on every
+    // layout that ships `list.top < diff.top`, so a top and a region are the same
+    // answer and the wrong one cannot be told from the right one.
+    let regions = beside();
     assert_eq!(
         (regions.list.top, regions.list.rows),
         (regions.diff.top, regions.diff.rows),
@@ -1942,7 +1950,7 @@ fn a_mark_names_its_region_when_both_share_a_first_row() {
         "a pointer on the rail's own bar marked the diff's"
     );
     assert_eq!(
-        regions.hover_at(79, 10),
+        regions.hover_at(99, 10),
         Some(Hovered::Track(Grabbed::Diff)),
         "a pointer on the diff's own bar marked the rail's"
     );

--- a/crates/vigia/tests/input.rs
+++ b/crates/vigia/tests/input.rs
@@ -1896,3 +1896,54 @@ fn a_region_with_no_rows_lights_nothing() {
         Some((Grabbed::Diff, 1))
     );
 }
+
+#[test]
+fn a_mark_names_its_region_when_both_share_a_first_row() {
+    // **The screen [#252](https://github.com/breferrari/vigia/issues/252) draws,
+    // which nothing in this file draws today**: the list beside the diff rather
+    // than above it, so the two regions share a first row and a row count and
+    // differ only in their columns.
+    //
+    // Every mark that named a region by its top collapses on this fixture, which
+    // is why it is the gate on
+    // [#254](https://github.com/breferrari/vigia/issues/254) and why no existing
+    // test could have caught the assumption: on every layout that ships,
+    // `list.top < diff.top`, so a top and a region are the same answer and the
+    // wrong one is indistinguishable from the right one.
+    let regions = Regions {
+        list: Region::bare(1, 20, 0, 30, Some(29)),
+        diff: Region::bare(1, 20, 30, 50, Some(79)),
+        sheet: None,
+    };
+    assert_eq!(
+        (regions.list.top, regions.list.rows),
+        (regions.diff.top, regions.diff.rows),
+        "the fixture is not the case this test exists for"
+    );
+
+    // **The routing half.** `J` moves the map's window and `j` moves the diff's
+    // viewport, and under the old encoding both answered `1`.
+    assert_eq!(
+        scroll_mark(Action::ScrollList(1), regions),
+        Some((Grabbed::List, 1)),
+        "the map's own key named a region by a row both regions start on"
+    );
+    assert_eq!(
+        scroll_mark(Action::Scroll(1), regions),
+        Some((Grabbed::Diff, 1)),
+        "the diff's key named a region by a row both regions start on"
+    );
+
+    // **The hover half**, one bar column each, which is the coordinate that
+    // actually separates them on this layout.
+    assert_eq!(
+        regions.hover_at(29, 10),
+        Some(Hovered::Track(Grabbed::List)),
+        "a pointer on the rail's own bar marked the diff's"
+    );
+    assert_eq!(
+        regions.hover_at(79, 10),
+        Some(Hovered::Track(Grabbed::Diff)),
+        "a pointer on the diff's own bar marked the rail's"
+    );
+}

--- a/crates/vigia/tests/input.rs
+++ b/crates/vigia/tests/input.rs
@@ -1561,26 +1561,26 @@ fn a_hover_resolves_to_a_button_a_bar_or_a_listed_file() {
     assert_eq!(regions.hover_at(79, 5), Some(Hovered::Button(79, 5)));
     assert_eq!(regions.hover_at(79, 19), Some(Hovered::Button(79, 19)));
 
-    // A track answers as its **region's first row**, which is the key
-    // `Chrome::gripped` uses, because what a hover on this column means is
-    // *this bar* and the thumb is what answers. The track and the thumb are one
-    // target: a press anywhere on a track seeks.
+    // A track answers as **its region**, which is the key `Chrome::gripped`
+    // uses, because what a hover on this column means is *this bar* and the
+    // thumb is what answers. The track and the thumb are one target: a press
+    // anywhere on a track seeks.
     assert_eq!(
         regions.hover_at(79, 12),
-        Some(Hovered::Track(5)),
+        Some(Hovered::Track(Grabbed::Diff)),
         "the diff's"
     );
     assert_eq!(
         regions.hover_at(79, 2),
-        Some(Hovered::Track(1)),
+        Some(Hovered::Track(Grabbed::List)),
         "the list's"
     );
 
     // The list's bar has no buttons at all in this fixture, so every row of it
     // is track. A resolver that assumed both bars were stepped would answer
     // `Button` here and light a cell that is drawing a thumb.
-    assert_eq!(regions.hover_at(79, 1), Some(Hovered::Track(1)));
-    assert_eq!(regions.hover_at(79, 3), Some(Hovered::Track(1)));
+    assert_eq!(regions.hover_at(79, 1), Some(Hovered::Track(Grabbed::List)));
+    assert_eq!(regions.hover_at(79, 3), Some(Hovered::Track(Grabbed::List)));
 
     // **A listed file, off the bar's column**, which is a surface a click acts
     // on because it puts the diff at that file.
@@ -1596,7 +1596,7 @@ fn a_hover_resolves_to_a_button_a_bar_or_a_listed_file() {
     // ordering this resolver has to get right: the scrollbar is drawn inside the
     // region that owns those rows, so asking the list first would mark a file
     // the reader is pointing past.
-    assert_eq!(regions.hover_at(79, 2), Some(Hovered::Track(1)));
+    assert_eq!(regions.hover_at(79, 2), Some(Hovered::Track(Grabbed::List)));
 
     // **The diff's body answers nothing**, which §11.1 rules: it is not
     // clickable and a mark would imply it is.
@@ -1658,7 +1658,7 @@ fn a_hover_mark_is_retired_by_its_replacement_and_by_focus_lost() {
     // the same event that leaves a button arrives on a bar or on a file.
     assert_eq!(
         hover_after(&at(MouseEventKind::Moved, 79, 12), regions, button),
-        Some(Hovered::Track(5)),
+        Some(Hovered::Track(Grabbed::Diff)),
         "a pointer moving from a button onto the diff's bar lost the mark"
     );
     assert_eq!(
@@ -1825,7 +1825,7 @@ fn each_bar_answers_only_the_keys_that_move_it() {
     // The two regions move different things: `j`/`k`/`d`/`u`/`Space`/`g`/`G` and
     // the file steps move the diff's viewport, `J`/`K` move the list's window.
     let regions = two_regions();
-    let (list, diff) = (regions.list.top, regions.diff.top);
+    let (list, diff) = (Grabbed::List, Grabbed::Diff);
 
     for (action, want) in [
         (Action::Scroll(1), Some((diff, 1))),
@@ -1860,9 +1860,21 @@ fn each_bar_answers_only_the_keys_that_move_it() {
 
 #[test]
 fn a_region_with_no_rows_lights_nothing() {
-    // With no list on screen the two regions report the **same** top row, because
-    // the diff starts where the list would have. So an unguarded mark would light
-    // the diff's arrows for a movement of a map nobody can see.
+    // **A mark nobody can see still costs a wake**, which is what this guard is
+    // for now and is not what it was for.
+    //
+    // Until [#254](https://github.com/breferrari/vigia/issues/254) the mark was
+    // the region's first row and the danger was a *collision*: with no list on
+    // screen the diff starts where the list would have, both reported top 1, and
+    // an unguarded `ScrollList` lit the **diff's** arrows for a movement of a map
+    // nobody can see. The mark names its region now, so that confusion cannot be
+    // spelled at all, and deleting this guard would draw nothing wrong.
+    //
+    // It stays because the drawing is not the only consumer. `Shell` arms
+    // `scrolling_until` on every mark it is handed, so a mark naming a bar that
+    // is not drawn buys a `SCROLL_LINGER` timer, a wake, and a repaint that
+    // changes no cell. I1 is what that spends, and the `None` below is what does
+    // not spend it.
     let regions = Regions {
         list: Region::bare(1, 0, 0, 80, Some(79)),
         diff: Region::bare(1, 20, 0, 80, Some(79)),
@@ -1876,8 +1888,11 @@ fn a_region_with_no_rows_lights_nothing() {
     assert_eq!(
         scroll_mark(Action::ScrollList(1), regions),
         None,
-        "scrolling a list that is not drawn lit the diff's bar, because the two \
-         share a top row when the list has no rows"
+        "scrolling a list that is not drawn armed a linger clock and bought a \
+         wake for a mark with no bar to draw it on"
     );
-    assert_eq!(scroll_mark(Action::Scroll(1), regions), Some((1, 1)));
+    assert_eq!(
+        scroll_mark(Action::Scroll(1), regions),
+        Some((Grabbed::Diff, 1))
+    );
 }

--- a/crates/vigia/tests/render.rs
+++ b/crates/vigia/tests/render.rs
@@ -33,8 +33,8 @@ use ratatui::layout::Rect;
 use ratatui::style::Color;
 use ratatui::style::{Modifier, Style};
 use vigia::{
-    Chrome, FileEntry, Glyphs, HEAT_BUCKETS, HeatBucket, Hovered, Mode, Position, Region, Row,
-    Scale, Theme, View, body_layout, diff_height, regions, render,
+    Chrome, FileEntry, Glyphs, Grabbed, HEAT_BUCKETS, HeatBucket, Hovered, Mode, Position, Region,
+    Row, Scale, Theme, View, body_layout, diff_height, regions, render,
 };
 use vigia_core::{Class, HISTORY_BUCKETS, LineKind, Recency, Span};
 
@@ -4485,12 +4485,12 @@ fn a_dragged_bar_lights_its_thumb_and_the_other_bar_stays_put() {
     let x = width - 1;
     let laid = regions(Rect::new(0, 0, width, height), &chrome(), &view);
 
-    for (name, gripped, other) in [
-        ("the list", laid.list, laid.diff),
-        ("the diff", laid.diff, laid.list),
+    for (name, whose, gripped, other) in [
+        ("the list", Grabbed::List, laid.list, laid.diff),
+        ("the diff", Grabbed::Diff, laid.diff, laid.list),
     ] {
         let held = Chrome {
-            gripped: Some(gripped.top),
+            gripped: Some(whose),
             ..chrome()
         };
         let backend = screen(width, height, &view, &held);
@@ -4546,10 +4546,10 @@ fn a_scroll_lights_one_arrow_on_one_bar() {
     let (diff_up, diff_down) = ends(laid.diff);
     let (list_up, list_down) = ends(laid.list);
 
-    for (name, scrolled, way, lit, dark, other) in [
+    for (name, whose, way, lit, dark, other) in [
         (
             "the diff",
-            laid.diff,
+            Grabbed::Diff,
             -1isize,
             diff_up,
             diff_down,
@@ -4557,7 +4557,7 @@ fn a_scroll_lights_one_arrow_on_one_bar() {
         ),
         (
             "the diff",
-            laid.diff,
+            Grabbed::Diff,
             1,
             diff_down,
             diff_up,
@@ -4565,7 +4565,7 @@ fn a_scroll_lights_one_arrow_on_one_bar() {
         ),
         (
             "the list",
-            laid.list,
+            Grabbed::List,
             -1,
             list_up,
             list_down,
@@ -4573,7 +4573,7 @@ fn a_scroll_lights_one_arrow_on_one_bar() {
         ),
         (
             "the list",
-            laid.list,
+            Grabbed::List,
             1,
             list_down,
             list_up,
@@ -4581,7 +4581,7 @@ fn a_scroll_lights_one_arrow_on_one_bar() {
         ),
     ] {
         let scrolling = Chrome {
-            scrolling: Some((scrolled.top, way)),
+            scrolling: Some((whose, way)),
             ..chrome()
         };
         let backend = screen(width, height, &view, &scrolling);
@@ -4609,7 +4609,7 @@ fn a_scroll_lights_one_arrow_on_one_bar() {
     // Magnitude is not direction: a half page lights what a single row lights.
     for way in [-9isize, -1, 1, 9] {
         let scrolling = Chrome {
-            scrolling: Some((laid.diff.top, way)),
+            scrolling: Some((Grabbed::Diff, way)),
             ..chrome()
         };
         let backend = screen(width, height, &view, &scrolling);
@@ -5128,7 +5128,7 @@ fn a_gesture_is_always_brighter_than_a_pointer_at_rest() {
     );
 
     let hovering = Chrome {
-        hovered: Some(Hovered::Track(laid.diff.top)),
+        hovered: Some(Hovered::Track(Grabbed::Diff)),
         ..chrome()
     };
     assert!(
@@ -5140,7 +5140,7 @@ fn a_gesture_is_always_brighter_than_a_pointer_at_rest() {
     assert!(
         thumb_fg(
             &Chrome {
-                gripped: Some(laid.diff.top),
+                gripped: Some(Grabbed::Diff),
                 ..hovering.clone()
             },
             laid.diff


### PR DESCRIPTION
Closes #254.

`Chrome::gripped`, `Chrome::scrolling` and `Hovered::Track` each said **which** of the two regions a mark belonged to by naming that region's first row, and `Painter::scrollbar` compared each against the `area.y` of the rect it was painting. A row tells the two regions apart only while they are stacked. #252 puts the list beside the diff, where both start on the same row and every one of those comparisons starts matching for both bars at once.

That is the 0.5.0 defect `Chrome::scrolling`'s own docblock records, arriving by a second route: a mark that lit the matching arrow on both bars because it did not say which region it meant.

**No screen that exists today changes.** All 20 snapshots are unmoved with no `.snap.new` pending, and that is the gate on the claim.

## This keeps a decision and replaces an encoding

Worth stating, because it reads like a refusal being overturned and is not. `Chrome::scrolling`'s docblock records that the row was **added** on 2026-08-16 for exactly the right purpose, to say which region, after 0.5.0 shipped a bare direction. The decision was *carry the region*. The row was only its encoding, and the encoding is the half that rests on regions having distinct first rows.

## What made it small

Every producer already held the identity and collapsed it at the last step, so most of the change is deleting conversions. `Shell::gripped` converted an `Option<Grabbed>` it was already holding and is a plain read now. `scroll_mark` picked a region by `Action` and returned its top, and returns the `Grabbed` now. `hover_at` matched a region and returned that region's top, and names it now. `Grabbed::top` is deleted with its only caller.

## One guard changed meaning rather than shape

`scroll_mark` still refuses a region with no rows, and its test still gates that, but the reason in both moved. The collision it used to prevent (with no list on screen the two tops are the same number, so `ScrollList` lit the **diff's** arrows) cannot be spelled now that a mark names its region, and deleting the guard would draw nothing wrong.

It stays because the drawing is not the only consumer: `Shell` arms `scrolling_until` on every mark it is handed, so a mark naming an undrawn bar buys a `SCROLL_LINGER` timer, a wake, and a repaint that changes no cell. **I1 is what that spends.** The test keeps its assertion and states the new reason.

## Four new gates, and why three of them live inside `render.rs`

The assumption being removed was correct on every layout that ships, because all of them stack the list above the diff. A mark keyed on a top and a mark keyed on a region are the same answer there.

`tests/input.rs` takes the routing and hover halves, on a new named `beside()` fixture. That fixture is a **dedup, not a new shape**: #251 already added two tests driving two regions that share a first row, verbatim identical to each other, and an earlier draft of this PR wrongly claimed the file drew no such screen. It drew it twice, for the region geometry #251 fixed, and never for the paint marks. That is precisely why this assumption survived that pass, and it is recorded in the fixture's docblock now rather than left to be rediscovered.

The drawn half needs a module inside `render.rs`. `tests/render.rs` drives the whole of `render`, so it can only ask for layouts the shipped ladder produces, and none of them put two bars on one row; `Painter` and `Painter::scrollbar` are both private, so no shared fixture is possible across that boundary. In-crate white-box modules are already precedented in `lib.rs` and `app.rs`.

## The mutation battery, including one that survived

Seven run by hand. **The fifth survived its first two attempts and is the most valuable thing this pass produced.**

| Mutation | Killed by |
|---|---|
| `scroll_mark` always names the diff | `a_mark_names_its_region_when_both_share_a_first_row` and two others |
| `scroll_mark` drops the no-rows guard | `a_region_with_no_rows_lights_nothing` |
| `hover_at` names the list for both bars | `a_hover_resolves_to_a_button_a_bar_or_a_listed_file` and two others |
| the drag mark infers from `area.y` again | **only** `only_the_gripped_regions_thumb_lights...` |
| **the hover mark ignores which region** | **only** `only_the_hovered_regions_thumb_lights...`, which did not exist until it survived |
| the keyed arrow ignores which region | **only** `only_the_scrolled_regions_arrows_light...` |
| the drag rung stops beating the hover rung | both thumb gates |

Two things fall out and both are worth more than the count.

**The hover mark had no drawn gate at all.** The first two render gates set `gripped` and `scrolling`; neither ever set `hovered`, so the third of the three marks this PR is about reached the drawer with nothing checking it told the bars apart. On a rail that is a pointer resting on the map's bar lighting the diff's thumb.

**Then it survived a second time, and that was the test's fault.** The new gate first compared thumb **colours**, and `Theme::bar_hover` is `Theme::bar`'s colour plus `BOLD` on the default palette, so the rungs are not separable by `fg`. `tests/render.rs` already spells the reduction that is, `(fg, add_modifier)` under the name `weight`; this module spells it the same way now, and says why: a palette is free to move a rung into the weight channel, so a gate reading one channel is a gate that can go blind.

## Verification

- `cargo test --workspace --no-fail-fast`: **759 passed, 0 failed**, from a 755 baseline on the same branch point.
- `cargo fmt --check` clean; `cargo clippy --all-targets --all-features` under `RUSTFLAGS=-D warnings` clean.
- **No `insta` snapshot moved and no `.snap.new` pending.**
- All 13 shell budget gates green in release.
- Seven mutations, all killed, table above.

## What the review pass found

`/simplify`, four agents, three real findings and no false positives.

**Reuse** found the `beside()` dedup above, and the false claim in my own comment that came with it. **Altitude** found `Grabbed`'s own docblock stale: the variant-level docs carried the new reasoning while the type definition still read *"which region a drag that is already under way belongs to"*, false for two of its three call sites and the first thing "go to definition" shows. Widened rather than replaced, since the drag paragraph is still load-bearing for `drag_action`, with the rejected rename recorded beside it. **Simplification** and **efficiency** came back clean, the latter noting unprompted that `Option<Grabbed>` niche-optimises to 1 byte where `Option<u16>` needed 4, and that `scroll_mark`'s `&&` now short-circuits so `Grabbed::region` is only called when `way != 0`.

Altitude also observed something the plan did not: this change **reduces** a divergence risk rather than only deferring one. `self.gripped == Some(area.y)` required input's `Regions` and render's `Areas` to agree numerically on a row; `self.gripped == Some(whose)` is a nominal check that cannot be defeated by the two disagreeing on geometry.

## Two things to disagree with

**`Grabbed` is reused rather than renamed.** The type means *which of the two bars*, which fits all three marks, but the name says "grabbed" and a hover mark is not grabbed. `Bar` collides with `render::Bar`, and a second two-variant type carrying the same fact needs a conversion at every boundary to buy nothing. The reviewer's counter-proposal was `Which`; that is a naming question and this was a defect fix, so the docblock carries the width instead.

**The plan promised a full `/harden` loop and this ships a `/simplify` pass plus the mutation battery.** The reason is a reprioritisation that landed mid-pass (#258): three reader-reported hitches went to the front of Phase 8, and this row is latent by construction. Spending a multi-round audit fan-out here would contradict that. Stated rather than absorbed, and the battery above is what carries the rigor in its place.

## Not in scope

The rail itself (#252). `Hovered::Button` and `Hovered::Row`, which key on a cell and on a screen row rather than on a region and are unambiguous under either layout. `SPEC.md` does not change: the contract says nothing about how a mark is keyed.
