### PR TITLE
The README's ladders and the picture catch up (#318)

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,10 +311,10 @@ Three independent settings decide how the pane is **drawn**, and most confusion 
 
 | | First answer wins |
 |---|---|
-| 🎨 **Palette** | `VIGIA_THEME` (a name, or a path) → `~/.config/vigia/theme` → `ansi` |
+| 🎨 **Palette** | `VIGIA_THEME` (a name, or a path) → `~/.config/vigia/theme` → **your terminal's own background** → `ansi` |
 | 🔦 **Depth** | `VIGIA_COLOR` → `NO_COLOR` → `TERM=dumb` → `COLORTERM` → `TERM_PROGRAM` → `TERM` → 16 |
-| ✏️ **Glyphs** | `VIGIA_GLYPHS` → `TERM=dumb`/`linux` → `TERM_PROGRAM` → `WT_SESSION` → `TERM` → braille, or blocks on a bare Windows console |
-| 🪟 **View** | `~/.config/vigia/config` → everything off |
+| ✏️ **Glyphs** | `VIGIA_GLYPHS` → `TERM=dumb`/`linux` → **an engine that draws octants and names its version** → `TERM_PROGRAM` → `WT_SESSION` → `TERM` → braille, or blocks on a bare Windows console |
+| 🪟 **View** | `~/.config/vigia/config` → everything off, except `links` |
 
 ```sh
 VIGIA_THEME=ansi     # the fallback: the sixteen names, inherited from your scheme
@@ -461,11 +461,11 @@ Built in the open, spec first. [`SPEC.md`](SPEC.md) is the source of truth and i
 
 <br>
 
-**It is a mockup, not a screenshot**, and `VIGIA_THEME=dark` is what draws it. All of it draws today: the header, the blank row under it, the pinned list, the counters in green and red, the sparklines, the heat bars, the caret and the bold path that goes with it, the pulse, the scrollbar with its step buttons, the tinted rows and their left bars, the highlighted diff, and the status bar.
+**It is a mockup, not a screenshot**, and `VIGIA_THEME=dark` is what draws it. All of it draws today: the header and the pills its facts sit in, the blank row under it, the pinned list, the counters in green and red, the sparklines, the heat bars, the caret and the bold path that goes with it, the pulse, the scrollbar with its step buttons, the tinted rows with their left bars and their gutter tones, the highlighted diff, and the status bar.
 
 **The picture is a specification here, not decoration.** `SPEC.md` §5.1 rules that where the mockup answers a question the spec left open, the mockup *is* the answer, so every disagreement between it and the binary is either a bug or a departure somebody wrote down. **One is left**: the header reads the worktree's name rather than `vigia`, because a title bar spends six of forty columns telling you which program you started, and what you cannot tell by looking is which tree.
 
-Everything else that disagreed was the picture being behind, and it has been brought forward: the status bar's hints, the position beside the follow marker, the branch, the caret standing on the pane's own edge, the diff's heading drawing the same row as the list above it, and the row's right-hand order, which now places the pulse, heat strip, sparkline and counters where the binary places them.
+Everything else that disagreed was the picture being behind, and it has been brought forward: the status bar's hints, the position beside the follow marker, the branch, the caret standing on the pane's own edge, the diff's heading drawing the same row as the list above it, and the row's right-hand order, which now places the pulse, heat strip, sparkline and counters where the binary places them. **Two more came forward in August 2026**: the header's facts wear their pills, and the sparklines are drawn in the cyan the binary has used since the ramp landed rather than the green they were first mocked in, which is the ruling that green already means *added* two rows down.
 
 </details>
 

--- a/assets/preview.svg
+++ b/assets/preview.svg
@@ -16,6 +16,14 @@
   <g clip-path="url(#win)">
     <!-- title bar -->
     <rect x="8" y="8" width="884" height="46" fill="#161b22"/>
+    <!-- #323: the header's facts wear pills, the loud one on the first
+         segment and the quiet one on the rest, with the separators left on the
+         bar between them. Drawn before the text so the words sit on top, and
+         only at truecolour: the depth ladder drops these backgrounds with
+         every other one, which is why this is the `dark` picture. -->
+    <rect x="94" y="16" width="58" height="30" rx="6" fill="#173042"/>
+    <rect x="160" y="16" width="51" height="30" rx="6" fill="#21262d"/>
+    <rect x="220" y="16" width="92" height="30" rx="6" fill="#21262d"/>
     <circle cx="34" cy="31" r="6" fill="#f85149"/>
     <circle cx="54" cy="31" r="6" fill="#e3b341"/>
     <circle cx="74" cy="31" r="6" fill="#3fb950"/>
@@ -59,14 +67,14 @@
         <rect x="696.5" y="82" width="7" height="8" rx="2" fill="#21262d"/>
       </g>
       <g>
-        <rect x="712.7" y="86" width="7" height="4" rx="1.5" fill="#1f6f3f"/>
-        <rect x="720.8" y="82" width="7" height="8" rx="1.5" fill="#2a8f4f"/>
-        <rect x="728.9" y="76" width="7" height="14" rx="1.5" fill="#3fb950"/>
-        <rect x="737.0" y="70" width="7" height="20" rx="1.5" fill="#56d364"/>
-        <rect x="745.1" y="66" width="7" height="24" rx="1.5" fill="#7ee787"/>
-        <rect x="753.2" y="74" width="7" height="16" rx="1.5" fill="#3fb950"/>
-        <rect x="761.3" y="82" width="7" height="8" rx="1.5" fill="#2a8f4f"/>
-        <rect x="769.4" y="86" width="7" height="4" rx="1.5" fill="#1f6f3f"/>
+        <rect x="712.7" y="86" width="7" height="4" rx="1.5" fill="#39c5cf"/>
+        <rect x="720.8" y="82" width="7" height="8" rx="1.5" fill="#5cd7df"/>
+        <rect x="728.9" y="76" width="7" height="14" rx="1.5" fill="#7ae9f0"/>
+        <rect x="737.0" y="70" width="7" height="20" rx="1.5" fill="#8aecf2"/>
+        <rect x="745.1" y="66" width="7" height="24" rx="1.5" fill="#a8f2f7"/>
+        <rect x="753.2" y="74" width="7" height="16" rx="1.5" fill="#7ae9f0"/>
+        <rect x="761.3" y="82" width="7" height="8" rx="1.5" fill="#5cd7df"/>
+        <rect x="769.4" y="86" width="7" height="4" rx="1.5" fill="#39c5cf"/>
       </g>
       <text class="m grn" x="826.1" y="92" text-anchor="end">+42</text>
       <text class="m red" x="874.7" y="92" text-anchor="end">&#8722;7</text>
@@ -88,14 +96,14 @@
         <rect x="696.5" y="114" width="7" height="8" rx="2" fill="#21262d"/>
       </g>
       <g>
-        <rect x="712.7" y="120" width="7" height="2" rx="1.5" fill="#1f6f3f"/>
-        <rect x="720.8" y="116" width="7" height="6" rx="1.5" fill="#2a8f4f"/>
-        <rect x="728.9" y="112" width="7" height="10" rx="1.5" fill="#3fb950"/>
-        <rect x="737.0" y="116" width="7" height="6" rx="1.5" fill="#2a8f4f"/>
-        <rect x="745.1" y="118" width="7" height="4" rx="1.5" fill="#1f6f3f"/>
-        <rect x="753.2" y="120" width="7" height="2" rx="1.5" fill="#1f6f3f"/>
-        <rect x="761.3" y="120" width="7" height="2" rx="1.5" fill="#1f6f3f"/>
-        <rect x="769.4" y="120" width="7" height="2" rx="1.5" fill="#1f6f3f"/>
+        <rect x="712.7" y="120" width="7" height="2" rx="1.5" fill="#39c5cf"/>
+        <rect x="720.8" y="116" width="7" height="6" rx="1.5" fill="#5cd7df"/>
+        <rect x="728.9" y="112" width="7" height="10" rx="1.5" fill="#7ae9f0"/>
+        <rect x="737.0" y="116" width="7" height="6" rx="1.5" fill="#5cd7df"/>
+        <rect x="745.1" y="118" width="7" height="4" rx="1.5" fill="#39c5cf"/>
+        <rect x="753.2" y="120" width="7" height="2" rx="1.5" fill="#39c5cf"/>
+        <rect x="761.3" y="120" width="7" height="2" rx="1.5" fill="#39c5cf"/>
+        <rect x="769.4" y="120" width="7" height="2" rx="1.5" fill="#39c5cf"/>
       </g>
       <text class="m grn" x="826.1" y="124" text-anchor="end">+11</text>
       <text class="m red" x="874.7" y="124" text-anchor="end">&#8722;3</text>
@@ -174,14 +182,14 @@
         <rect x="696.5" y="192" width="7" height="8" rx="2" fill="#21262d"/>
       </g>
       <g>
-        <rect x="712.7" y="196" width="7" height="4" rx="1.5" fill="#1f6f3f"/>
-        <rect x="720.8" y="192" width="7" height="8" rx="1.5" fill="#2a8f4f"/>
-        <rect x="728.9" y="186" width="7" height="14" rx="1.5" fill="#3fb950"/>
-        <rect x="737.0" y="180" width="7" height="20" rx="1.5" fill="#56d364"/>
-        <rect x="745.1" y="176" width="7" height="24" rx="1.5" fill="#7ee787"/>
-        <rect x="753.2" y="184" width="7" height="16" rx="1.5" fill="#3fb950"/>
-        <rect x="761.3" y="192" width="7" height="8" rx="1.5" fill="#2a8f4f"/>
-        <rect x="769.4" y="196" width="7" height="4" rx="1.5" fill="#1f6f3f"/>
+        <rect x="712.7" y="196" width="7" height="4" rx="1.5" fill="#39c5cf"/>
+        <rect x="720.8" y="192" width="7" height="8" rx="1.5" fill="#5cd7df"/>
+        <rect x="728.9" y="186" width="7" height="14" rx="1.5" fill="#7ae9f0"/>
+        <rect x="737.0" y="180" width="7" height="20" rx="1.5" fill="#8aecf2"/>
+        <rect x="745.1" y="176" width="7" height="24" rx="1.5" fill="#a8f2f7"/>
+        <rect x="753.2" y="184" width="7" height="16" rx="1.5" fill="#7ae9f0"/>
+        <rect x="761.3" y="192" width="7" height="8" rx="1.5" fill="#5cd7df"/>
+        <rect x="769.4" y="196" width="7" height="4" rx="1.5" fill="#39c5cf"/>
       </g>
       <text class="m grn" x="826.1" y="202" text-anchor="end">+42</text>
       <text class="m red" x="874.7" y="202" text-anchor="end">&#8722;7</text>


### PR DESCRIPTION
Four statements in `README.md` stopped being true when the B18 slate landed, and the picture the README leads with stopped agreeing with the binary. This is the correctness half; the missing-feature prose follows separately.

## What was false

The precedence table never moved when the ladders under it did, and two of its rows contradicted prose in the same document:

| Row | Said | Actually |
|---|---|---|
| Palette | `VIGIA_THEME` → theme file → `ansi` | the terminal's own background sits between the file and `ansi` (#325) |
| Glyphs | ... → `TERM_PROGRAM` → `WT_SESSION` → `TERM` → braille | the octant rung was missing entirely (#324) |
| View | `~/.config/vigia/config` → everything off | `links` starts on (#326) |

The palette row contradicted the paragraph forty lines below it, which already said `vigia` asks the terminal at startup; the view row contradicted the config section, which already said `links` is the one key that starts on. A reader got both stories in one file.

## The picture, which SPEC section 5.1 makes a specification

`assets/preview.svg` is the README's hero image and the spec for the look, and the "About that picture" section makes a specific, checkable claim: *one* departure from the binary is left. Two more had appeared:

1. **The header's pills were missing.** #323 changed what the header draws at truecolour and section 5.3 requires the mockup to be corrected in the same pass. It was not. That is my omission from that pass, fixed here: the loud pill on the first fact, the quiet one on the rest, the separators left bare on the bar between them, painted before the text so the words sit on top.
2. **The sparklines were green.** The binary has drawn them in cyan since the ramp landed, on the ruling that green already means *added* two rows down, and the picture was never brought forward. The 24 bars now use the binary's own stops, computed from the same eight-step Oklab interpolation `Theme::spark_ramp` produces rather than eyeballed: `#39c5cf`, `#5cd7df`, `#7ae9f0`, `#8aecf2`, `#a8f2f7`.

**This is a visible change to the front-page image**, which is why it is called out here rather than buried: if the cyan is not wanted, the ruling to revisit is the one in section 11.1 that made the binary cyan, and this commit is the cheap thing to revert.

With both brought forward the section's claim is true again: the one departure left is the header reading the worktree's name rather than `vigia`. The enumeration in that section gained the pills and the gutter tones.

**Not changed:** the ASCII pane diagram. It is a layout diagram, the layout did not move, and it never could show colour. The wash and gutter *values* still differ from the binary's, which section 11.1 records as intentional: the picture specifies that a row is washed, not the exact triple.

## Checks

Docs and one asset; no code touched. `render` (130) and `legibility` (65) run green anyway, since those are the suites that read the drawn screen the picture claims to describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
