### PR TITLE
Octants arrive where the terminal draws them (#324)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,13 +369,13 @@ The per-file sparkline draws from the eighth-blocks `▁▂▃▄▅▆▇█` b
 ```sh
 VIGIA_GLYPHS=braille         # denser: 8 buckets in 4 columns
 VIGIA_GLYPHS=block           # the safe floor, if you see boxes
-VIGIA_GLYPHS=octant          # Unicode 16 solid 2x4, very few fonts have these yet
+VIGIA_GLYPHS=octant          # Unicode 16 solid 2x4, chosen for you where the terminal draws them
 VIGIA_GLYPHS=auto            # decide for me, which is the default
 ```
 
 **If the sparkline is a row of boxes, you want `block`.** That is a font without the braille patterns U+2800 to U+28FF, and it is the one direction detection cannot see. Windows is where this is most likely: the old console draws with Consolas, which carries none of them, so a bare `conhost` gets blocks and Windows Terminal gets braille.
 
-`octant` is deliberately never chosen for you. The Unicode 16 octants are newer than most fonts, including the current Cascadia, and terminals that draw them do so themselves rather than from your font, which nothing in the environment advertises.
+`octant` is chosen for you exactly where it is not a bet: ghostty 1.2+, kitty 0.40+ and VTE-based terminals from 0.78 draw the Unicode 16 octants themselves, the way every terminal draws box drawing, and each of those names itself and its version in the environment. Everywhere else the octants would come from your font, most fonts do not have them yet, and the answer stays braille; `VIGIA_GLYPHS=octant` remains your word for a terminal the table does not know. foot 1.20+ draws them too and exports no version, so it is deliberately not promoted: a foot one release older would get tofu, and that trade is recorded in the code rather than taken silently.
 
 </details>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -488,7 +488,7 @@ Milestone: [Phase 8](https://github.com/breferrari/vigia/milestone/8)
 | ⬜ | The diff learns the delta formula: calm washes, hot words, a two-tone gutter | [#321](https://github.com/breferrari/vigia/issues/321) |
 | ⬜ | The glance ramps become gradients and the band goes with them | [#322](https://github.com/breferrari/vigia/issues/322) |
 | ⬜ | The chrome earns 2026: segmented bars, a spliced sheet title, opt-in icons | [#323](https://github.com/breferrari/vigia/issues/323) |
-| ⬜ | The glyph ladder learns which terminals draw octants natively | [#324](https://github.com/breferrari/vigia/issues/324) |
+| 🔨 | The glyph ladder learns which terminals draw octants natively | [#324](https://github.com/breferrari/vigia/issues/324) |
 | ⬜ | The pane takes its colours from the terminal, and follows a theme flip live | [#325](https://github.com/breferrari/vigia/issues/325) |
 | ⬜ | A path is a link: OSC 8 on the list and the headings | [#326](https://github.com/breferrari/vigia/issues/326) |
 

--- a/crates/vigia/src/glyphs.rs
+++ b/crates/vigia/src/glyphs.rs
@@ -193,14 +193,20 @@ impl Glyphs {
     ///    512 glyph bitmap that has never held braille. This is the one rung
     ///    with no colour analogue, and it is why a monitor of this class carries
     ///    a console mode beside its braille and block ones.
-    /// 4. **`TERM_PROGRAM`**, a terminal naming itself. See [`program_glyphs`].
-    /// 5. **Windows with `WT_SESSION`**, which is Windows Terminal identifying
+    /// 4. **An engine that draws octants itself, at [`Glyphs::Octant`]**. See
+    ///    [`octant_of`]: ghostty, kitty and VTE rasterise U+1CD00 the way every
+    ///    terminal rasterises box drawing, so the font is never asked and the
+    ///    rung is decided by identity plus version, exactly how `Depth` decides
+    ///    truecolour. `SPEC.md` §10's Windows bullet carries the correction
+    ///    that licensed this ([#324](https://github.com/breferrari/vigia/issues/324)).
+    /// 5. **`TERM_PROGRAM`**, a terminal naming itself. See [`program_glyphs`].
+    /// 6. **Windows with `WT_SESSION`**, which is Windows Terminal identifying
     ///    itself, and it ships Cascadia. Measured: see the module docs.
-    /// 6. **`TERM` naming a terminal that ships its own entry.** See
+    /// 7. **`TERM` naming a terminal that ships its own entry.** See
     ///    [`BRAILLE_TERMS`].
-    /// 7. **Windows otherwise, at [`Glyphs::Block`]**, because the console this
+    /// 8. **Windows otherwise, at [`Glyphs::Block`]**, because the console this
     ///    reaches draws with Consolas and Consolas has no braille. Measured.
-    /// 8. **[`Glyphs::Braille`] otherwise**, which is the broad claim on this
+    /// 9. **[`Glyphs::Braille`] otherwise**, which is the broad claim on this
     ///    ladder and the one worth stating a reason for. Braille has been in
     ///    every mainstream Unix monospace face for twenty years, the one Unix
     ///    terminal that cannot draw it is caught at rung 3, and the reference
@@ -232,6 +238,10 @@ impl Glyphs {
         let term = lookup("TERM").unwrap_or_default().to_ascii_lowercase();
         if term == "dumb" || term == "linux" {
             return Ok(Self::Block);
+        }
+
+        if let Some(glyphs) = octant_of(&lookup, &term) {
+            return Ok(glyphs);
         }
 
         if let Some(glyphs) = lookup("TERM_PROGRAM")
@@ -361,6 +371,67 @@ impl Glyphs {
 /// here: a program not named returns nothing and falls through, because this is
 /// evidence about terminals somebody checked rather than a claim about the ones
 /// nobody has.
+/// The engines that draw the octant range themselves, by version.
+///
+/// **This is a rendering table, not a font table**, which is the correction
+/// `SPEC.md` §10 records: ghostty 1.2+, kitty 0.40+ and VTE 0.78+ rasterise
+/// U+1CD00 in the terminal, so the font is never consulted and "no font
+/// carries them" stops being the operative fact. The 2026 support matrix in
+/// `docs/research/318-drawing-vocabulary.md` §1.4 is the evidence, verified
+/// per terminal against its own source or release notes.
+///
+/// **foot is deliberately absent, and the absence is a decision.** foot 1.20+
+/// draws the range too, but foot exports no version signal at all, and a foot
+/// older than 1.20 (Debian stable ships one) takes octants from a font that
+/// does not have them. A bare-identity rung would hand tofu to exactly the
+/// readers who never chose anything. `VIGIA_GLYPHS=octant` stays one word
+/// away, and this table learns foot the day it exports a version.
+///
+/// **A multiplexer blanks the answer**: behind `tmux`/`screen` the outer
+/// terminal is invisible and glyph width tables can lag the Unicode the cell
+/// carries (tmux grew `codepoint-widths` overrides only in 3.6), so the rung
+/// is never chosen there. Braille is twenty years old and survives the same
+/// path unharmed.
+///
+/// **A version that cannot be parsed answers no**, which fails toward braille:
+/// the sparkline gets less density, never tofu.
+fn octant_of(lookup: &impl Fn(&str) -> Option<String>, term: &str) -> Option<Glyphs> {
+    if term.starts_with("tmux") || term.starts_with("screen") {
+        return None;
+    }
+    let version = |key: &str| lookup(key).and_then(|raw| version_of(&raw));
+    let program = lookup("TERM_PROGRAM")
+        .map(|p| p.trim().to_ascii_lowercase())
+        .unwrap_or_default();
+
+    if (program == "ghostty" || names(term, "xterm-ghostty"))
+        && version("TERM_PROGRAM_VERSION").is_some_and(|v| v >= (1, 2))
+    {
+        return Some(Glyphs::Octant);
+    }
+    if (program == "kitty" || names(term, "xterm-kitty"))
+        && version("TERM_PROGRAM_VERSION").is_some_and(|v| v >= (0, 40))
+    {
+        return Some(Glyphs::Octant);
+    }
+    // VTE's own convention: a single number, 7802 for 0.78.2. Carried by every
+    // VTE terminal (GNOME Terminal, Ptyxis, and the rest of that family).
+    if let Some(raw) = lookup("VTE_VERSION") {
+        if raw.trim().parse::<u32>().is_ok_and(|v| v >= 7800) {
+            return Some(Glyphs::Octant);
+        }
+    }
+    None
+}
+
+/// `"1.3.1-arch2"` to `(1, 3)`: the leading major and minor, or `None`.
+fn version_of(raw: &str) -> Option<(u32, u32)> {
+    let mut parts = raw.trim().split(['.', '-']);
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+    Some((major, minor))
+}
+
 fn program_glyphs(program: &str) -> Option<Glyphs> {
     // Lowercased because the values are brand names and are spelled as such.
     match program.to_ascii_lowercase().as_str() {

--- a/crates/vigia/tests/glyphs.rs
+++ b/crates/vigia/tests/glyphs.rs
@@ -7,11 +7,13 @@
 //! than by asserting each variable alone against an empty environment. That is
 //! `tests/colour.rs`'s shape and its reasoning is unchanged.
 //!
-//! **What this ladder has that the colour one does not** is a rung nothing can
-//! reach by detection at all. No font measured carries the Unicode 16 octants,
-//! so [`Glyphs::Octant`] is reachable only through [`GLYPHS_VAR`], and a sweep
-//! of the whole table asserting that is worth more than any single row: an
-//! accidental promotion would paint tofu on every terminal it reached.
+//! **What this ladder has that the colour one does not** is a rung that is
+//! never a font bet. No font measured carries the Unicode 16 octants, and the
+//! engines that draw them rasterise the range themselves (#324), so
+//! [`Glyphs::Octant`] is reachable only through [`GLYPHS_VAR`] or an engine
+//! naming itself *with a qualifying version*, and a sweep of the whole table
+//! asserting that is worth more than any single row: an accidental promotion
+//! would paint tofu on every terminal it reached.
 //!
 //! **The packing half is arithmetic**, and the property that matters most is not
 //! "a glyph came back". A packer that returned the full cell for everything
@@ -54,13 +56,14 @@ struct Row {
 /// Every row below the first sets the signals **above** it to something that
 /// would answer differently, so a rung that stopped being consulted in the right
 /// order fails here rather than in a screenshot.
-const TABLE: [Row; 12] = [
+const TABLE: [Row; 19] = [
     Row {
         why: "the override outranks every signal under it",
         windows: true,
         env: &[
             (GLYPHS_VAR, "block"),
             ("TERM_PROGRAM", "ghostty"),
+            ("TERM_PROGRAM_VERSION", "1.3.1"),
             ("WT_SESSION", "1"),
             ("TERM", "xterm-kitty"),
         ],
@@ -87,14 +90,76 @@ const TABLE: [Row; 12] = [
     Row {
         why: "a terminal saying it cannot draw takes the floor",
         windows: false,
-        env: &[("TERM", "dumb"), ("TERM_PROGRAM", "ghostty")],
+        env: &[
+            ("TERM", "dumb"),
+            ("TERM_PROGRAM", "ghostty"),
+            ("TERM_PROGRAM_VERSION", "1.3.1"),
+        ],
         want: Glyphs::Block,
     },
     Row {
         why: "the linux console has no braille in its bitmap font",
         windows: false,
-        env: &[("TERM", "linux"), ("TERM_PROGRAM", "ghostty")],
+        env: &[
+            ("TERM", "linux"),
+            ("TERM_PROGRAM", "ghostty"),
+            ("TERM_PROGRAM_VERSION", "1.3.1"),
+        ],
         want: Glyphs::Block,
+    },
+    Row {
+        why: "ghostty at 1.2+ draws octants itself, and says so with a version",
+        windows: false,
+        env: &[
+            ("TERM_PROGRAM", "ghostty"),
+            ("TERM_PROGRAM_VERSION", "1.3.1-arch2"),
+            ("TERM", "xterm-ghostty"),
+        ],
+        want: Glyphs::Octant,
+    },
+    Row {
+        why: "a ghostty before 1.2 takes octants from a font that lacks them",
+        windows: false,
+        env: &[
+            ("TERM_PROGRAM", "ghostty"),
+            ("TERM_PROGRAM_VERSION", "1.1.3"),
+            ("TERM", "xterm-ghostty"),
+        ],
+        want: Glyphs::Braille,
+    },
+    Row {
+        why: "kitty at 0.40+ draws octants itself",
+        windows: false,
+        env: &[("TERM", "xterm-kitty"), ("TERM_PROGRAM_VERSION", "0.42.1")],
+        want: Glyphs::Octant,
+    },
+    Row {
+        why: "a kitty with no version to show stays braille, which fails safe",
+        windows: false,
+        env: &[("TERM", "xterm-kitty")],
+        want: Glyphs::Braille,
+    },
+    Row {
+        why: "VTE says its version in its own convention, 7802 for 0.78.2",
+        windows: false,
+        env: &[("VTE_VERSION", "7802"), ("TERM", "xterm-256color")],
+        want: Glyphs::Octant,
+    },
+    Row {
+        why: "a VTE before 0.78 stays braille",
+        windows: false,
+        env: &[("VTE_VERSION", "7403"), ("TERM", "xterm-256color")],
+        want: Glyphs::Braille,
+    },
+    Row {
+        why: "a multiplexer hides the terminal, so the octant rung is never chosen behind one",
+        windows: false,
+        env: &[
+            ("TERM", "tmux-256color"),
+            ("TERM_PROGRAM", "ghostty"),
+            ("TERM_PROGRAM_VERSION", "1.3.1"),
+        ],
+        want: Glyphs::Braille,
     },
     Row {
         why: "a named program outranks the TERM under it",
@@ -163,25 +228,32 @@ fn an_override_that_is_not_a_rung_is_refused() {
 }
 
 #[test]
-fn detection_never_returns_octants() {
-    // **The sweep is the point, not any single row.** No font measured carries
-    // U+1CD00, including the newest Cascadia, so a signal that promoted to
-    // octants would paint tofu everywhere it reached and no gate over one
-    // terminal would see it. Every row of the table, on both platforms, with the
-    // override absent.
+fn octants_come_only_from_a_version_qualified_engine() {
+    // **The sweep is the point, not any single row**, and since
+    // [#324](https://github.com/breferrari/vigia/issues/324) its claim is
+    // narrower than the absolute it replaced: octants are never a *font* bet,
+    // so with the override and every engine-version signal stripped, no row of
+    // the table may promote. What remains reachable is exactly the engines
+    // that rasterise the range themselves, named with a qualifying version,
+    // which the positive rows above pin one by one. The old sweep said
+    // "detection never returns octants"; that sentence was a fact about fonts
+    // quoted as a fact about rendering, and SPEC.md section 10 carries the
+    // correction.
     for row in &TABLE {
         let stripped: Vec<(&str, &str)> = row
             .env
             .iter()
             .copied()
-            .filter(|(key, _)| *key != GLYPHS_VAR)
+            .filter(|(key, _)| {
+                *key != GLYPHS_VAR && *key != "TERM_PROGRAM_VERSION" && *key != "VTE_VERSION"
+            })
             .collect();
         for windows in [false, true] {
             let got = Glyphs::from_env(windows, env(&stripped)).expect("a rung");
             assert_ne!(
                 got,
                 Glyphs::Octant,
-                "{} on windows={windows} detected octants",
+                "{} on windows={windows} detected octants with no version to stand on",
                 row.why
             );
         }


### PR DESCRIPTION
Detection returns the octant rung on the engines that rasterise U+1CD00 themselves (SPEC 11.2 B18, the section-10 correction, #324). Plan comment: https://github.com/breferrari/vigia/issues/324#issuecomment-5418801624

## What shipped

- `octant_of` in `glyphs.rs`, a rendering table rather than a font table: ghostty 1.2+ (identity and version probed live on this machine: `TERM_PROGRAM=ghostty`, `TERM_PROGRAM_VERSION=1.3.1-arch2`), kitty 0.40+ (version parsed when present; absent fails safe to braille whichever release introduced the variable), VTE 0.78+ (`VTE_VERSION` numeric convention, 7802 is 0.78.2). The rung sits between the console floors and the braille rungs, and a multiplexer blanks it.
- **foot is deliberately absent and the absence is a decision recorded in the docblock**: foot 1.20+ draws the range but exports no version, and Debian stable ships an older foot whose font would draw tofu. The table learns foot the day it exports a version; `VIGIA_GLYPHS=octant` stays one word away.
- The old sweep `detection_never_returns_octants` was the exact sentence the section-10 correction dates, and it did not survive as written: it is now `octants_come_only_from_a_version_qualified_engine`, stripping the promoting signals and sweeping the whole table, with seven new positive and negative precedence rows (ghostty at 1.3 and 1.1, kitty with and without a version, VTE at 7802 and 7403, tmux blanking a qualified ghostty). The console floors and the override were re-proven above an engine that would otherwise promote.
- README's sparkline section says the true sentence now.

## Visual evidence

No new drawing: the octant tables shipped in #159, and `docs/research/assets/probe-foot.png` and `probe-ghostty.png` in the merged dossier already show the range rendering on this machine's terminals with a font that carries none of it. This build only lets detection say what those probes proved.

## Checks

glyphs suite 21 green (12-row precedence table grown to 19), full shell suite 31 binaries green, clippy clean. Docs-and-detection diff; no frame-path change, so no budget delta to quote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
