### PR TITLE
A path is a link (#326)

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,9 +415,12 @@ rail     = on     # the file list beside the diff, from 134 columns
 single   = on     # one file at a time
 staged   = on     # what is staged, beside what is not
 icons    = on     # a file-type glyph before every listed path (needs a Nerd Font)
+links    = off    # paths are clickable file:// links; this is the off switch
 ```
 
 Same shape as the theme file: one key per line, `#` for a comment, and a key it does not know is an error rather than a shrug. No file is the ordinary case. The keys still work, so a setting is a starting point rather than a decision: `s` gives the whole diff back for as long as you want it.
+
+**`links` is the one key that starts on**: every listed path is an OSC 8 hyperlink to its file, so a Ctrl+click (or however your terminal opens links) lands in your editor. A terminal that does not speak OSC 8 shows the same text and swallows the link, which is why nothing has to be detected and the key only exists to turn it off.
 
 **`follow` is deliberately not a key.** Following the newest change is what makes the pane correct without being touched, so it is not something to turn off in a file. `f` turns it off for a session, which is where that choice belongs.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -490,7 +490,7 @@ Milestone: [Phase 8](https://github.com/breferrari/vigia/milestone/8)
 | 🔨 | The chrome earns 2026: segmented bars, a spliced sheet title, opt-in icons | [#323](https://github.com/breferrari/vigia/issues/323) |
 | ✅ | The glyph ladder learns which terminals draw octants natively | [#324](https://github.com/breferrari/vigia/issues/324) |
 | ⬜ | The pane takes its colours from the terminal, and follows a theme flip live | [#325](https://github.com/breferrari/vigia/issues/325) |
-| ⬜ | A path is a link: OSC 8 on the list and the headings | [#326](https://github.com/breferrari/vigia/issues/326) |
+| 🔨 | A path is a link: OSC 8 on the list and the headings | [#326](https://github.com/breferrari/vigia/issues/326) |
 
 **[#313](https://github.com/breferrari/vigia/issues/313) was the next row to take and shipped 2026-08-25.** The pane could not see staged files at all, because `SPEC.md` §11.1's opening contract was the working tree against the index, so an agent that staged its own work emptied it. `a` now draws the staged run beside the unstaged one as two labelled runs, with the staged rows marked; the ruling is §11.2 **B17**, and the second half the issue left open (how to tell one from the other on screen) was ruled by the reader as a union rather than a swap. The default is unchanged and off, so [#50](https://github.com/breferrari/vigia/issues/50) is narrowed rather than answered.
 

--- a/crates/vigia/src/app.rs
+++ b/crates/vigia/src/app.rs
@@ -88,6 +88,8 @@ pub struct App {
     masthead: bool,
     /// Whether listed paths carry a file-type icon. Config only; no gesture.
     icons: bool,
+    /// Whether listed paths are OSC 8 hyperlinks. Config only; on by default.
+    links: bool,
     /// Whether the reader has asked for the pinned list beside the diff.
     ///
     /// **A request rather than a layout**, and the distinction is the one
@@ -331,6 +333,11 @@ impl Default for App {
             // Derived: an unpressed, unconfigured shell draws no icons, and off
             // is byte-identical to every version before the key existed.
             icons: false,
+            // On, which is `Config`'s own hand-written default and the one
+            // field of this pane whose absence-of-a-file state is not "off":
+            // OSC 8 degrades silently, so the link costs a reader nothing
+            // anywhere it is not understood (#326).
+            links: true,
             staged_files: 0,
             // Derived, and for once trivially so: nobody has pressed `?`.
             sheet: None,
@@ -396,6 +403,7 @@ impl App {
             single: config.single,
             staged: config.staged,
             icons: config.icons,
+            links: config.links,
             ..Self::new()
         }
     }
@@ -546,6 +554,7 @@ impl App {
         branch: Option<&str>,
         pointing: Pointing,
         elsewhere: usize,
+        root: &str,
     ) -> Chrome {
         let Pointing {
             pressed,
@@ -576,6 +585,8 @@ impl App {
             masthead: self.masthead,
             rail: self.rail,
             icons: self.icons,
+            links: self.links,
+            root: root.to_owned(),
             sheet: self.sheet,
             // `None` until a frame has completed, which is the honest first
             // paint: there is no p99 of nothing. The status bar simply has no
@@ -1576,6 +1587,7 @@ mod tests {
                 scrolling: Some((Grabbed::List, -1)),
             },
             0,
+            "",
         );
 
         assert_eq!(chrome.pressed, Some((79, 5)), "the pressed cell");
@@ -1599,13 +1611,13 @@ mod tests {
         // beside it would let this pass while the chrome dropped the field.
         let mut app = App::new();
         assert_eq!(
-            app.chrome("fixture", None, Pointing::default(), 0).mode,
+            app.chrome("fixture", None, Pointing::default(), 0, "").mode,
             Mode::Watching
         );
 
         app.watch_lost();
         assert_eq!(
-            app.chrome("fixture", None, Pointing::default(), 0).mode,
+            app.chrome("fixture", None, Pointing::default(), 0, "").mode,
             Mode::Lost
         );
 
@@ -1618,7 +1630,7 @@ mod tests {
         app.clear_notice();
         app.warn("a file vanished between being named and being read");
         assert_eq!(
-            app.chrome("fixture", None, Pointing::default(), 0).mode,
+            app.chrome("fixture", None, Pointing::default(), 0, "").mode,
             Mode::Lost
         );
     }
@@ -1630,13 +1642,14 @@ mod tests {
         // that nothing invents one when there is none.
         let app = App::new();
         assert_eq!(
-            app.chrome("fixture", Some("main"), Pointing::default(), 0)
+            app.chrome("fixture", Some("main"), Pointing::default(), 0, "")
                 .branch
                 .as_deref(),
             Some("main")
         );
         assert_eq!(
-            app.chrome("fixture", None, Pointing::default(), 0).branch,
+            app.chrome("fixture", None, Pointing::default(), 0, "")
+                .branch,
             None
         );
     }

--- a/crates/vigia/src/config.rs
+++ b/crates/vigia/src/config.rs
@@ -65,7 +65,7 @@ pub const CONFIG_FILE: &str = ".config/vigia/config";
 ///
 /// Four fields rather than a map, because the set is closed by a ruling and a
 /// map would let [`parse`] accept a key nothing reads.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Config {
     /// Draw the churn band at the top. `m`.
     pub masthead: bool,
@@ -105,6 +105,34 @@ pub struct Config {
     /// byte-identical to every version before it, which `tests/render.rs`
     /// holds as a buffer comparison.
     pub icons: bool,
+    /// Wrap every listed path in an OSC 8 hyperlink to its file. Config only.
+    ///
+    /// **The first key whose default is on**, and the reasoning is B18's
+    /// ([#326](https://github.com/breferrari/vigia/issues/326)): the 2026
+    /// support matrix shows OSC 8 degrading silently everywhere it is not
+    /// understood, so there is nothing to protect a reader from and the key
+    /// exists to turn a nicety off, not to discover it. That inverts this
+    /// struct's `Default`, which is now written by hand and says so.
+    pub links: bool,
+}
+
+/// Every toggle off and the links on, which is the shipped pane.
+///
+/// **Hand-written because `links` inverted the rule** the derive encoded: the
+/// derived `Default` was "everything off equals the pane every version drew",
+/// and `links` defaults on for its own field's reason. `App::new` and this must
+/// stay one answer; `tests/config.rs` pins the pair.
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            masthead: false,
+            rail: false,
+            single: false,
+            staged: false,
+            icons: false,
+            links: true,
+        }
+    }
 }
 
 /// Every key this file accepts, in the order the gestures sheet lists them.
@@ -130,7 +158,7 @@ pub struct Config {
 ///
 /// That is a gate and a runtime check rather than the type system, and saying so
 /// is the difference between a check and a claim that suppresses one.
-pub const KEYS: [&str; 5] = ["masthead", "rail", "single", "staged", "icons"];
+pub const KEYS: [&str; 6] = ["masthead", "rail", "single", "staged", "icons", "links"];
 
 impl Config {
     /// Set `key`, which [`parse`] has already checked is one of [`KEYS`].
@@ -156,6 +184,7 @@ impl Config {
             "single" => self.single = on,
             "staged" => self.staged = on,
             "icons" => self.icons = on,
+            "links" => self.links = on,
             _ => return false,
         }
         true

--- a/crates/vigia/src/lib.rs
+++ b/crates/vigia/src/lib.rs
@@ -500,6 +500,7 @@ pub fn run(path: &Path) -> Result<(), Failure> {
         theme,
         glyphs,
         name: short_name(worktree.workdir()),
+        root: worktree.workdir().to_string_lossy().into_owned(),
         branch: None,
         elsewhere: 0,
         screen: View::default(),
@@ -1145,6 +1146,9 @@ struct Shell {
     glyphs: Glyphs,
     /// What the header calls the working tree.
     name: String,
+    /// The worktree's absolute path, spelled once for the links' `file://`
+    /// targets ([#326](https://github.com/breferrari/vigia/issues/326)).
+    root: String,
     /// What the header calls the branch, or `None` when there is none to call.
     ///
     /// Refreshed per draw rather than held for the session, because an agent in
@@ -1325,6 +1329,7 @@ impl Shell {
             self.branch.as_deref(),
             self.pointing(),
             self.elsewhere,
+            &self.root,
         );
         let area = self.area()?;
         Ok(diff_height(
@@ -1640,6 +1645,7 @@ impl Shell {
             self.branch.as_deref(),
             self.pointing(),
             self.elsewhere,
+            &self.root,
         );
         let body = body_layout(
             self.area()?,
@@ -1715,6 +1721,7 @@ impl Shell {
             self.branch.as_deref(),
             self.pointing(),
             self.elsewhere,
+            &self.root,
         );
         // Borrowed out of `self` before the draw, not for style: the closure would
         // otherwise hold `&self` while `self.session` is borrowed mutably to reach

--- a/crates/vigia/src/render.rs
+++ b/crates/vigia/src/render.rs
@@ -1614,6 +1614,16 @@ pub struct Chrome {
     /// Whether listed paths carry a file-type icon, from the config file's
     /// `icons` key ([#323](https://github.com/breferrari/vigia/issues/323)).
     pub icons: bool,
+    /// Whether listed paths are OSC 8 hyperlinks, from the `links` key, on by
+    /// default ([#326](https://github.com/breferrari/vigia/issues/326)).
+    pub links: bool,
+    /// The worktree's absolute path, for the links' `file://` targets.
+    ///
+    /// **Empty means no links whatever `links` says**, which is also what
+    /// keeps every hand-built test fixture linkless without a flag to
+    /// remember: a URI with no root would point nowhere, and a link that
+    /// points nowhere is worse than the text alone.
+    pub root: String,
     /// What recent frames cost, which `SPEC.md` §5.1 rules is their p99.
     ///
     /// `None` on the very first paint, when no frame has completed to have a
@@ -4292,6 +4302,7 @@ pub fn render(
         scrolling: chrome.scrolling,
         spark_ramp: theme.spark_ramp(),
         icons: chrome.icons,
+        link_root: (chrome.links && !chrome.root.is_empty()).then(|| chrome.root.clone()),
     };
 
     painter.header(Rect { height: 1, ..area }, view, chrome);
@@ -5701,6 +5712,9 @@ struct Painter<'a> {
     spark_ramp: Option<[Color; 8]>,
     /// [`Chrome::icons`]: whether a listed path carries its type's glyph.
     icons: bool,
+    /// [`Chrome::links`] with [`Chrome::root`]: the `file://` prefix every
+    /// linked path shares, or `None` where links are off or rootless.
+    link_root: Option<String>,
 }
 
 impl Painter<'_> {
@@ -6049,6 +6063,50 @@ impl Painter<'_> {
             first = false;
             // Past this segment and the ` · ` that follows it.
             x = end.saturating_add(3);
+        }
+    }
+
+    /// Put `label` as one OSC 8 hyperlink to `root/path`, tui-link's shape.
+    ///
+    /// **One cell carries the whole wrapped string** with its width forced to
+    /// the label's, which is `CellDiffOption::ForcedWidth`'s documented job;
+    /// the covered cells behind it are reset so nothing stale can survive a
+    /// frame where the writer never visits them. A terminal without OSC 8
+    /// renders the label and swallows the wrapper, which the 2026 matrix
+    /// verified for every terminal it covers, and is why the `links` key
+    /// defaults on (#326).
+    fn put_linked(&mut self, x: u16, y: u16, label: &str, root: &str, path: &str, ink: Style) {
+        let width = width_of(label) as u16;
+        if width == 0 {
+            return;
+        }
+        let mut uri = String::with_capacity(root.len() + path.len() + 8);
+        uri.push_str("file://");
+        for half in [root, "/", path] {
+            for byte in half.bytes() {
+                match byte {
+                    b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => {
+                        uri.push(byte as char);
+                    }
+                    other => {
+                        uri.push('%');
+                        uri.push_str(&format!("{other:02X}"));
+                    }
+                }
+            }
+        }
+        let wrapped = format!("\x1b]8;;{uri}\x1b\\{label}\x1b]8;;\x1b\\");
+        for offset in 1..width {
+            if let Some(cell) = self.buf.cell_mut((x + offset, y)) {
+                cell.reset();
+            }
+        }
+        if let Some(cell) = self.buf.cell_mut((x, y)) {
+            cell.set_symbol(&wrapped);
+            cell.set_style(ink);
+            cell.diff_option = ratatui::buffer::CellDiffOption::ForcedWidth(
+                std::num::NonZeroU16::new(width).expect("width is checked nonzero above"),
+            );
         }
     }
 
@@ -7991,7 +8049,13 @@ impl Painter<'_> {
         } else {
             x
         };
-        self.put(x, area.y, &elide_head(label, room), room, ink);
+        let drawn = elide_head(label, room);
+        match self.link_root.clone() {
+            Some(root) => self.put_linked(x, area.y, &drawn, &root, heading.path, ink),
+            None => {
+                self.put(x, area.y, &drawn, room, ink);
+            }
+        }
     }
 
     /// Walk a line into styled runs, stopping at the pane's edge, and say
@@ -8642,6 +8706,7 @@ mod tests {
             scrolling,
             spark_ramp: None,
             icons: false,
+            link_root: None,
         };
         // Scrollable by a wide margin, so both bars draw a thumb well short of
         // their track and the arrows exist to be read.

--- a/crates/vigia/tests/budgets.rs
+++ b/crates/vigia/tests/budgets.rs
@@ -164,7 +164,7 @@ fn layout(app: &App, files: usize) -> Body {
 fn layout_of(app: &App, pane: Rect, files: usize) -> Body {
     body_layout(
         pane,
-        &app.chrome("fixture", None, Pointing::default(), 0),
+        &app.chrome("fixture", None, Pointing::default(), 0, ""),
         files,
         files,
     )
@@ -229,7 +229,7 @@ fn frame_body(
     screen: Body,
 ) {
     app.sample_memory();
-    let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+    let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
     let view = app.view(frame, highlighter, history, screen).expect("view");
     // **The pane comes from the buffer being painted rather than from
     // [`area`]** ([#252](https://github.com/breferrari/vigia/issues/252)). The two
@@ -410,7 +410,7 @@ fn the_timed_frame_draws_the_readouts_it_is_timing() {
         );
     }
 
-    let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+    let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
     assert!(
         chrome.frame.is_some(),
         "the timed frame never recorded what it cost, so every wall-clock gate \
@@ -858,7 +858,7 @@ fn frame_budget_on(
         // where the hint bar's `q quit` scored on every frame.
         let laid = vigia::regions(
             pane,
-            &app.chrome("fixture", None, Pointing::default(), 0),
+            &app.chrome("fixture", None, Pointing::default(), 0, ""),
             &app.view(&mut frame, &mut highlighter, &history, screen)
                 .expect("view"),
         );
@@ -1856,7 +1856,7 @@ fn scroll(name: &str, setup: Scroll) -> Option<Scrolled> {
             app.view(&mut frame, &mut highlighter, &history, screen)
                 .expect("view")
         });
-        let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+        let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
         let (painted, paint, paint_cpu) = timed_cpu(|| {
             render(
                 &mut buf,
@@ -2381,7 +2381,7 @@ fn sheet_size_on(name: &str, pane: Rect) -> (u16, u16) {
     let screen = layout_of(&app, pane, FILES);
     app.apply(vigia::Action::ToggleSheet, &mut frame, screen.diff)
         .expect("toggle the sheet");
-    let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+    let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
     let laid = vigia::regions(pane, &chrome, &{
         let mut highlighter = Highlighter::eager();
         let history = History::new();

--- a/crates/vigia/tests/config.rs
+++ b/crates/vigia/tests/config.rs
@@ -90,7 +90,7 @@ fn no_file_is_not_an_error_and_is_todays_pane() {
 /// It takes no area because `App::chrome` is width-independent; the first draft
 /// took one and ignored it, which read as a sweep and was not.
 fn chrome_of(app: &App) -> (bool, bool, bool, Option<usize>) {
-    let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+    let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
     (chrome.masthead, chrome.rail, chrome.following, chrome.sheet)
 }
 
@@ -157,6 +157,8 @@ fn each_key_sets_the_state_the_pane_starts_in() {
             single: true,
             staged: false,
             icons: false,
+            // Untouched by the file, so the hand-written default holds: on.
+            links: true,
         }
     );
 
@@ -181,6 +183,7 @@ fn the_key_still_toggles_from_the_configured_state() {
         single: true,
         staged: false,
         icons: false,
+        links: false,
     };
     let mut app = App::configured(config);
 
@@ -348,6 +351,8 @@ fn comments_and_blank_lines_and_a_byte_order_mark_are_all_survivable() {
             single: true,
             staged: false,
             icons: false,
+            // Untouched by the file, so the hand-written default holds: on.
+            links: true,
         }
     );
 
@@ -447,7 +452,7 @@ fn a_railed_default_below_the_arrival_width_keeps_the_request() {
         rail: true,
         ..Config::default()
     });
-    let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+    let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
     assert!(chrome.rail, "the file's request did not reach the chrome");
 
     let narrow = body_layout(Rect::new(0, 0, 100, 30), &chrome, 6, 6);
@@ -492,6 +497,7 @@ fn the_configured_pane_is_the_pane_the_keys_would_have_made() {
         rail: true,
         single: true,
         staged: true,
+        links: false,
         icons: false,
     });
 
@@ -519,7 +525,7 @@ fn the_configured_pane_is_the_pane_the_keys_would_have_made() {
     // `App::configured` left all 945 tests green.
     let body = diff_height(
         Rect::new(0, 0, 80, 24),
-        &configured.chrome("fixture", None, Pointing::default(), 0),
+        &configured.chrome("fixture", None, Pointing::default(), 0, ""),
         6,
         6,
     );
@@ -567,6 +573,7 @@ fn every_key_is_a_field_and_every_field_is_a_key() {
             rail: true,
             single: true,
             staged: true,
+            links: true,
             icons: true,
         },
         "setting every key in KEYS did not set every field, so the two have drifted"
@@ -576,14 +583,17 @@ fn every_key_is_a_field_and_every_field_is_a_key() {
     // say.** A name in `KEYS` with no arm in `Config::set` used to parse to
     // `Ok(Config::default())`: the key existed, the file was accepted, and the
     // setting did nothing. The comparison above cannot see it either, because an
-    // extra dead key leaves the all-true result unchanged. `assert_ne` against the
-    // default is what makes the drift red.
+    // extra dead key leaves the all-true result unchanged. **Compared as
+    // on-against-off rather than against the default since #326**, because
+    // `links` defaults on and `links = on` is legitimately the default spelled
+    // out; a dead arm still cannot make the two spellings differ.
     for key in vigia::config::KEYS {
-        let got = config::parse(&format!("{key} = on\n"))
+        let lit = config::parse(&format!("{key} = on\n"))
+            .unwrap_or_else(|why| panic!("KEYS names {key:?} and parse refuses it: {why}"));
+        let unlit = config::parse(&format!("{key} = off\n"))
             .unwrap_or_else(|why| panic!("KEYS names {key:?} and parse refuses it: {why}"));
         assert_ne!(
-            got,
-            Config::default(),
+            lit, unlit,
             "{key:?} is in KEYS and setting it changed nothing, so KEYS and \
              Config::set have drifted"
         );

--- a/crates/vigia/tests/first_paint.rs
+++ b/crates/vigia/tests/first_paint.rs
@@ -121,7 +121,7 @@ fn cold_start(root: &std::path::Path) -> FirstPaint {
     let mut app = App::new();
     let history = History::new();
 
-    let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+    let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
     let body = body_layout(area(), &chrome, frame.files().len(), frame.files().len());
     let theme = Theme::default();
     let mut buf = Buffer::empty(area());
@@ -155,7 +155,7 @@ fn cold_start(root: &std::path::Path) -> FirstPaint {
     let view = app
         .view(&mut frame, &mut highlighter, &history, body)
         .expect("view");
-    let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+    let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
     render(&mut buf, area(), &view, &theme, Glyphs::default(), &chrome);
     let second = began.elapsed();
     let parsed_second = highlight_delta(before, highlighter.stats()).lines;
@@ -418,7 +418,7 @@ fn the_opening_frames_never_compile_a_grammar_the_warmer_has_not_reached() {
     let mut app = App::new();
     let history = History::new();
     let theme = Theme::default();
-    let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+    let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
     let body = body_layout(area(), &chrome, frame.files().len(), frame.files().len());
     let mut buf = Buffer::empty(area());
 

--- a/crates/vigia/tests/follow.rs
+++ b/crates/vigia/tests/follow.rs
@@ -48,7 +48,7 @@ const OTHER: usize = 21;
 fn layout() -> Body {
     body_layout(
         Rect::new(0, 0, 80, 24),
-        &App::new().chrome("fixture", None, Pointing::default(), 0),
+        &App::new().chrome("fixture", None, Pointing::default(), 0, ""),
         FILES,
         FILES,
     )
@@ -202,7 +202,7 @@ fn a_scripted_edit_sequence_draws_the_file_that_changed_last() {
     let area = Rect::new(0, 0, 64, 12);
     let height = body_layout(
         area,
-        &app.chrome("fixture", None, Pointing::default(), 0),
+        &app.chrome("fixture", None, Pointing::default(), 0, ""),
         frame.files().len(),
         frame.files().len(),
     );
@@ -212,7 +212,7 @@ fn a_scripted_edit_sequence_draws_the_file_that_changed_last() {
     assert_eq!(view.files, 3, "the fixture is not three changed files");
 
     let theme = Theme::default();
-    let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+    let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
     let mut terminal = Terminal::new(TestBackend::new(64, 12)).expect("terminal");
     terminal
         .draw(|f| {
@@ -559,7 +559,7 @@ const CUT_HUNK_LINES: u32 = CUT_LINES as u32 + vigia_core::CONTEXT * 2;
 fn tall_layout(app: &App) -> Body {
     body_layout(
         Rect::new(0, 0, 80, 24),
-        &app.chrome("fixture", None, Pointing::default(), 0),
+        &app.chrome("fixture", None, Pointing::default(), 0, ""),
         1,
         1,
     )
@@ -877,7 +877,7 @@ fn a_tick_that_follows_nothing_drops_the_landing_the_one_before_it_armed() {
 
     let layout = body_layout(
         Rect::new(0, 0, 80, 24),
-        &app.chrome("fixture", None, Pointing::default(), 0),
+        &app.chrome("fixture", None, Pointing::default(), 0, ""),
         frame.files().len(),
         frame.files().len(),
     );
@@ -1051,7 +1051,7 @@ fn an_advance_that_renumbers_the_files_drops_a_landing_armed_before_it() {
 
     let layout = body_layout(
         Rect::new(0, 0, 80, 24),
-        &app.chrome("fixture", None, Pointing::default(), 0),
+        &app.chrome("fixture", None, Pointing::default(), 0, ""),
         frame.files().len(),
         frame.files().len(),
     );
@@ -1131,7 +1131,7 @@ fn a_refused_landing_is_settled_rather_than_deferred() {
 
     let layout = body_layout(
         Rect::new(0, 0, 80, 24),
-        &app.chrome("fixture", None, Pointing::default(), 0),
+        &app.chrome("fixture", None, Pointing::default(), 0, ""),
         frame.files().len(),
         frame.files().len(),
     );
@@ -1205,7 +1205,7 @@ fn a_landing_above_a_hunkless_tail_leaves_no_blank_rows() {
     let history = History::new();
     let layout = body_layout(
         Rect::new(0, 0, 80, 24),
-        &app.chrome("fixture", None, Pointing::default(), 0),
+        &app.chrome("fixture", None, Pointing::default(), 0, ""),
         frame.files().len(),
         frame.files().len(),
     );

--- a/crates/vigia/tests/legibility.rs
+++ b/crates/vigia/tests/legibility.rs
@@ -561,6 +561,8 @@ fn chrome() -> Chrome {
         // case that draws none since #158.
         staged: None,
         icons: false,
+        links: false,
+        root: String::new(),
         elsewhere: 0,
         branch: None,
         mode: Mode::Watching,

--- a/crates/vigia/tests/list.rs
+++ b/crates/vigia/tests/list.rs
@@ -85,7 +85,7 @@ const MANY: usize = 500;
 const DEEP: u16 = 50;
 
 fn chrome(app: &App) -> vigia::Chrome {
-    app.chrome("fixture", None, Pointing::default(), 0)
+    app.chrome("fixture", None, Pointing::default(), 0, "")
 }
 
 /// The same, with the rail asked for.
@@ -732,7 +732,7 @@ fn the_region_at_fifty_files() {
         let area = ratatui::layout::Rect::new(0, 0, 80, 24);
         let body = body_layout(
             area,
-            &app.chrome("vigia", None, Pointing::default(), 0),
+            &app.chrome("vigia", None, Pointing::default(), 0, ""),
             FILES,
             FILES,
         );
@@ -742,7 +742,7 @@ fn the_region_at_fifty_files() {
 
         let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal");
         let theme = Theme::default();
-        let chrome = app.chrome("vigia", None, Pointing::default(), 0);
+        let chrome = app.chrome("vigia", None, Pointing::default(), 0, "");
         terminal
             .draw(|f| {
                 let area = f.area();
@@ -1831,7 +1831,7 @@ fn the_scroll_step_is_measured_in_the_height_the_paint_uses() {
 
     let chrome = vigia::Chrome {
         staged: Some(3),
-        ..vigia::App::new().chrome("fixture", None, vigia::Pointing::default(), 0)
+        ..vigia::App::new().chrome("fixture", None, vigia::Pointing::default(), 0, "")
     };
     // Both derived from the changed set the way `Shell::diff_rows_for` and
     // `Shell::paint` derive them, which is what the two seams now do by

--- a/crates/vigia/tests/masthead.rs
+++ b/crates/vigia/tests/masthead.rs
@@ -93,7 +93,7 @@ fn area() -> Rect {
 }
 
 fn chrome(app: &App) -> Chrome {
-    app.chrome("fixture", None, Pointing::default(), 0)
+    app.chrome("fixture", None, Pointing::default(), 0, "")
 }
 
 #[test]
@@ -202,7 +202,7 @@ fn the_branch_stays_on_a_pane_with_no_masthead() {
     let mut app = App::new();
     let mut highlighter = Highlighter::eager();
     let history = History::new();
-    let drawn = app.chrome("fixture", Some(BRANCH), Pointing::default(), 0);
+    let drawn = app.chrome("fixture", Some(BRANCH), Pointing::default(), 0, "");
     assert!(
         !drawn.masthead,
         "the fixture asked for a masthead, so this proves nothing about a pane without one"

--- a/crates/vigia/tests/observe.rs
+++ b/crates/vigia/tests/observe.rs
@@ -912,9 +912,13 @@ impl Pane<'_> {
         // branch*; the header names it always, so the guard's premise went and
         // the wrapper with it.
         self.branch = worktree.branch();
-        let chrome = self
-            .app
-            .chrome(&self.name, self.branch.as_deref(), Pointing::default(), 0);
+        let chrome = self.app.chrome(
+            &self.name,
+            self.branch.as_deref(),
+            Pointing::default(),
+            0,
+            "",
+        );
         self.body = body_layout(
             self.area,
             &chrome,
@@ -936,9 +940,13 @@ impl Pane<'_> {
                 self.app.warn(e.to_string());
             }
         }
-        let chrome = self
-            .app
-            .chrome(&self.name, self.branch.as_deref(), Pointing::default(), 0);
+        let chrome = self.app.chrome(
+            &self.name,
+            self.branch.as_deref(),
+            Pointing::default(),
+            0,
+            "",
+        );
         let _regions = regions(self.area, &chrome, &self.view);
         render(
             &mut self.buffer,
@@ -954,7 +962,13 @@ impl Pane<'_> {
     /// see it.
     fn readout(&self) -> Option<Duration> {
         self.app
-            .chrome(&self.name, self.branch.as_deref(), Pointing::default(), 0)
+            .chrome(
+                &self.name,
+                self.branch.as_deref(),
+                Pointing::default(),
+                0,
+                "",
+            )
             .frame
     }
 }

--- a/crates/vigia/tests/paint.rs
+++ b/crates/vigia/tests/paint.rs
@@ -81,7 +81,7 @@ fn painted(name: &str, ext: &str, width: u16, height: u16) -> Painted {
     let mut highlighter = Highlighter::eager();
     let history = History::new();
     let area = Rect::new(0, 0, width, height);
-    let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+    let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
     let screen = body_layout(area, &chrome, FILES, FILES);
     let rows = screen.diff;
     let view = app
@@ -371,7 +371,7 @@ fn a_row_of_zero_width_characters_still_costs_the_pane() {
         files: 1,
         ..View::default()
     };
-    let chrome = App::new().chrome("fixture", None, Pointing::default(), 0);
+    let chrome = App::new().chrome("fixture", None, Pointing::default(), 0, "");
     let mut buf = Buffer::empty(area);
     let stats = render(
         &mut buf,
@@ -436,7 +436,7 @@ fn a_tab_stop_after_the_bound_still_counts_from_the_line_start() {
         gripped: None,
         scrolling: None,
         worktree: "fixture".to_owned(),
-        ..App::new().chrome("fixture", None, Pointing::default(), 0)
+        ..App::new().chrome("fixture", None, Pointing::default(), 0, "")
     };
     let mut buf = Buffer::empty(area);
     render(
@@ -497,7 +497,7 @@ fn a_gesture_costs_one_screenful_however_many_events_it_arrived_as() {
         let mut app = App::past_first_paint();
         let mut highlighter = Highlighter::eager();
         let history = History::new();
-        let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+        let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
         let screen = body_layout(area, &chrome, BURST_FILES, BURST_FILES);
         let rows = screen.diff;
         let mut buf = Buffer::empty(area);

--- a/crates/vigia/tests/palette.rs
+++ b/crates/vigia/tests/palette.rs
@@ -70,6 +70,8 @@ fn chrome() -> Chrome {
         rail: false,
         sheet: None,
         icons: false,
+        links: false,
+        root: String::new(),
         frame: None,
         memory: None,
     }

--- a/crates/vigia/tests/rail.rs
+++ b/crates/vigia/tests/rail.rs
@@ -154,7 +154,7 @@ fn chrome() -> Chrome {
 
 /// A shell that has not asked, which is what ships.
 fn stacked_chrome() -> Chrome {
-    App::new().chrome("fixture", None, Pointing::default(), 0)
+    App::new().chrome("fixture", None, Pointing::default(), 0, "")
 }
 
 /// A file with a full history and a full heat strip, so every glance element has
@@ -1357,11 +1357,24 @@ fn r_asks_for_the_rail_and_r_puts_it_back() {
     );
 
     let wide = Rect::new(0, 0, 160, TALL);
-    let railed =
-        |app: &App| body_layout(wide, &app.chrome("f", None, Pointing::default(), 0), 3, 3).rail;
+    let railed = |app: &App| {
+        body_layout(
+            wide,
+            &app.chrome("f", None, Pointing::default(), 0, ""),
+            3,
+            3,
+        )
+        .rail
+    };
     assert!(!railed(&app), "a fresh shell drew a rail");
 
-    let height = body_layout(wide, &app.chrome("f", None, Pointing::default(), 0), 3, 3).diff;
+    let height = body_layout(
+        wide,
+        &app.chrome("f", None, Pointing::default(), 0, ""),
+        3,
+        3,
+    )
+    .diff;
     app.apply(Action::ToggleRail, &mut frame, height)
         .expect("toggle");
     assert!(railed(&app), "`r` did not put the list beside the diff");
@@ -1407,7 +1420,8 @@ fn r_below_the_arrival_width_changes_nothing_and_eats_no_gesture() {
     repo::materialise(&mut frame);
     let mut app = App::new();
     let wide = Rect::new(0, 0, arrives, TALL);
-    let of = |app: &App, at| body_layout(at, &app.chrome("f", None, Pointing::default(), 0), 3, 3);
+    let of =
+        |app: &App, at| body_layout(at, &app.chrome("f", None, Pointing::default(), 0, ""), 3, 3);
 
     let height = of(&app, wide).diff;
     app.apply(Action::ToggleRail, &mut frame, height)
@@ -1459,12 +1473,12 @@ fn asking_for_the_rail_keeps_the_row_the_diff_was_on() {
     let mut highlighter = vigia_core::Highlighter::eager();
     let history = vigia_core::History::new();
 
-    let height = body_layout(at, &app.chrome("f", None, Pointing::default(), 0), 3, 3).diff;
+    let height = body_layout(at, &app.chrome("f", None, Pointing::default(), 0, ""), 3, 3).diff;
     app.apply(Action::Scroll(30), &mut frame, height)
         .expect("scroll");
 
     let mut top_row = |app: &mut App, frame: &mut vigia_core::Frame<'_>| -> String {
-        let chrome = app.chrome("f", None, Pointing::default(), 0);
+        let chrome = app.chrome("f", None, Pointing::default(), 0, "");
         let body = body_layout(at, &chrome, 3, 3);
         let view = app
             .view(frame, &mut highlighter, &history, body)
@@ -1494,7 +1508,7 @@ fn asking_for_the_rail_keeps_the_row_the_diff_was_on() {
     // because the two rows are then identical and a string is trivially a prefix
     // of itself. Found by mutation.
     assert!(
-        body_layout(at, &app.chrome("f", None, Pointing::default(), 0), 3, 3).rail,
+        body_layout(at, &app.chrome("f", None, Pointing::default(), 0, ""), 3, 3).rail,
         "the toggle did not reach the layout, so the comparison below is between \
          two stacked frames"
     );
@@ -1533,7 +1547,7 @@ fn r_reaches_the_painted_screen_and_not_only_the_layout() {
     let at = Rect::new(0, 0, 160, TALL);
 
     let mut shape = |app: &mut App, frame: &mut vigia_core::Frame<'_>| -> (u16, u16) {
-        let chrome = app.chrome("f", None, Pointing::default(), 0);
+        let chrome = app.chrome("f", None, Pointing::default(), 0, "");
         let body = body_layout(at, &chrome, 3, 3);
         let view = app
             .view(frame, &mut highlighter, &history, body)
@@ -1545,7 +1559,7 @@ fn r_reaches_the_painted_screen_and_not_only_the_layout() {
     };
 
     let stacked = shape(&mut app, &mut frame);
-    let height = body_layout(at, &app.chrome("f", None, Pointing::default(), 0), 3, 3).diff;
+    let height = body_layout(at, &app.chrome("f", None, Pointing::default(), 0, ""), 3, 3).diff;
     app.apply(Action::ToggleRail, &mut frame, height)
         .expect("toggle");
     let beside = shape(&mut app, &mut frame);
@@ -1601,7 +1615,7 @@ fn a_rail_draws_the_tail_of_the_staged_run() {
     let chrome = Chrome {
         rail: true,
         staged: Some(3),
-        ..App::new().chrome("fixture", None, Pointing::default(), 0)
+        ..App::new().chrome("fixture", None, Pointing::default(), 0, "")
     };
     let body = body_layout(
         at,

--- a/crates/vigia/tests/reads.rs
+++ b/crates/vigia/tests/reads.rs
@@ -130,7 +130,7 @@ const RAIL_WIDTH: u16 = 160;
 fn layout_on(width: u16, height: u16) -> Body {
     body_layout(
         Rect::new(0, 0, width, height),
-        &railed(App::new().chrome("fixture", None, Pointing::default(), 0)),
+        &railed(App::new().chrome("fixture", None, Pointing::default(), 0, "")),
         FILES,
         FILES,
     )

--- a/crates/vigia/tests/render.rs
+++ b/crates/vigia/tests/render.rs
@@ -309,6 +309,8 @@ fn chrome() -> Chrome {
         // which `lib.rs`'s `branch_for` gates.
         staged: None,
         icons: false,
+        links: false,
+        root: String::new(),
         elsewhere: 0,
         branch: None,
         mode: Mode::Watching,
@@ -7993,6 +7995,78 @@ fn the_chrome_wears_pills_at_truecolour_and_none_below() {
         assert!(
             !pills.contains(&buffer[(x, 0)].bg),
             "a pill survived below truecolour at column {x}"
+        );
+    }
+}
+
+/// #326: a linked path is one cell carrying the whole OSC 8 wrapper with its
+/// width forced to the label's, tui-link's shape; rootless or switched off it
+/// is exactly the plain cells it always was.
+#[test]
+fn a_linked_path_is_one_cell_carrying_the_uri() {
+    let view = View {
+        rows: vec![
+            file("src/engine/watch.rs", 42, 7),
+            file("src/we ird%.rs", 1, 0),
+        ],
+        files: 2,
+        ..two_regions(2)
+    };
+    let mut shown = chrome();
+    shown.links = true;
+    shown.root = "/home/reader/tree".to_owned();
+    let theme = vigia::Theme::dark();
+    let backend = themed_screen(64, 18, &view, &shown, &theme);
+    let buffer = backend.buffer();
+
+    let row = (0..18u16)
+        .find(|y| (0..64u16).any(|x| buffer[(x, *y)].symbol().contains("watch.rs")))
+        .expect("the linked path was not drawn");
+    let (x, cell) = (0..64u16)
+        .map(|x| (x, &buffer[(x, row)]))
+        .find(|(_, c)| c.symbol().contains("watch.rs"))
+        .expect("fixture");
+    let symbol = cell.symbol();
+    assert!(
+        symbol.contains("\x1b]8;;file:///home/reader/tree/src/engine/watch.rs\x1b\\"),
+        "the cell does not open the link: {symbol:?}"
+    );
+    assert!(
+        symbol.ends_with("\x1b]8;;\x1b\\"),
+        "the cell does not close the link: {symbol:?}"
+    );
+    // The width the cell forces is the label's: the fixture's label is the
+    // path spelled whole, nineteen columns of ASCII.
+    assert_eq!(
+        cell.diff_option,
+        ratatui::buffer::CellDiffOption::ForcedWidth(
+            std::num::NonZeroU16::new("src/engine/watch.rs".len() as u16).expect("nonzero")
+        ),
+        "the forced width is not the label's"
+    );
+    assert_eq!(
+        buffer[(x + 1, row)].symbol(),
+        " ",
+        "the covered cell behind the link is not blank"
+    );
+
+    // Encoding: the space and the percent are escaped, nothing else invented.
+    let odd = (0..18u16)
+        .flat_map(|y| (0..64u16).map(move |x| (x, y)))
+        .map(|(x, y)| buffer[(x, y)].symbol().to_owned())
+        .find(|s| s.contains("ird%25.rs"))
+        .expect("the odd path was not linked");
+    assert!(
+        odd.contains("file:///home/reader/tree/src/we%20ird%25.rs"),
+        "the URI is not minimally encoded: {odd:?}"
+    );
+
+    // And the default fixture, rootless, draws not one escape anywhere.
+    let plain = washed_screen(64, 18, &view, &chrome());
+    for y in 0..18u16 {
+        assert!(
+            !row_text(&plain, y).contains('\x1b'),
+            "a rootless chrome leaked an escape into row {y}"
         );
     }
 }

--- a/crates/vigia/tests/rows.rs
+++ b/crates/vigia/tests/rows.rs
@@ -441,7 +441,7 @@ fn a_real_repository_draws() {
     // picture of a screen nobody gets.
     let split = body_layout(
         area,
-        &app.chrome("fixture", None, Pointing::default(), 0),
+        &app.chrome("fixture", None, Pointing::default(), 0, ""),
         frame.files().len(),
         frame.files().len(),
     );
@@ -459,7 +459,7 @@ fn a_real_repository_draws() {
     );
 
     let theme = Theme::default();
-    let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+    let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
     terminal
         .draw(|f| {
             let area = f.area();
@@ -555,7 +555,7 @@ fn a_recorded_tick_reaches_the_drawn_sparkline() {
     let area = Rect::new(0, 0, 80, 12);
     let split = body_layout(
         area,
-        &app.chrome("fixture", None, Pointing::default(), 0),
+        &app.chrome("fixture", None, Pointing::default(), 0, ""),
         frame.files().len(),
         frame.files().len(),
     );
@@ -586,7 +586,7 @@ fn a_recorded_tick_reaches_the_drawn_sparkline() {
     );
 
     let theme = Theme::default();
-    let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+    let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
     terminal
         .draw(|f| {
             let drawn = f.area();
@@ -687,7 +687,7 @@ fn every_rung_draws_from_the_stores_own_figures() {
         let mut app = App::new();
         let mut terminal = Terminal::new(TestBackend::new(pane, 12)).expect("terminal");
         let area = Rect::new(0, 0, pane, 12);
-        let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+        let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
         let split = body_layout(area, &chrome, frame.files().len(), frame.files().len());
         let view = app
             .view(&mut frame, &mut highlighter, &history, split)

--- a/crates/vigia/tests/scroll.rs
+++ b/crates/vigia/tests/scroll.rs
@@ -50,7 +50,7 @@ fn body() -> usize {
     // scroll arithmetic below is not entangled with I6's two-line footer.
     diff_height(
         Rect::new(0, 0, 80, 24),
-        &App::new().chrome("fixture", None, Pointing::default(), 0),
+        &App::new().chrome("fixture", None, Pointing::default(), 0, ""),
         FILES,
         FILES,
     )
@@ -76,7 +76,7 @@ fn split() -> Body {
 fn listed() -> Body {
     body_layout(
         Rect::new(0, 0, 80, 24),
-        &App::new().chrome("fixture", None, Pointing::default(), 0),
+        &App::new().chrome("fixture", None, Pointing::default(), 0, ""),
         FILES,
         FILES,
     )

--- a/crates/vigia/tests/sheet.rs
+++ b/crates/vigia/tests/sheet.rs
@@ -87,7 +87,7 @@ fn area() -> Rect {
 }
 
 fn chrome(app: &App) -> Chrome {
-    app.chrome("fixture", Some("main"), Pointing::default(), 0)
+    app.chrome("fixture", Some("main"), Pointing::default(), 0, "")
 }
 
 fn press(code: KeyCode) -> Event {
@@ -889,6 +889,7 @@ fn drawn_close(
             ..Pointing::default()
         },
         0,
+        "",
     );
     let body = body_layout(area(), &chrome, FILES, FILES);
     let view = app

--- a/crates/vigia/tests/single.rs
+++ b/crates/vigia/tests/single.rs
@@ -56,7 +56,7 @@ const PINNED: usize = 2;
 fn body() -> usize {
     diff_height(
         Rect::new(0, 0, 80, 24),
-        &App::new().chrome("fixture", None, Pointing::default(), 0),
+        &App::new().chrome("fixture", None, Pointing::default(), 0, ""),
         FILES,
         FILES,
     )
@@ -75,7 +75,7 @@ fn split() -> Body {
 fn listed() -> Body {
     body_layout(
         Rect::new(0, 0, 80, 24),
-        &App::new().chrome("fixture", None, Pointing::default(), 0),
+        &App::new().chrome("fixture", None, Pointing::default(), 0, ""),
         FILES,
         FILES,
     )
@@ -406,7 +406,7 @@ fn n_p_a_digit_and_a_click_still_change_the_file() {
     let area = Rect::new(0, 0, 80, 24);
     let laid = regions(
         area,
-        &app.chrome("fixture", None, Pointing::default(), 0),
+        &app.chrome("fixture", None, Pointing::default(), 0, ""),
         &view,
     );
     assert!(
@@ -954,7 +954,7 @@ fn a_pinned_pane_draws_and_its_bar_is_the_files() {
     let mut app = pinned(&mut frame);
 
     let at = Rect::new(0, 0, 80, 24);
-    let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+    let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
     let laid = body_layout(at, &chrome, FILES, FILES);
     let view = app
         .view(&mut frame, &mut highlighter, &history, laid)
@@ -1037,7 +1037,7 @@ fn the_pin_and_the_rail_do_not_fight() {
     let at = Rect::new(0, 0, 160, 30);
     app.apply(Action::ToggleRail, &mut frame, body())
         .expect("apply");
-    let chrome = app.chrome("fixture", None, Pointing::default(), 0);
+    let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
     let laid = body_layout(at, &chrome, FILES, FILES);
     assert!(
         laid.rail,
@@ -1225,12 +1225,12 @@ fn a_pinned_end_key_rests_on_the_bottom_at_every_width() {
 
         // Exactly what the shell does: size the body from the chrome as it
         // stands, apply, then lay out and draw from the chrome as it ends up.
-        let before = app.chrome("fixture", None, Pointing::default(), 0);
+        let before = app.chrome("fixture", None, Pointing::default(), 0, "");
         let height = body_layout(at, &before, FILES, FILES).diff;
         app.apply(Action::Bottom, &mut frame, height)
             .expect("apply");
 
-        let after = app.chrome("fixture", None, Pointing::default(), 0);
+        let after = app.chrome("fixture", None, Pointing::default(), 0, "");
         let laid = body_layout(at, &after, FILES, FILES);
         if laid.diff == 0 || laid.diff >= SPAN {
             continue;

--- a/crates/vigia/tests/soak.rs
+++ b/crates/vigia/tests/soak.rs
@@ -1217,7 +1217,7 @@ fn drive(
         }
 
         if let Some(action) = scripted(frames, body.diff) {
-            let chrome = app.chrome(NAME, None, Pointing::default(), 0);
+            let chrome = app.chrome(NAME, None, Pointing::default(), 0, "");
             let height = diff_height(area, &chrome, frame.files().len(), frame.files().len());
             if let Err(e) = app.apply(action, &mut frame, height) {
                 failed += 1;
@@ -1243,7 +1243,7 @@ fn drive(
         // `record_frame` is at the bottom of the loop, where the frame ends.
         let frame_began = Instant::now();
         app.sample_memory();
-        let chrome = app.chrome(NAME, None, Pointing::default(), 0);
+        let chrome = app.chrome(NAME, None, Pointing::default(), 0, "");
         body = body_layout(area, &chrome, frame.files().len(), frame.files().len());
         match app.view(&mut frame, &mut highlighter, &history, body) {
             Ok(fresh) => {

--- a/crates/vigia/tests/viewport.rs
+++ b/crates/vigia/tests/viewport.rs
@@ -38,7 +38,7 @@ const SPAN: usize = 4;
 fn body() -> usize {
     diff_height(
         Rect::new(0, 0, 80, 24),
-        &App::new().chrome("fixture", None, Pointing::default(), 0),
+        &App::new().chrome("fixture", None, Pointing::default(), 0, ""),
         FILES,
         FILES,
     )

--- a/crates/vigia/tests/writes.rs
+++ b/crates/vigia/tests/writes.rs
@@ -521,7 +521,7 @@ impl Rig<'_> {
     /// those mid-sequence. `budgets.rs` hoists its own because nothing in its loop
     /// changes either term.
     fn paint(&mut self) -> usize {
-        let chrome = self.app.chrome("fixture", None, Pointing::default(), 0);
+        let chrome = self.app.chrome("fixture", None, Pointing::default(), 0, "");
         let body = body_layout(
             area(),
             &chrome,


### PR DESCRIPTION
A path is a link (SPEC 11.2 B18, #326). Plan comment: https://github.com/breferrari/vigia/issues/326#issuecomment-5419048149

## What shipped

- `Painter::put_linked`: the elided path label goes into one cell as the full OSC 8 wrapper with `CellDiffOption::ForcedWidth` set to the label's width, tui-link's proven shape (its source read during planning; Codex CLI ships the same). Covered cells are reset behind it. Minimal percent-encoding, verified on a path carrying a space and a percent.
- `Chrome` gains `root` (the worktree's absolute path, from the session) and `links` (the config key). **An empty root draws no links**, which keeps every hand-built fixture linkless with no flag to remember.
- The config file gains `links`, **the first key whose default is on**: the 2026 matrix shows OSC 8 degrading silently everywhere (Konsole ships it off and loses only the link; old tmux swallows the OSC whole), so the key exists to turn a nicety off. `Config::Default` is hand-written now and its docblock carries the ruling; the every-key drift gate was reworked to compare on-against-off, because "on" is legitimately the default for this key.
- README documents the key and what clicking does.

## Checks

Full shell suite 31 binaries green, including the new gate (`a_linked_path_is_one_cell_carrying_the_uri`: wrapper shape, forced width, blank covered cells, encoding, and the rootless screen carrying not one escape). clippy clean. The click itself needs a hand on a mouse; the wrapper bytes and width honesty are what the gates can hold, and they do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
