### PR TITLE
ci: the watch bound asks for slack and the test step never supplied it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,26 @@ jobs:
 
       # Correctness first, in debug, where the structural budget gates still
       # apply and the absolute ones report that they are skipped.
+      #
+      # **The slack belongs here too, and its absence was a hole.** The claim
+      # above is true of every absolute gate that guards on
+      # `absolute_gates_apply` — those skip in debug and never reach this step.
+      # It is NOT true of `watch.rs`, whose `max_delay` bound is an absolute
+      # wall-clock assertion that runs unconditionally, in debug, right here. It
+      # calls `budget()`, which is the opt-in, and its own comment says it "takes
+      # slack because it is an absolute wall-clock bound on a shared runner" — so
+      # the test was written believing this step supplied it. It did not, and the
+      # bound was held to its raw 500ms on a shared runner. `windows-latest`
+      # measured 773.68ms on a post-merge run of `main` and went red.
+      #
+      # Guarding the bound on `absolute_gates_apply` instead would be worse, and
+      # in a shape this file already records: no step runs `watch.rs` in release,
+      # so the assertion would then run NOWHERE. That is I7's hole below, reached
+      # through the selector rather than the gate — green, and about nothing.
       - name: test
         run: cargo test --workspace
+        env:
+          VIGIA_BUDGET_SLACK: "3"
 
       # Then the budgets, in release, because that is what they were set
       # against. Slack applies to the absolute wall-clock gates only: hosted

--- a/crates/vigia-core/tests/watch.rs
+++ b/crates/vigia-core/tests/watch.rs
@@ -302,9 +302,17 @@ fn a_continuous_writer_still_gets_a_tick_within_max_delay() {
     // burst loop re-checks its deadline once per event, so the overshoot is
     // whatever one `accept` costs, and one `accept` is a `stat` plus a gitignore
     // probe. On a Windows CI runner scanning files created milliseconds earlier
-    // that single syscall has been measured at 244ms past the deadline, which is
-    // not something the loop can preempt. A developer machine still runs this at
-    // zero slack.
+    // that single syscall has been measured at 244ms past the deadline, and on a
+    // post-merge run of `main` at **473ms past** (773.68ms held against a 300ms
+    // `max_delay`), which is not something the loop can preempt. A developer
+    // machine still runs this at zero slack and measures 300.1ms — an overshoot
+    // of 0.1ms — so the slack buys nothing locally and everything on a runner.
+    //
+    // That 773.68ms went red because the `test` step supplied no
+    // `VIGIA_BUDGET_SLACK`, so this `budget()` call was resolving to 1. The step
+    // sets it now. Do NOT respond to a future red here by raising the constant:
+    // it is the local bound too, and at zero slack it is currently tight to
+    // within a millisecond.
     assert!(
         tick.coalesced_for < budget(MAX_DELAY_BOUND),
         "the burst was held for {:?}, past the {:?} its max_delay allows",


### PR DESCRIPTION
## What went red

A **post-merge run of `main`** at `2d2fe86` failed on `windows-latest`:

```
thread 'a_continuous_writer_still_gets_a_tick_within_max_delay' panicked at crates\vigia-core\tests\watch.rs:308:5:
the burst was held for 773.6769ms, past the 500ms its max_delay allows
```

Nobody saw it. The PR run was green, the next commit's run was green, and nothing watches `main` after a merge. It surfaced only from reading `gh run list --branch main`.

## Why it went red, which is not "Windows is slow"

`500ms` in that message is `MAX_DELAY_BOUND` **unmultiplied**. `budget()` had resolved slack to `1`.

`VIGIA_BUDGET_SLACK: "3"` is set on the `budgets` step and on the `first_paint` step. It has never been set on the `test` step. That stayed invisible because every other absolute gate guards on `absolute_gates_apply`, so it skips in debug and never reaches that step.

`watch.rs` is the one exception. Its `max_delay` bound is an absolute wall-clock assertion that runs **unconditionally, in debug, in that step**. It calls `budget()` — which is the opt-in — and its own comment says it *"takes slack because it is an absolute wall-clock bound on a shared runner"*. It was written believing the step supplied it. The step didn't, so a shared runner was held to the developer-machine bound.

## Why not guard it on `absolute_gates_apply` instead

Because no step runs `watch.rs` in release. The bound would then run **nowhere** — which is I7's hole recorded two comments further down in this same file, reached through the test *selector* rather than the gate. `ci.yml` already calls that shape *"green, and about nothing."* Recreating it to fix a flake would be a bad trade.

## Blast radius: one assertion

`watch.rs:309` is the only live `budget()` call in a debug workspace run. `warm.rs` guards at 223/557/729 and `first_paint.rs` at 253, so all of those skip in debug. Setting the variable on the `test` step changes exactly one bound.

## Verification

The suite was already green here, so green proves nothing. Checked by mutation instead — bound temporarily at 200ms, same binary, same machine:

| slack | effective bound | result |
|---|---|---|
| 1 | 200ms | **FAIL** — held 300.10ms |
| 3 | 600ms | pass |

So the variable demonstrably decides the outcome, and the plumbing reaches the assertion.

Local overshoot is **0.1ms** against a 300ms `max_delay` (300.10ms held). The slack therefore buys nothing on a developer machine and **1500ms of headroom** on a runner, against **773.68ms** worst observed.

Full workspace suite green under the exact step this changes (`VIGIA_BUDGET_SLACK=3 cargo test --workspace`).

## What this does not claim

It does not prove the flake is gone — a probabilistic failure cannot be proven absent by one run. What is established is the bound the assertion is held to on CI, which moves from 500ms to 1500ms against a worst-observed 773.68ms. If it reds again above 1500ms, that is a real engine finding rather than runner variance, and `flake-rate.yml` is the instrument for confirming it.

The comment now carries both measurements and says explicitly **not** to raise `MAX_DELAY_BOUND` in response to a future red: it is the local bound too, and at zero slack it is tight to within a millisecond.
