### PR TITLE
The slate simplifies (#318)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,6 +37,8 @@ Milestone: [Phase 1](https://github.com/breferrari/vigia/milestone/1)
 
 Prove `gix` before anything is built on top, since everything sits on it. No TUI.
 
+**[#337](https://github.com/breferrari/vigia/issues/337) was shelved the day it was filed, 2026-08-26, and the reason is the rule rather than the severity.** It is an instrument defect (the macOS leg of the watch suite failing three different ways in one day, on three diffs that touch no watch code), and `CLAUDE.md` files instrument findings to the shelf so the queue serves the product rather than the mirror. It is also, unusually, *blocking*: PR #336 could not merge behind it. What that licenses is an unblock sized to the blockage and nothing more, which is what the #318 pass did: file the evidence, say so in the report, and leave the diagnosis to a pass that takes it deliberately. It is the exception the rule already names, taken as the rule describes.
+
 | | Task | Issue |
 |---|---|---|
 | ✅ | `gix` gives working-tree-vs-index diffs at fidelity and speed | closed by the Phase 1 spike, evidence in `SPEC.md` §10 |
@@ -620,6 +622,7 @@ Everything on the deferral shelf below has a milestone here, so shelved work is 
 | | Task | Issue |
 |---|---|---|
 | ✅ | A symlink diffs as its target's contents, and on Windows was never reusable | [#15](https://github.com/breferrari/vigia/issues/15) |
+| ⬜ | The macOS watch suite fails three different ways under CI load, and it is blocking merges | [#337](https://github.com/breferrari/vigia/issues/337) |
 | ⬜ | The caret row's weight is the one modifier a theme file cannot reach | [#195](https://github.com/breferrari/vigia/issues/195) |
 | ⬜ | The sheet's tables are audited, not derived, so the keymap can still drift into them | [#312](https://github.com/breferrari/vigia/issues/312) |
 | ⬜ | The fingerprint cannot see a timestamp-preserving write | [#16](https://github.com/breferrari/vigia/issues/16) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -489,10 +489,10 @@ Milestone: [Phase 8](https://github.com/breferrari/vigia/milestone/8)
 | ✅ | The glance ramps become gradients and the band goes with them | [#322](https://github.com/breferrari/vigia/issues/322) |
 | ✅ | The chrome earns 2026: segmented bars, a spliced sheet title, opt-in icons | [#323](https://github.com/breferrari/vigia/issues/323) |
 | ✅ | The glyph ladder learns which terminals draw octants natively | [#324](https://github.com/breferrari/vigia/issues/324) |
-| 🔨 | The pane takes its colours from the terminal, and follows a theme flip live | [#325](https://github.com/breferrari/vigia/issues/325) |
+| ✅ | The pane takes its colours from the terminal, and follows a theme flip live | [#325](https://github.com/breferrari/vigia/issues/325) |
 | ⬜ | A theme flip mid-session cannot reach the shell, and the blocker is crossterm's parser | [#332](https://github.com/breferrari/vigia/issues/332) |
 | ⬜ | A system palette built from the terminal's own colours | [#333](https://github.com/breferrari/vigia/issues/333) |
-| 🔨 | A path is a link: OSC 8 on the list and the headings | [#326](https://github.com/breferrari/vigia/issues/326) |
+| ✅ | A path is a link: OSC 8 on the list and the headings | [#326](https://github.com/breferrari/vigia/issues/326) |
 
 **[#313](https://github.com/breferrari/vigia/issues/313) was the next row to take and shipped 2026-08-25.** The pane could not see staged files at all, because `SPEC.md` §11.1's opening contract was the working tree against the index, so an agent that staged its own work emptied it. `a` now draws the staged run beside the unstaged one as two labelled runs, with the staged rows marked; the ruling is §11.2 **B17**, and the second half the issue left open (how to tell one from the other on screen) was ruled by the reader as a union rather than a swap. The default is unchanged and off, so [#50](https://github.com/breferrari/vigia/issues/50) is narrowed rather than answered.
 

--- a/crates/vigia-core/src/emphasis.rs
+++ b/crates/vigia-core/src/emphasis.rs
@@ -53,11 +53,11 @@ pub type Emphasis = Vec<Range<u32>>;
 /// (the tail of the longer run, pairs past [`TOKEN_CAP`], pairs outside
 /// [`MAX_DISTANCE`]) get an empty emphasis, which the shell draws as the
 /// whole-line wash it always drew.
-pub fn mark(removed: &[&str], added: &[&str]) -> (Vec<Emphasis>, Vec<Emphasis>) {
+pub fn mark<S: AsRef<str>>(removed: &[S], added: &[S]) -> (Vec<Emphasis>, Vec<Emphasis>) {
     let mut out_removed = vec![Vec::new(); removed.len()];
     let mut out_added = vec![Vec::new(); added.len()];
     for i in 0..removed.len().min(added.len()) {
-        if let Some((r, a)) = pair(removed[i], added[i]) {
+        if let Some((r, a)) = pair(removed[i].as_ref(), added[i].as_ref()) {
             out_removed[i] = r;
             out_added[i] = a;
         }
@@ -92,13 +92,13 @@ fn pair(removed: &str, added: &str) -> Option<(Emphasis, Emphasis)> {
 /// Byte ranges of the tokens whose indices are *not* in `shared`, adjacent
 /// ranges merged so one edit reads as one patch rather than confetti.
 fn unshared(tokens: &[Range<u32>], shared: impl Iterator<Item = usize>) -> Emphasis {
-    let mut keep = vec![true; tokens.len()];
-    for index in shared {
-        keep[index] = false;
-    }
+    // `lcs` emits its indices in strictly ascending order (prefix, middle
+    // walk, then the suffix loop reversed back to ascending), so membership is
+    // one peek rather than a bool table per pair.
+    let mut shared = shared.peekable();
     let mut out: Emphasis = Vec::new();
     for (index, range) in tokens.iter().enumerate() {
-        if !keep[index] {
+        if shared.next_if_eq(&index).is_some() {
             continue;
         }
         match out.last_mut() {

--- a/crates/vigia-core/src/hunk.rs
+++ b/crates/vigia-core/src/hunk.rs
@@ -40,7 +40,7 @@ pub struct Line {
     /// Meaning rather than styling, which is why it lives here: `SPEC.md`
     /// §11.1 has the engine emit meanings and the shell colour them, and
     /// *these bytes are the change inside the change* is a meaning.
-    pub emph: Vec<std::ops::Range<u32>>,
+    pub emph: crate::emphasis::Emphasis,
 }
 
 /// A contiguous run of changes plus its surrounding context.
@@ -332,10 +332,7 @@ pub(crate) fn compute(path: String, before: &[u8], after: &[u8]) -> FileDiff {
             // so the frame path inherits the ranges for free.
             let removed_texts: Vec<String> = raw.before.clone().map(&line_before).collect();
             let added_texts: Vec<String> = raw.after.clone().map(&line_after).collect();
-            let (removed_emph, added_emph) = crate::emphasis::mark(
-                &removed_texts.iter().map(String::as_str).collect::<Vec<_>>(),
-                &added_texts.iter().map(String::as_str).collect::<Vec<_>>(),
-            );
+            let (removed_emph, added_emph) = crate::emphasis::mark(&removed_texts, &added_texts);
             for (text, emph) in removed_texts.into_iter().zip(removed_emph) {
                 lines.push(Line {
                     kind: LineKind::Removed,

--- a/crates/vigia/Cargo.toml
+++ b/crates/vigia/Cargo.toml
@@ -35,7 +35,6 @@ exclude = ["tests/**"]
 ratatui.workspace = true
 vigia-core.workspace = true
 
-
 # Here and not in `vigia-core`, because the memory readout is a drawn thing:
 # SPEC.md section 6 keeps the core free of anything the shell decides, and a
 # number that exists to be painted is the shell's. Linux is deliberately absent

--- a/crates/vigia/src/glyphs.rs
+++ b/crates/vigia/src/glyphs.rs
@@ -353,24 +353,6 @@ impl Glyphs {
         CLIMB[level] << col
     }
 }
-
-/// What `TERM_PROGRAM` names, and whether that terminal's font has braille.
-///
-/// **Deliberately a separate table from
-/// `colour.rs`'s `program_depth`, and the entries coinciding
-/// today is not a reason to share one.** The criterion is different: that one
-/// asks how many colours a terminal draws, this one asks what its font carries.
-/// `Apple_Terminal` is the proof rather than a hypothetical, because it already
-/// answers differently on the two ladders: it is the one entry there that is
-/// *not* truecolour, and it is braille here, since Menlo and SF Mono both carry
-/// U+2800. A shared table returning one rung could not express that, and a
-/// shared table of *names* would silently gain a wrong entry the first time
-/// somebody adds a terminal to the other list for the other reason.
-///
-/// **Only positive answers**, which is that table's discipline and matters more
-/// here: a program not named returns nothing and falls through, because this is
-/// evidence about terminals somebody checked rather than a claim about the ones
-/// nobody has.
 /// The engines that draw the octant range themselves, by version.
 ///
 /// **This is a rendering table, not a font table**, which is the correction
@@ -404,15 +386,18 @@ fn octant_of(lookup: &impl Fn(&str) -> Option<String>, term: &str) -> Option<Gly
         .map(|p| p.trim().to_ascii_lowercase())
         .unwrap_or_default();
 
-    if (program == "ghostty" || names(term, "xterm-ghostty"))
-        && version("TERM_PROGRAM_VERSION").is_some_and(|v| v >= (1, 2))
-    {
-        return Some(Glyphs::Octant);
-    }
-    if (program == "kitty" || names(term, "xterm-kitty"))
-        && version("TERM_PROGRAM_VERSION").is_some_and(|v| v >= (0, 40))
-    {
-        return Some(Glyphs::Octant);
+    // One row per engine that self-draws the range and says which version it
+    // is, so the table the docblock promises to grow grows by a row. `foot`
+    // joins the day it exports a version; see above for why not before.
+    for (named, term_entry, floor) in [
+        ("ghostty", "xterm-ghostty", (1, 2)),
+        ("kitty", "xterm-kitty", (0, 40)),
+    ] {
+        if (program == named || names(term, term_entry))
+            && version("TERM_PROGRAM_VERSION").is_some_and(|v| v >= floor)
+        {
+            return Some(Glyphs::Octant);
+        }
     }
     // VTE's own convention: a single number, 7802 for 0.78.2. Carried by every
     // VTE terminal (GNOME Terminal, Ptyxis, and the rest of that family).
@@ -432,6 +417,23 @@ fn version_of(raw: &str) -> Option<(u32, u32)> {
     Some((major, minor))
 }
 
+/// What `TERM_PROGRAM` names, and whether that terminal's font has braille.
+///
+/// **Deliberately a separate table from
+/// `colour.rs`'s `program_depth`, and the entries coinciding
+/// today is not a reason to share one.** The criterion is different: that one
+/// asks how many colours a terminal draws, this one asks what its font carries.
+/// `Apple_Terminal` is the proof rather than a hypothetical, because it already
+/// answers differently on the two ladders: it is the one entry there that is
+/// *not* truecolour, and it is braille here, since Menlo and SF Mono both carry
+/// U+2800. A shared table returning one rung could not express that, and a
+/// shared table of *names* would silently gain a wrong entry the first time
+/// somebody adds a terminal to the other list for the other reason.
+///
+/// **Only positive answers**, which is that table's discipline and matters more
+/// here: a program not named returns nothing and falls through, because this is
+/// evidence about terminals somebody checked rather than a claim about the ones
+/// nobody has.
 fn program_glyphs(program: &str) -> Option<Glyphs> {
     // Lowercased because the values are brand names and are spelled as such.
     match program.to_ascii_lowercase().as_str() {

--- a/crates/vigia/src/icons.rs
+++ b/crates/vigia/src/icons.rs
@@ -29,25 +29,45 @@
 pub const GENERIC: char = '\u{f016}';
 
 /// The glyph for `path`, by its extension or well-known name.
+///
+/// The extension comes from [`std::path::Path::extension`], the same rule
+/// `vigia-core` already applies to these git-relative paths, so the two
+/// cannot disagree: a file *named* `rs` has no extension and takes the
+/// generic mark, and a dotfile's leading dot is a stem, not a separator.
+/// Nothing here allocates, because this runs once per drawn file row.
 pub fn icon_of(path: &str) -> char {
     let name = path.rsplit('/').next().unwrap_or(path);
-    let lower = name.to_ascii_lowercase();
-    if lower.starts_with(".git") {
+    if name
+        .get(..4)
+        .is_some_and(|p| p.eq_ignore_ascii_case(".git"))
+    {
         return '\u{e702}';
     }
-    let extension = lower.rsplit('.').next().unwrap_or_default();
-    match extension {
-        "rs" => '\u{e7a8}',
-        "js" | "mjs" | "cjs" => '\u{e74e}',
-        "ts" | "tsx" | "jsx" => '\u{e628}',
-        "py" => '\u{e73c}',
-        "rb" => '\u{e739}',
-        "java" => '\u{e738}',
-        "sh" | "bash" | "zsh" | "fish" => '\u{f489}',
-        "md" | "markdown" => '\u{f48a}',
-        "json" => '\u{e60b}',
-        "toml" | "yaml" | "yml" | "ini" | "conf" => '\u{e615}',
-        "lock" => '\u{e60b}',
+    let Some(extension) = std::path::Path::new(name)
+        .extension()
+        .and_then(|e| e.to_str())
+    else {
+        return GENERIC;
+    };
+    // Lowercased into a stack buffer: the longest key is `markdown`, eight
+    // bytes, and anything longer is the generic mark before any copying.
+    let mut lower = [0u8; 8];
+    if extension.len() > lower.len() || !extension.is_ascii() {
+        return GENERIC;
+    }
+    lower[..extension.len()].copy_from_slice(extension.as_bytes());
+    lower[..extension.len()].make_ascii_lowercase();
+    match &lower[..extension.len()] {
+        b"rs" => '\u{e7a8}',
+        b"js" | b"mjs" | b"cjs" => '\u{e74e}',
+        b"ts" | b"tsx" | b"jsx" => '\u{e628}',
+        b"py" => '\u{e73c}',
+        b"rb" => '\u{e739}',
+        b"java" => '\u{e738}',
+        b"sh" | b"bash" | b"zsh" | b"fish" => '\u{f489}',
+        b"md" | b"markdown" => '\u{f48a}',
+        b"json" | b"lock" => '\u{e60b}',
+        b"toml" | b"yaml" | b"yml" | b"ini" | b"conf" => '\u{e615}',
         _ => GENERIC,
     }
 }
@@ -63,5 +83,9 @@ mod tests {
         assert_eq!(icon_of(".gitignore"), '\u{e702}');
         assert_eq!(icon_of("assets/blob.bin"), GENERIC);
         assert_eq!(icon_of("no-extension"), GENERIC);
+        // A file *named* like an extension has none, which is the rule this
+        // shares with the core's own `Path::extension` use.
+        assert_eq!(icon_of("src/rs"), GENERIC);
+        assert_eq!(icon_of("SRC/MAIN.RS"), '\u{e7a8}', "case folds");
     }
 }

--- a/crates/vigia/src/render.rs
+++ b/crates/vigia/src/render.rs
@@ -4896,6 +4896,13 @@ const SHEET_FRAME: usize = 2;
 /// What the sheet's own title bar spells, corner excluded.
 const SHEET_TITLE: &str = "─ gestures ";
 
+/// What the rounded rungs splice into the top border, `┐` and `┌` either side.
+///
+/// The same word [`SHEET_TITLE`] carries without its rule, spelled once so the
+/// border string, the styled overwrite and the width arithmetic cannot drift
+/// ([#323](https://github.com/breferrari/vigia/issues/323)).
+const SHEET_SPLICE: &str = " gestures ";
+
 /// What the mouse group's heading spells, spaces included.
 const SHEET_MOUSE_LABEL: &str = " mouse ";
 
@@ -6037,7 +6044,12 @@ impl Painter<'_> {
         let text = self.text_area(area);
         let mut x = text.x;
         let mut first = true;
-        for segment in drawn.split(" · ") {
+        // Split and advanced by [`FACT_SEPARATOR`] itself rather than by a
+        // second spelling of it: `header_left` joins with that constant, and
+        // two literals that agree today are exactly what its own docblock
+        // warns about. A separator that changed would otherwise leave this
+        // painting pills over the wrong cells with nothing failing.
+        for segment in drawn.split(FACT_SEPARATOR) {
             let width = width_of(segment) as u16;
             let end = x
                 .saturating_add(width)
@@ -6052,17 +6064,17 @@ impl Painter<'_> {
             };
             // One cell of padding either side where the separator's spaces
             // are, clamped to the text area, so a pill breathes without a
-            // character being added anywhere.
-            let from = x.saturating_sub(1).max(text.x);
-            let to = end.saturating_add(1).min(text.x.saturating_add(text.width));
-            for cell in from..to {
-                if let Some(cell) = self.buf.cell_mut((cell, area.y)) {
-                    cell.set_style(pill);
-                }
-            }
+            // character being added anywhere. Through `chip_span`, so both
+            // pill painters clip through one expression.
+            self.chip_span(
+                Rect { y: area.y, ..text },
+                x.saturating_sub(1).max(text.x),
+                end.saturating_add(1),
+                pill,
+            );
             first = false;
-            // Past this segment and the ` · ` that follows it.
-            x = end.saturating_add(3);
+            // Past this segment and the separator that follows it.
+            x = end.saturating_add(width_of(FACT_SEPARATOR) as u16);
         }
     }
 
@@ -6178,10 +6190,11 @@ impl Painter<'_> {
         // the same inputs and the same picker, so the two cannot disagree
         // about which words are on the row.
         let text = self.text_area(area);
-        let room =
-            usize::from(text.width).saturating_sub(width_of(right).min(usize::from(text.width)));
-        let drawn = widest_fitting_or_last(&rungs, room).to_owned();
-        self.chip_row(area, &drawn);
+        // `saturating_sub` already floors at zero, so clamping the subtrahend
+        // to the width first was a no-op.
+        let room = usize::from(text.width).saturating_sub(width_of(right));
+        let drawn = widest_fitting_or_last(&rungs, room);
+        self.chip_row(area, drawn);
     }
 
     /// The footer, on the bottom one or two rows of `area`.
@@ -6518,6 +6531,9 @@ impl Painter<'_> {
         // its dot rows less the baseline, and [`Glyphs::glyph`] already spells
         // both, floor included: level zero is the axis rather than nothing.
         let levels = rung.levels();
+        // The ramp's top row index, invariant across every cell and row of
+        // this band rather than recomputed inside both loops.
+        let top = rows.saturating_sub(1).max(1);
 
         for cell in 0..width {
             // A dense cell carries two sub-columns, left older than right, which
@@ -6552,14 +6568,14 @@ impl Painter<'_> {
                 // btop's own rule (#322): the baseline draws the quiet stop and
                 // the top row the hot one, one style per row, so the graph
                 // reads hotter as it climbs while costing one lookup. Without a
-                // ramp the column's band draws as it always did.
-                let ink = match self.spark_ramp.as_ref() {
-                    Some(ramp) => {
-                        let top = rows.saturating_sub(1).max(1);
-                        self.theme.spark_at(band).fg(ramp[(row * 7 / top).min(7)])
-                    }
-                    None => self.theme.spark_at(band),
-                };
+                // ramp the column's band draws as it always did. Written the
+                // way [`Bucket::drawn`] writes the same rule one screen away:
+                // the band's style keeps whatever modifier a theme set and the
+                // stop overrides only the ink.
+                let mut ink = self.theme.spark_at(band);
+                if let Some(ramp) = self.spark_ramp.as_ref() {
+                    ink = ink.fg(ramp[(row * 7 / top).min(7)]);
+                }
                 self.bar_cell(x, y, glyph, ink);
             }
         }
@@ -7203,10 +7219,15 @@ impl Painter<'_> {
         if rounded {
             top.push('╭');
             top.push('┐');
-            top.push_str(" gestures ");
+            top.push_str(SHEET_SPLICE);
             top.push_str(&counter);
             top.push('┌');
-            for _ in 0..width.saturating_sub(13 + width_of(&counter) + 4) {
+            // Corner, splice brackets, the title, the counter, then the three
+            // cells the control sits in and the closing corner: the same
+            // sixteen fixed cells the square spelling costs, which is what
+            // keeps every width rung where it was.
+            let fixed = 3 + width_of(SHEET_SPLICE) + width_of(&counter) + 4;
+            for _ in 0..width.saturating_sub(fixed) {
                 top.push(RULE);
             }
             top.push_str("   ╮");
@@ -7227,7 +7248,13 @@ impl Painter<'_> {
             // The spliced word in the chrome's own weight, over the border's
             // reserved gap: the splice is what makes the title read as a label
             // on the box rather than a break in it.
-            self.put(area.x + 2, area.y, " gestures ", 10, lit);
+            self.put(
+                area.x + 2,
+                area.y,
+                SHEET_SPLICE,
+                width_of(SHEET_SPLICE),
+                lit,
+            );
         }
         // **The control takes a hover rung, which is what says it is clickable.**
         // B10's ladder, minus its top rung: chrome at rest and [`Theme::bar_hover`]
@@ -8074,8 +8101,7 @@ impl Painter<'_> {
         text: &str,
         spans: &[Span],
         content: usize,
-        word: Option<Color>,
-        emph: &[std::ops::Range<u32>],
+        emphasis: Option<(Color, &[std::ops::Range<u32>])>,
     ) -> bool {
         let mut column = 0usize;
         let mut at = 0usize;
@@ -8100,8 +8126,7 @@ impl Painter<'_> {
                 span.class,
                 &mut column,
                 content,
-                word,
-                emph,
+                emphasis,
             ) {
                 return true;
             }
@@ -8127,8 +8152,7 @@ impl Painter<'_> {
                 Class::Plain,
                 &mut column,
                 content,
-                word,
-                emph,
+                emphasis,
             );
         }
         false
@@ -8153,14 +8177,16 @@ impl Painter<'_> {
         class: Class,
         column: &mut usize,
         content: usize,
-        word: Option<Color>,
-        emph: &[std::ops::Range<u32>],
+        emphasis: Option<(Color, &[std::ops::Range<u32>])>,
     ) -> bool {
         let plain = |painter: &mut Self, runs: &mut Vec<(String, Style)>, column: &mut usize| {
             let piece = text.get(range.start..range.end).unwrap_or_default();
             painter.push_run(runs, piece, class, column, content, None)
         };
-        let Some(word) = word.filter(|_| !emph.is_empty()) else {
+        // The colour and the ranges are one value: a patch with no ranges is
+        // not a patch, so the pairing is in the type rather than in a filter
+        // every caller has to remember.
+        let Some((word, emph)) = emphasis.filter(|(_, emph)| !emph.is_empty()) else {
             return plain(self, runs, column);
         };
         let mut at = range.start;
@@ -8331,11 +8357,9 @@ impl Painter<'_> {
                 LineKind::Removed => self.theme.removed_gutter,
                 LineKind::Context => Style::new(),
             };
-            let numbered_style = match tone.bg {
-                Some(_) => self.theme.gutter.patch(tone),
-                None => self.theme.gutter,
-            };
-            x = self.put(x, area.y, &numbered, room, numbered_style);
+            // `patch` on an unset style is the identity, so the context row
+            // and the palettes that draw no tone need no arm of their own.
+            x = self.put(x, area.y, &numbered, room, self.theme.gutter.patch(tone));
             room = room.saturating_sub(gutter + 1);
         }
 
@@ -8430,12 +8454,13 @@ impl Painter<'_> {
         // the resolved theme, so the depth ladder has already decided whether
         // it survives: below truecolour the background is gone and `word` is
         // `None` by the same rule that blanked the wash.
-        let word = match kind {
+        let emphasis = match kind {
             LineKind::Added => self.theme.added_word.bg,
             LineKind::Removed => self.theme.removed_word.bg,
             LineKind::Context => None,
-        };
-        let clipped = self.content_runs(&mut runs, text, spans, content, word, emph);
+        }
+        .map(|word| (word, emph));
+        let clipped = self.content_runs(&mut runs, text, spans, content, emphasis);
         self.paint.rows += 1;
 
         // Content is the one thing that can neither break nor elide: wrapping it


### PR DESCRIPTION
The `/simplify` sweep the look-and-feel sizing rule owes the B18 slate (#318), plus the tracker rows the merges left behind.

Four review agents read the merged slate (6383600..065ffac plus #335) for reuse, simplification, efficiency and altitude. 18 findings applied, 6 skipped with reasons.

## Applied

**Correctness-adjacent, found as cleanup.** `icon_of` split extensions with `rsplit('.')`, so a file *named* `rs`, `md` or `lock` drew that language's icon; it now uses `Path::extension`, the rule `vigia-core` already applies to these paths, and two new cases pin it. The rounded sheet's `" gestures "` was spelled three times with the width baked into a magic `13`; it is `SHEET_SPLICE` once, with the arithmetic derived. `chip_row` split on a second literal `" · "` beside `FACT_SEPARATOR`, which is exactly the drift that constant's own docblock warns about; it splits and advances by the constant now.

**Allocation on the frame path.** `Painter.link_root` was an owned `String` cloned once per frame and again per file row; it borrows from the chrome. The percent-encoder allocated a `String` per escaped byte, the icon mark a `String` per row, and the header rung a `String` per frame: all gone. `icon_of` lowercased the whole filename per row; it lowercases at most eight bytes into a stack buffer. `emphasis::mark` is generic over `AsRef<str>`, so `hunk.rs` stops building two bridging `Vec<&str>` per change block, and `unshared` replaced its per-pair bool table with a peekable walk over indices that were already ascending.

**Shape.** `content_runs`/`push_split` took a colour and its ranges as two arguments and immediately fused them; they take `Option<(Color, &[Range<u32>])>`. The gutter's `match tone.bg` special-cased what `Style::patch` already owns. `chip_row` now paints through `chip_span`, so one clip expression serves both pills. The band hoists its loop-invariant top index and matches `Bucket::drawn`'s shape. `octant_of`'s two engine arms are a table, so the docblock's promise to grow by a row is true. The `emph` field takes the `Emphasis` alias. `washed_screen` delegates to `themed_screen`.

**And one real defect this pass introduced and this pass fixed:** the octant block had been inserted between `program_glyphs`'s docblock and its function, orphaning the comment onto the wrong item. Pure relocation, no text changed.

## Skipped, with reasons

- **Caching the spark ramp at theme resolution.** Real: about 45 transcendental ops per frame for a session constant. Every clean fix ripples through a public struct and ~30 fixtures, for roughly a microsecond of a 16ms frame. Out of proportion to a cleanup pass; recorded as an efficiency row in the vault instead.
- **Reusing gix-imara-diff for the word-level LCS.** A maintenance-surface argument, not a cost one: the tokenizer and the distance bound stay either way, and the module's shape was adopted from delta deliberately. Not a cleanup.
- Four smaller ones where the fix would have folded load-bearing comments or changed intended behaviour.

## Checks

45 test suites green (31 shell binaries, 13 core, plus the lib), clippy clean, fmt clean. No behaviour changed; every gate that would notice (the pill gates, the wash gates, the sheet's 50, the icon alignment gate) passed untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
