### PR TITLE
The pane stops showing what is no longer there (#340)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ cargo install --git https://github.com/breferrari/vigia vigia
    status  │  q quit · f follow · ? keys   3.1ms frame   25MiB  follow ▶  1/3
 ```
 
+The header's facts sit in **pills**, one to a fact, so the worktree, the branch and the count read as three things rather than one run-on line.
+
 The list is **pinned**, so the signals stay on screen while you read the diff under them. Press `r` on a pane of 134 columns or more and it moves *beside* the diff instead, as a left rail, so a path sits against its own numbers rather than across a void that grows with the pane. It costs the diff real width, which is why you ask for it rather than the pane deciding: `r` again puts it back, and below 134 the key does nothing. The pane drawn above is narrower than that, and the stacked layout is what ships at every width.
 
 Press `s` and the diff shows **only the file the caret is on**. Scrolling stops at that file's two ends instead of carrying on past them into the next one, and the scrollbar measures the file rather than the whole changeset, so you are keeping one position in your head instead of two. It is follow's companion: `f` decides which file the pane goes to on its own, `s` decides how much of the rest of the tree your own scrolling reaches once it is there. `n`, `p`, the digits, a click on a listed file and follow itself all still move between files, and `s` again gives the whole diff back.
@@ -113,7 +115,7 @@ Every file gets the same row in both regions:
 |---|---|---|
 | `▸` | **caret** | 📍 *where you are.* The diff below is inside this file |
 | `M` | **kind** | modified, added, deleted, renamed |
-| `src/…` | **path** | which file. How brightly it is drawn is how recently it changed |
+| `src/…` | **path** | which file. How brightly it is drawn is how recently it changed, and it is a link you can click |
 | `●` | **pulse** | ⚡ it changed on the newest tick |
 | green `M` | **staged** | 📦 this row is what the index holds, not the working tree (`a`) |
 | `■■■■` | **heat strip** | 🗺️ **where** in the file the change is |
@@ -138,7 +140,7 @@ A slice nothing touched is still drawn, in a dark track colour, because a strip 
 
 <br>
 
-Twelve columns across the last two minutes, so each column is ten seconds, oldest on the left. A taller column is more bytes moving around that ten seconds. Every column always covers the whole two minutes between them: a narrow pane draws six columns of twenty seconds rather than the last minute, and a pane wide enough to spare the room draws twenty-four of five.
+Twelve columns across the last two minutes, so each column is ten seconds, oldest on the left. A taller column is more bytes moving around that ten seconds, and a busier one is a hotter colour: on a terminal with 24-bit colour the height and the ink climb the same ramp together, so the shape reads at a glance and the colour confirms it. Every column always covers the whole two minutes between them: a narrow pane draws six columns of twenty seconds rather than the last minute, and a pane wide enough to spare the room draws twenty-four of five.
 
 **Around, rather than in.** A save is a point event, so the raw samples are zero almost everywhere and drawing them gives you a spike train on a flat line rather than a graph. What the column draws is a **level**: the bytes near it, weighted by a six-second kernel that looks both ways, which is what reading a series of point events as a density means. The mockup drew these as waves before the first commit, and drawing the events raw was the defect.
 
@@ -183,6 +185,14 @@ The grammars are `bat`'s curated collection, which is the same set that tool hig
 A file type nothing recognises is not an error. It draws exactly as it did before there was highlighting at all, because a monitor that refused a file it could not colour would have inverted its own job.
 
 </details>
+
+### 🎯 And *what* changed inside the line
+
+A changed line sits on a calm wash of its own colour, and the words that actually changed sit in a **hotter patch of that same colour**. A renamed function in a long line reads as one bright token rather than a whole red line above a whole green one, and you find the edit without reading either line to its end.
+
+The pairing is bounded on purpose. A removed line and the added line under it are compared token by token, and a pair that differs too much is left as two whole lines rather than confettied into unrelated highlights: past that bound there is no shared shape left to point at. The line numbers of a changed row take a slightly darker tone of the same wash, so the gutter reads as its own column without a border being spent on one.
+
+All three are backgrounds, so they need 24-bit colour and they leave together below it. What is left there is what was always there: the `+` and `-` column, and the left bar beside it.
 
 ### 📈 And the masthead, which is the whole tree
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,6 @@ cargo install --git https://github.com/breferrari/vigia vigia
    status  │  q quit · f follow · ? keys   3.1ms frame   25MiB  follow ▶  1/3
 ```
 
-The header's facts sit in **pills**, one to a fact, so the worktree, the branch and the count read as three things rather than one run-on line.
-
 The list is **pinned**, so the signals stay on screen while you read the diff under them. Press `r` on a pane of 134 columns or more and it moves *beside* the diff instead, as a left rail, so a path sits against its own numbers rather than across a void that grows with the pane. It costs the diff real width, which is why you ask for it rather than the pane deciding: `r` again puts it back, and below 134 the key does nothing. The pane drawn above is narrower than that, and the stacked layout is what ships at every width.
 
 Press `s` and the diff shows **only the file the caret is on**. Scrolling stops at that file's two ends instead of carrying on past them into the next one, and the scrollbar measures the file rather than the whole changeset, so you are keeping one position in your head instead of two. It is follow's companion: `f` decides which file the pane goes to on its own, `s` decides how much of the rest of the tree your own scrolling reaches once it is there. `n`, `p`, the digits, a click on a listed file and follow itself all still move between files, and `s` again gives the whole diff back.
@@ -245,8 +243,8 @@ The blank above the band is the row the header keeps between itself and the list
 | `r` | list beside the diff, or above it |
 | `s` | one file, or the whole diff |
 | `a` | show or hide staged changes |
-| `?` | **all of this, on screen**, a page at a time where the pane is small |
-| `q` `Esc` `Ctrl+C` | quit |
+| `?` `Esc` | **all of this, on screen**, a page at a time where the pane is small. `Esc` puts it away |
+| `q` `Ctrl+C` | quit |
 
 </td><td valign="top" width="50%">
 
@@ -471,11 +469,11 @@ Built in the open, spec first. [`SPEC.md`](SPEC.md) is the source of truth and i
 
 <br>
 
-**It is a mockup, not a screenshot**, and `VIGIA_THEME=dark` is what draws it. All of it draws today: the header and the pills its facts sit in, the blank row under it, the pinned list, the counters in green and red, the sparklines, the heat bars, the caret and the bold path that goes with it, the pulse, the scrollbar with its step buttons, the tinted rows with their left bars and their gutter tones, the highlighted diff, and the status bar.
+**It is a mockup, not a screenshot**, and `VIGIA_THEME=dark` is what draws it. All of it draws today: the header, the blank row under it, the pinned list, the counters in green and red, the sparklines, the heat bars, the caret and the bold path that goes with it, the pulse, the scrollbar with its step buttons, the tinted rows with their left bars and their gutter tones, the highlighted diff, and the status bar.
 
 **The picture is a specification here, not decoration.** `SPEC.md` §5.1 rules that where the mockup answers a question the spec left open, the mockup *is* the answer, so every disagreement between it and the binary is either a bug or a departure somebody wrote down. **One is left**: the header reads the worktree's name rather than `vigia`, because a title bar spends six of forty columns telling you which program you started, and what you cannot tell by looking is which tree.
 
-Everything else that disagreed was the picture being behind, and it has been brought forward: the status bar's hints, the position beside the follow marker, the branch, the caret standing on the pane's own edge, the diff's heading drawing the same row as the list above it, and the row's right-hand order, which now places the pulse, heat strip, sparkline and counters where the binary places them. **Two more came forward in August 2026**: the header's facts wear their pills, and the sparklines are drawn in the cyan the binary has used since the ramp landed rather than the green they were first mocked in, which is the ruling that green already means *added* two rows down.
+Everything else that disagreed was the picture being behind, and it has been brought forward: the status bar's hints, the position beside the follow marker, the branch, the caret standing on the pane's own edge, the diff's heading drawing the same row as the list above it, and the row's right-hand order, which now places the pulse, heat strip, sparkline and counters where the binary places them. **One more came forward in August 2026**: the sparklines are drawn in the cyan the binary has used since the ramp landed rather than the green they were first mocked in, which is the ruling that green already means *added* two rows down.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -311,10 +311,10 @@ Three independent settings decide how the pane is **drawn**, and most confusion 
 
 | | First answer wins |
 |---|---|
-| 🎨 **Palette** | `VIGIA_THEME` (a name, or a path) → `~/.config/vigia/theme` → `ansi` |
+| 🎨 **Palette** | `VIGIA_THEME` (a name, or a path) → `~/.config/vigia/theme` → **your terminal's own background** → `ansi` |
 | 🔦 **Depth** | `VIGIA_COLOR` → `NO_COLOR` → `TERM=dumb` → `COLORTERM` → `TERM_PROGRAM` → `TERM` → 16 |
-| ✏️ **Glyphs** | `VIGIA_GLYPHS` → `TERM=dumb`/`linux` → `TERM_PROGRAM` → `WT_SESSION` → `TERM` → braille, or blocks on a bare Windows console |
-| 🪟 **View** | `~/.config/vigia/config` → everything off |
+| ✏️ **Glyphs** | `VIGIA_GLYPHS` → `TERM=dumb`/`linux` → **an engine that draws octants and names its version** → `TERM_PROGRAM` → `WT_SESSION` → `TERM` → braille, or blocks on a bare Windows console |
+| 🪟 **View** | `~/.config/vigia/config` → everything off, except `links` |
 
 ```sh
 VIGIA_THEME=ansi     # the fallback: the sixteen names, inherited from your scheme
@@ -461,11 +461,11 @@ Built in the open, spec first. [`SPEC.md`](SPEC.md) is the source of truth and i
 
 <br>
 
-**It is a mockup, not a screenshot**, and `VIGIA_THEME=dark` is what draws it. All of it draws today: the header, the blank row under it, the pinned list, the counters in green and red, the sparklines, the heat bars, the caret and the bold path that goes with it, the pulse, the scrollbar with its step buttons, the tinted rows and their left bars, the highlighted diff, and the status bar.
+**It is a mockup, not a screenshot**, and `VIGIA_THEME=dark` is what draws it. All of it draws today: the header and the pills its facts sit in, the blank row under it, the pinned list, the counters in green and red, the sparklines, the heat bars, the caret and the bold path that goes with it, the pulse, the scrollbar with its step buttons, the tinted rows with their left bars and their gutter tones, the highlighted diff, and the status bar.
 
 **The picture is a specification here, not decoration.** `SPEC.md` §5.1 rules that where the mockup answers a question the spec left open, the mockup *is* the answer, so every disagreement between it and the binary is either a bug or a departure somebody wrote down. **One is left**: the header reads the worktree's name rather than `vigia`, because a title bar spends six of forty columns telling you which program you started, and what you cannot tell by looking is which tree.
 
-Everything else that disagreed was the picture being behind, and it has been brought forward: the status bar's hints, the position beside the follow marker, the branch, the caret standing on the pane's own edge, the diff's heading drawing the same row as the list above it, and the row's right-hand order, which now places the pulse, heat strip, sparkline and counters where the binary places them.
+Everything else that disagreed was the picture being behind, and it has been brought forward: the status bar's hints, the position beside the follow marker, the branch, the caret standing on the pane's own edge, the diff's heading drawing the same row as the list above it, and the row's right-hand order, which now places the pulse, heat strip, sparkline and counters where the binary places them. **Two more came forward in August 2026**: the header's facts wear their pills, and the sparklines are drawn in the cyan the binary has used since the ramp landed rather than the green they were first mocked in, which is the ruling that green already means *added* two rows down.
 
 </details>
 

--- a/assets/preview.svg
+++ b/assets/preview.svg
@@ -16,14 +16,6 @@
   <g clip-path="url(#win)">
     <!-- title bar -->
     <rect x="8" y="8" width="884" height="46" fill="#161b22"/>
-    <!-- #323: the header's facts wear pills, the loud one on the first
-         segment and the quiet one on the rest, with the separators left on the
-         bar between them. Drawn before the text so the words sit on top, and
-         only at truecolour: the depth ladder drops these backgrounds with
-         every other one, which is why this is the `dark` picture. -->
-    <rect x="94" y="16" width="58" height="30" rx="6" fill="#173042"/>
-    <rect x="160" y="16" width="51" height="30" rx="6" fill="#21262d"/>
-    <rect x="220" y="16" width="92" height="30" rx="6" fill="#21262d"/>
     <circle cx="34" cy="31" r="6" fill="#f85149"/>
     <circle cx="54" cy="31" r="6" fill="#e3b341"/>
     <circle cx="74" cy="31" r="6" fill="#3fb950"/>

--- a/assets/preview.svg
+++ b/assets/preview.svg
@@ -16,6 +16,14 @@
   <g clip-path="url(#win)">
     <!-- title bar -->
     <rect x="8" y="8" width="884" height="46" fill="#161b22"/>
+    <!-- #323: the header's facts wear pills, the loud one on the first
+         segment and the quiet one on the rest, with the separators left on the
+         bar between them. Drawn before the text so the words sit on top, and
+         only at truecolour: the depth ladder drops these backgrounds with
+         every other one, which is why this is the `dark` picture. -->
+    <rect x="94" y="16" width="58" height="30" rx="6" fill="#173042"/>
+    <rect x="160" y="16" width="51" height="30" rx="6" fill="#21262d"/>
+    <rect x="220" y="16" width="92" height="30" rx="6" fill="#21262d"/>
     <circle cx="34" cy="31" r="6" fill="#f85149"/>
     <circle cx="54" cy="31" r="6" fill="#e3b341"/>
     <circle cx="74" cy="31" r="6" fill="#3fb950"/>
@@ -59,14 +67,14 @@
         <rect x="696.5" y="82" width="7" height="8" rx="2" fill="#21262d"/>
       </g>
       <g>
-        <rect x="712.7" y="86" width="7" height="4" rx="1.5" fill="#1f6f3f"/>
-        <rect x="720.8" y="82" width="7" height="8" rx="1.5" fill="#2a8f4f"/>
-        <rect x="728.9" y="76" width="7" height="14" rx="1.5" fill="#3fb950"/>
-        <rect x="737.0" y="70" width="7" height="20" rx="1.5" fill="#56d364"/>
-        <rect x="745.1" y="66" width="7" height="24" rx="1.5" fill="#7ee787"/>
-        <rect x="753.2" y="74" width="7" height="16" rx="1.5" fill="#3fb950"/>
-        <rect x="761.3" y="82" width="7" height="8" rx="1.5" fill="#2a8f4f"/>
-        <rect x="769.4" y="86" width="7" height="4" rx="1.5" fill="#1f6f3f"/>
+        <rect x="712.7" y="86" width="7" height="4" rx="1.5" fill="#39c5cf"/>
+        <rect x="720.8" y="82" width="7" height="8" rx="1.5" fill="#5cd7df"/>
+        <rect x="728.9" y="76" width="7" height="14" rx="1.5" fill="#7ae9f0"/>
+        <rect x="737.0" y="70" width="7" height="20" rx="1.5" fill="#8aecf2"/>
+        <rect x="745.1" y="66" width="7" height="24" rx="1.5" fill="#a8f2f7"/>
+        <rect x="753.2" y="74" width="7" height="16" rx="1.5" fill="#7ae9f0"/>
+        <rect x="761.3" y="82" width="7" height="8" rx="1.5" fill="#5cd7df"/>
+        <rect x="769.4" y="86" width="7" height="4" rx="1.5" fill="#39c5cf"/>
       </g>
       <text class="m grn" x="826.1" y="92" text-anchor="end">+42</text>
       <text class="m red" x="874.7" y="92" text-anchor="end">&#8722;7</text>
@@ -88,14 +96,14 @@
         <rect x="696.5" y="114" width="7" height="8" rx="2" fill="#21262d"/>
       </g>
       <g>
-        <rect x="712.7" y="120" width="7" height="2" rx="1.5" fill="#1f6f3f"/>
-        <rect x="720.8" y="116" width="7" height="6" rx="1.5" fill="#2a8f4f"/>
-        <rect x="728.9" y="112" width="7" height="10" rx="1.5" fill="#3fb950"/>
-        <rect x="737.0" y="116" width="7" height="6" rx="1.5" fill="#2a8f4f"/>
-        <rect x="745.1" y="118" width="7" height="4" rx="1.5" fill="#1f6f3f"/>
-        <rect x="753.2" y="120" width="7" height="2" rx="1.5" fill="#1f6f3f"/>
-        <rect x="761.3" y="120" width="7" height="2" rx="1.5" fill="#1f6f3f"/>
-        <rect x="769.4" y="120" width="7" height="2" rx="1.5" fill="#1f6f3f"/>
+        <rect x="712.7" y="120" width="7" height="2" rx="1.5" fill="#39c5cf"/>
+        <rect x="720.8" y="116" width="7" height="6" rx="1.5" fill="#5cd7df"/>
+        <rect x="728.9" y="112" width="7" height="10" rx="1.5" fill="#7ae9f0"/>
+        <rect x="737.0" y="116" width="7" height="6" rx="1.5" fill="#5cd7df"/>
+        <rect x="745.1" y="118" width="7" height="4" rx="1.5" fill="#39c5cf"/>
+        <rect x="753.2" y="120" width="7" height="2" rx="1.5" fill="#39c5cf"/>
+        <rect x="761.3" y="120" width="7" height="2" rx="1.5" fill="#39c5cf"/>
+        <rect x="769.4" y="120" width="7" height="2" rx="1.5" fill="#39c5cf"/>
       </g>
       <text class="m grn" x="826.1" y="124" text-anchor="end">+11</text>
       <text class="m red" x="874.7" y="124" text-anchor="end">&#8722;3</text>
@@ -174,14 +182,14 @@
         <rect x="696.5" y="192" width="7" height="8" rx="2" fill="#21262d"/>
       </g>
       <g>
-        <rect x="712.7" y="196" width="7" height="4" rx="1.5" fill="#1f6f3f"/>
-        <rect x="720.8" y="192" width="7" height="8" rx="1.5" fill="#2a8f4f"/>
-        <rect x="728.9" y="186" width="7" height="14" rx="1.5" fill="#3fb950"/>
-        <rect x="737.0" y="180" width="7" height="20" rx="1.5" fill="#56d364"/>
-        <rect x="745.1" y="176" width="7" height="24" rx="1.5" fill="#7ee787"/>
-        <rect x="753.2" y="184" width="7" height="16" rx="1.5" fill="#3fb950"/>
-        <rect x="761.3" y="192" width="7" height="8" rx="1.5" fill="#2a8f4f"/>
-        <rect x="769.4" y="196" width="7" height="4" rx="1.5" fill="#1f6f3f"/>
+        <rect x="712.7" y="196" width="7" height="4" rx="1.5" fill="#39c5cf"/>
+        <rect x="720.8" y="192" width="7" height="8" rx="1.5" fill="#5cd7df"/>
+        <rect x="728.9" y="186" width="7" height="14" rx="1.5" fill="#7ae9f0"/>
+        <rect x="737.0" y="180" width="7" height="20" rx="1.5" fill="#8aecf2"/>
+        <rect x="745.1" y="176" width="7" height="24" rx="1.5" fill="#a8f2f7"/>
+        <rect x="753.2" y="184" width="7" height="16" rx="1.5" fill="#7ae9f0"/>
+        <rect x="761.3" y="192" width="7" height="8" rx="1.5" fill="#5cd7df"/>
+        <rect x="769.4" y="196" width="7" height="4" rx="1.5" fill="#39c5cf"/>
       </g>
       <text class="m grn" x="826.1" y="202" text-anchor="end">+42</text>
       <text class="m red" x="874.7" y="202" text-anchor="end">&#8722;7</text>

--- a/crates/vigia/src/app.rs
+++ b/crates/vigia/src/app.rs
@@ -723,6 +723,16 @@ impl App {
 
         match action {
             Action::Quit => return Ok(false),
+            // **`Esc` leaves the frontmost thing, and the sheet is a thing**
+            // ([#340](https://github.com/breferrari/vigia/issues/340)).
+            // Reported from a real pane: a reader pressed `Esc` to put the
+            // help away and the monitor exited. `SPEC.md` §11.2 B12's rule
+            // that no key changes meaning while the sheet is up is intact,
+            // because `input::key_action` still maps this key to one action
+            // and is handed no state to branch on; what is frontmost is a
+            // question about this struct, so this struct answers it.
+            Action::Escape if self.sheet.is_some() => self.sheet = None,
+            Action::Escape => return Ok(false),
             Action::Redraw => {}
             // Re-engaging jumps rather than arming: `less +F` goes to the end
             // when you ask it to follow, and a reader who presses `f` is

--- a/crates/vigia/src/input.rs
+++ b/crates/vigia/src/input.rs
@@ -811,6 +811,7 @@ pub fn scroll_mark(action: Action, regions: Regions) -> Option<(Grabbed, isize)>
         | Action::ToggleStaged
         | Action::ToggleSheet
         | Action::CloseSheet
+        | Action::Escape
         | Action::Redraw
         | Action::Quit => return None,
     };
@@ -1219,6 +1220,24 @@ pub enum Action {
     ///
     /// It is the sheet's only pointer escape, and the pointer has no `?`.
     CloseSheet,
+    /// Leave the frontmost thing: the gestures sheet if one is up, and the
+    /// program if none is. `Esc`.
+    ///
+    /// **One key, one meaning, and the state is resolved where state lives**
+    /// ([#340](https://github.com/breferrari/vigia/issues/340)). `SPEC.md`
+    /// §11.2 B12 rules that no key changes meaning while the sheet is up, and
+    /// [`key_action`] is handed no shell state so that the rule is structural
+    /// rather than remembered. Both survive: this action *is* one meaning, the
+    /// one every terminal program gives `Esc`, and which thing is frontmost is
+    /// a question only [`crate::App`] can answer. `q` is untouched and still
+    /// quits from anywhere, which is what a reader who wants out of the
+    /// program presses.
+    ///
+    /// It was `Quit` outright until #340, reported from a real pane: a reader
+    /// pressed `Esc` to put the help away and the monitor exited. That is the
+    /// worst shape a mistake can take here, because the sheet is the surface a
+    /// reader opens precisely when they are unsure what a key does.
+    Escape,
     /// Put the pinned list's window at this fraction of the changed set.
     ///
     /// From dragging or clicking the list's own scrollbar. A fraction over
@@ -1310,6 +1329,7 @@ impl Action {
             | Self::ToggleStaged
             | Self::ToggleSheet
             | Self::CloseSheet
+            | Self::Escape
             | Self::Redraw
             | Self::Quit => self,
         }
@@ -1351,6 +1371,7 @@ impl Action {
             // following what an agent is writing is the monitor behaviour, and
             // the two would fight if one disengaged the other. `SPEC.md` §11.1.
             Self::Quit
+            | Self::Escape
             | Self::Redraw
             | Self::ToggleFollow
             // Showing or hiding the masthead resizes the diff's region and does
@@ -1457,6 +1478,7 @@ impl Action {
             // A toggle changes the region's height; it does not need to be
             // told one to decide what it means.
             Self::Quit
+            | Self::Escape
             | Self::Redraw
             | Self::ToggleFollow
             | Self::ToggleMasthead
@@ -1538,7 +1560,8 @@ fn key_action(key: &KeyEvent) -> Option<Action> {
     }
 
     match key.code {
-        KeyCode::Char('q') | KeyCode::Esc => Some(Action::Quit),
+        KeyCode::Char('q') => Some(Action::Quit),
+        KeyCode::Esc => Some(Action::Escape),
         KeyCode::Down | KeyCode::Char('j') => Some(Action::Scroll(1)),
         KeyCode::Up | KeyCode::Char('k') => Some(Action::Scroll(-1)),
         // Shift is the modifier because the alternatives are all taken or

--- a/crates/vigia/src/render.rs
+++ b/crates/vigia/src/render.rs
@@ -4275,6 +4275,17 @@ pub fn render(
     let body = Body::split(area, footer.height(), view.files, view.list.len(), chrome)
         .clamped_to(view.list.len());
     let margins = margins_of(area.width);
+    // **Planned before anything is painted, and painted last**
+    // ([#340](https://github.com/breferrari/vigia/issues/340)). The sheet
+    // composites over the regions, so a row underneath it must not *claim*
+    // columns inside it: `ratatui`'s differ walks past every column a
+    // `CellDiffOption::ForcedWidth` covers, so a claim reaching in makes the
+    // sheet's own cells unemittable and the row shows through. Everything this
+    // needs is already decided here, so the painter can be told where the
+    // sheet will land rather than finding out after the fact.
+    let sheet = chrome
+        .sheet
+        .and_then(|page| sheet_plan(area, footer.height(), margins, page));
 
     let mut painter = Painter {
         buf,
@@ -4301,6 +4312,7 @@ pub fn render(
         hovered: chrome.hovered,
         scrolling: chrome.scrolling,
         spark_ramp: theme.spark_ramp(),
+        covered: sheet.as_ref().map(|plan| plan.area),
         icons: chrome.icons,
         link_root: (chrome.links && !chrome.root.is_empty()).then(|| chrome.root.clone()),
     };
@@ -4467,10 +4479,8 @@ pub fn render(
     // B12: the sheet is the one drawn thing on this pane that takes no row from
     // any region, so it is composited after all of them and the plan above is
     // untouched by whether it is up.
-    if let Some(page) = chrome.sheet {
-        if let Some(plan) = sheet_plan(area, footer.height(), margins, page) {
-            painter.sheet(&plan);
-        }
+    if let Some(plan) = sheet {
+        painter.sheet(&plan);
     }
 
     painter.paint
@@ -4571,11 +4581,19 @@ const KEYBOARD: [Gesture; 14] = [
         verb: ["show or hide staged changes", "staged changes"],
     },
     Gesture {
-        keys: ["?", "?"],
+        keys: ["?  Esc", "?  Esc"],
         verb: ["this sheet", "this sheet"],
     },
+    // **`Esc` moved up a row with [#340](https://github.com/breferrari/vigia/issues/340)**,
+    // where it stopped quitting outright and started leaving the frontmost
+    // thing. **No field maximum moves and so no width rung does**, which is
+    // what makes this a wording change rather than a layout one: the wide
+    // keys field is still 22, held by `J  K  Shift+↑  Shift+↓` which ties the
+    // old `q  Esc  Ctrl+C  Ctrl+D` exactly, and the tight field is still 11,
+    // held by `Space  PgDn`. `crates/vigia/tests/sheet.rs` walks the rungs and
+    // is what fails if that stops being true.
     Gesture {
-        keys: ["q  Esc  Ctrl+C  Ctrl+D", "q  Esc"],
+        keys: ["q  Ctrl+C  Ctrl+D", "q"],
         verb: ["quit", "quit"],
     },
 ];
@@ -5719,6 +5737,10 @@ struct Painter<'a> {
     spark_ramp: Option<[Color; 8]>,
     /// [`Chrome::icons`]: whether a listed path carries its type's glyph.
     icons: bool,
+    /// Where the gestures sheet will be composited, so nothing underneath it
+    /// claims a column it will draw over
+    /// ([#340](https://github.com/breferrari/vigia/issues/340)).
+    covered: Option<Rect>,
     /// [`Chrome::links`] with [`Chrome::root`]: the `file://` prefix every
     /// linked path shares, or `None` where links are off or rootless.
     link_root: Option<String>,
@@ -6024,73 +6046,49 @@ impl Painter<'_> {
         self.put_marked(text.x, text.y, rung, room, style);
     }
 
-    /// Paint the pills behind a status line's ` · `-separated segments.
-    ///
-    /// `SPEC.md` §11.2 B18 ([#323](https://github.com/breferrari/vigia/issues/323)),
-    /// crush's pill shape from the #318 survey: a background run per segment,
-    /// the separator's own `·` left on the pane between them, its flanking
-    /// spaces absorbed into the pills either side so the seams are seamless.
-    /// **No text moves and no ladder is consulted**: the pills are painted over
-    /// the cells the rung already occupies, so every width rung draws exactly
-    /// the words it drew before, and below truecolour the backgrounds are gone
-    /// and this is a no-op by the same resolve that blanks every wash.
-    ///
-    /// The first segment takes the louder pill: the worktree name is the one
-    /// fact a reader glances for.
-    fn chip_row(&mut self, area: Rect, drawn: &str) {
-        if self.theme.chip.bg.is_none() && self.theme.chip_accent.bg.is_none() {
-            return;
-        }
-        let text = self.text_area(area);
-        let mut x = text.x;
-        let mut first = true;
-        // Split and advanced by [`FACT_SEPARATOR`] itself rather than by a
-        // second spelling of it: `header_left` joins with that constant, and
-        // two literals that agree today are exactly what its own docblock
-        // warns about. A separator that changed would otherwise leave this
-        // painting pills over the wrong cells with nothing failing.
-        for segment in drawn.split(FACT_SEPARATOR) {
-            let width = width_of(segment) as u16;
-            let end = x
-                .saturating_add(width)
-                .min(text.x.saturating_add(text.width));
-            if x >= end {
-                break;
-            }
-            let pill = if first {
-                self.theme.chip_accent
-            } else {
-                self.theme.chip
-            };
-            // One cell of padding either side where the separator's spaces
-            // are, clamped to the text area, so a pill breathes without a
-            // character being added anywhere. Through `chip_span`, so both
-            // pill painters clip through one expression.
-            self.chip_span(
-                Rect { y: area.y, ..text },
-                x.saturating_sub(1).max(text.x),
-                end.saturating_add(1),
-                pill,
-            );
-            first = false;
-            // Past this segment and the separator that follows it.
-            x = end.saturating_add(width_of(FACT_SEPARATOR) as u16);
-        }
-    }
-
     /// Put `label` as one OSC 8 hyperlink to `root/path`, tui-link's shape.
     ///
     /// **One cell carries the whole wrapped string** with its width forced to
-    /// the label's, which is `CellDiffOption::ForcedWidth`'s documented job;
-    /// the covered cells behind it are reset so nothing stale can survive a
-    /// frame where the writer never visits them. A terminal without OSC 8
-    /// renders the label and swallows the wrapper, which the 2026 matrix
-    /// verified for every terminal it covers, and is why the `links` key
-    /// defaults on (#326).
+    /// the label's, which is `CellDiffOption::ForcedWidth`'s documented job. A
+    /// terminal without OSC 8 renders the label and swallows the wrapper,
+    /// which the 2026 matrix verified for every terminal it covers, and is why
+    /// the `links` key defaults on (#326).
+    ///
+    /// **The covered columns record the label rather than blanks, and that is
+    /// a correctness requirement rather than tidiness**
+    /// ([#340](https://github.com/breferrari/vigia/issues/340)). `ratatui`'s
+    /// differ walks straight past every column a `ForcedWidth` claims: its
+    /// arm advances `pos` and emits the first cell only, with none of the
+    /// shrink protection the `None` arm carries for wide graphemes. So the
+    /// buffer's record of those columns is the *only* thing that can ever
+    /// force them to be repainted, and blanking them made the buffer say
+    /// "empty" where the terminal was showing a path. A shorter path drawn
+    /// where a longer one had been then compared equal-to-equal across the
+    /// uncovered tail and left the old path's end on screen, which is what a
+    /// reader saw as `settings.jsonodebase.md`.
+    ///
+    /// The shadow is never emitted: the differ skips it by construction. It
+    /// exists so that the frame *after* this one can tell what these columns
+    /// are showing, which is exactly what a double-buffered diff needs and
+    /// what the wide-cell trick otherwise throws away.
     fn put_linked(&mut self, x: u16, y: u16, label: &str, root: &str, path: &str, ink: Style) {
         let width = width_of(label) as u16;
         if width == 0 {
             return;
+        }
+        // **A claim that reaches under the sheet is not made at all**, because
+        // the differ would then skip the sheet's own cells across it and the
+        // row would show through the overlay (#340). The row still draws, as
+        // plain text: what a reader loses is a link on a path the sheet is
+        // covering anyway, which is the cheaper half of the trade by a wide
+        // margin.
+        if let Some(sheet) = self.covered {
+            let rows = sheet.y..sheet.y.saturating_add(sheet.height);
+            let reaches = x.saturating_add(width) > sheet.x && x < sheet.right();
+            if rows.contains(&y) && reaches {
+                self.put(x, y, label, usize::from(width), ink);
+                return;
+            }
         }
         let mut uri = String::with_capacity(root.len() + path.len() + 8);
         uri.push_str("file://");
@@ -6108,9 +6106,18 @@ impl Painter<'_> {
             }
         }
         let wrapped = format!("\x1b]8;;{uri}\x1b\\{label}\x1b]8;;\x1b\\");
-        for offset in 1..width {
-            if let Some(cell) = self.buf.cell_mut((x + offset, y)) {
+        // The shadow: what the terminal will actually be showing in the columns
+        // the cell below claims. Styled like the label so a later `set_style`
+        // over the row cannot make the record disagree with the paint.
+        for (offset, grapheme) in label.chars().skip(1).enumerate() {
+            let at = x + 1 + offset as u16;
+            if at >= x + width {
+                break;
+            }
+            if let Some(cell) = self.buf.cell_mut((at, y)) {
                 cell.reset();
+                cell.set_char(grapheme);
+                cell.set_style(ink);
             }
         }
         if let Some(cell) = self.buf.cell_mut((x, y)) {
@@ -6119,19 +6126,6 @@ impl Painter<'_> {
             cell.diff_option = ratatui::buffer::CellDiffOption::ForcedWidth(
                 std::num::NonZeroU16::new(width).expect("width is checked nonzero above"),
             );
-        }
-    }
-
-    /// One pill over a column span, for the footer's readouts and state.
-    fn chip_span(&mut self, row: Rect, from: u16, to: u16, pill: Style) {
-        if pill.bg.is_none() {
-            return;
-        }
-        let edge = row.x.saturating_add(row.width).min(self.buf.area.right());
-        for x in from.min(edge)..to.min(edge) {
-            if let Some(cell) = self.buf.cell_mut((x, row.y)) {
-                cell.set_style(pill);
-            }
         }
     }
 
@@ -6186,15 +6180,6 @@ impl Painter<'_> {
             chrome.staged,
         );
         self.status_line(area, &rungs, self.theme.chrome, right, right_style);
-        // The pills, over the rung `status_line` just placed: recomputed with
-        // the same inputs and the same picker, so the two cannot disagree
-        // about which words are on the row.
-        let text = self.text_area(area);
-        // `saturating_sub` already floors at zero, so clamping the subtrahend
-        // to the width first was a no-op.
-        let room = usize::from(text.width).saturating_sub(width_of(right));
-        let drawn = widest_fitting_or_last(&rungs, room);
-        self.chip_row(area, drawn);
     }
 
     /// The footer, on the bottom one or two rows of `area`.
@@ -6273,40 +6258,11 @@ impl Painter<'_> {
             );
             // The inset row for the reason `placed` uses one: the walk is bounded
             // by its `row`'s right edge, and the text's edge is not the pane's.
-            let row = Rect { y: upper.y, ..text };
-            self.footer_chips(row, placed, readouts, &right);
-            self.tint_readouts(row, placed, readouts);
+            self.tint_readouts(Rect { y: upper.y, ..text }, placed, readouts);
             self.status_line(bottom, &[footer.left], style, "", self.theme.chrome_dim);
         } else {
             self.status_line(bottom, &[footer.left], style, &right, self.theme.chrome_dim);
-            self.footer_chips(text, placed, readouts, &right);
             self.tint_readouts(text, placed, readouts);
-        }
-    }
-
-    /// The footer's two pills: the readouts in the quiet one, the state in the
-    /// loud one (#323). Painted before [`Painter::tint_readouts`], whose
-    /// foreground tints then land on the pill the way every run lands on a
-    /// wash; below truecolour both backgrounds are gone and nothing here
-    /// writes a cell.
-    fn footer_chips(&mut self, row: Rect, placed: u16, readouts: usize, right: &str) {
-        if readouts > 0 {
-            self.chip_span(
-                row,
-                placed.saturating_sub(1),
-                placed.saturating_add(readouts as u16),
-                self.theme.chip,
-            );
-        }
-        let total = width_of(right) as u16;
-        let state = total.saturating_sub(readouts as u16);
-        if state > 0 {
-            self.chip_span(
-                row,
-                placed.saturating_add(readouts as u16).saturating_add(1),
-                placed.saturating_add(total),
-                self.theme.chip_accent,
-            );
         }
     }
 
@@ -8730,6 +8686,7 @@ mod tests {
             hovered,
             scrolling,
             spark_ramp: None,
+            covered: None,
             icons: false,
             link_root: None,
         };
@@ -8937,7 +8894,7 @@ mod sheet_tables {
             .collect();
         assert_eq!(
             kept,
-            vec!["f", "m", "?"],
+            vec!["f", "m", "?  Esc"],
             "the rows the ladder keeps longest are not the three §11.1 names"
         );
     }
@@ -8948,7 +8905,7 @@ mod sheet_tables {
         // would break without touching the keep-set: `q` is on the hint bar at
         // every rung, so it is the row a sheet can most afford to lose.
         assert_eq!(
-            KEYBOARD[DROP_ORDER[0]].keys[0], "q  Esc  Ctrl+C  Ctrl+D",
+            KEYBOARD[DROP_ORDER[0]].keys[0], "q  Ctrl+C  Ctrl+D",
             "the first row the ladder gives up is not `q`"
         );
     }

--- a/crates/vigia/src/theme.rs
+++ b/crates/vigia/src/theme.rs
@@ -132,18 +132,6 @@ palette! {
     /// check. It was not exhaustive when it first named one, and the follow
     /// marker is what it missed.
     chrome_dim,
-    /// The background pill behind a chrome segment: the header's branch and
-    /// count, and the footer's readouts.
-    ///
-    /// `SPEC.md` §11.2 B18 ([#323](https://github.com/breferrari/vigia/issues/323)),
-    /// and the shape is crush's pills from the #318 survey: padded background
-    /// runs, no seam glyphs, the existing `·` separators riding between them.
-    /// A background, so it drops below truecolour with every other one, and a
-    /// palette that leaves it unset draws the flat chrome it always drew,
-    /// which is `ansi`'s standing contract.
-    chip,
-    /// The louder pill: the header's worktree name and the footer's state.
-    chip_accent,
 
     /// A changed file's path, at the recency the reader should read it as.
     ///
@@ -755,8 +743,6 @@ impl Theme {
             // `heat_added` below and for the same reason: sixteen names hold a
             // normal and a bright of each colour and no third, so the middle
             // stop is the normal one and the ramp reads as two.
-            chip: Style::new(),
-            chip_accent: Style::new(),
             spark: fg(Color::Cyan),
             spark_warm: fg(Color::Cyan),
             spark_hot: fg(Color::LightCyan),
@@ -885,8 +871,6 @@ impl Theme {
             // is writing to looks exactly as it did and only the busy buckets
             // gain. Brighter as it climbs, which is this palette's direction for
             // every ramp it has.
-            chip: Style::new().bg(Color::Rgb(0x21, 0x26, 0x2d)),
-            chip_accent: Style::new().bg(Color::Rgb(0x17, 0x30, 0x42)),
             spark: rgb(0x39, 0xc5, 0xcf),
             spark_warm: rgb(0x7a, 0xe9, 0xf0),
             spark_hot: rgb(0xa8, 0xf2, 0xf7),
@@ -1097,8 +1081,6 @@ impl Theme {
             // `the_sparkline_ramp_has_three_stops_where_the_depth_can_draw_them`
             // is what said so. Spread around it instead, and the quiet end
             // lightens.
-            chip: Style::new().bg(Color::Rgb(0xea, 0xee, 0xf2)),
-            chip_accent: Style::new().bg(Color::Rgb(0xd8, 0xe4, 0xf0)),
             spark: rgb(0x5a, 0xa6, 0xae),
             spark_warm: rgb(0x0a, 0x62, 0x6b),
             spark_hot: rgb(0x03, 0x28, 0x2e),

--- a/crates/vigia/tests/input.rs
+++ b/crates/vigia/tests/input.rs
@@ -42,13 +42,12 @@ fn wheel(kind: MouseEventKind) -> Event {
 
 #[test]
 fn every_way_out_is_a_way_out() {
-    // Three, because three habits exist. `q` is the pager reflex, `Esc` is the
-    // dialog reflex, and Ctrl-C is what a reader does when they have decided the
-    // program is not listening. In raw mode Ctrl-C is not a signal at all, it is
-    // an ordinary key event, so if this map drops it nothing else catches it.
+    // `q` is the pager reflex and Ctrl-C is what a reader does when they have
+    // decided the program is not listening. In raw mode Ctrl-C is not a signal
+    // at all, it is an ordinary key event, so if this map drops it nothing
+    // else catches it.
     for event in [
         press(KeyCode::Char('q')),
-        press(KeyCode::Esc),
         with(KeyModifiers::CONTROL, KeyCode::Char('c')),
         with(KeyModifiers::CONTROL, KeyCode::Char('d')),
     ] {
@@ -59,6 +58,19 @@ fn every_way_out_is_a_way_out() {
              alternate screen"
         );
     }
+
+    // **`Esc` is the dialog reflex, and a dialog reflex dismisses the dialog**
+    // ([#340](https://github.com/breferrari/vigia/issues/340)). It mapped to
+    // `Quit` here until a reader pressed it to put the gestures sheet away and
+    // the monitor exited. It is still a way out, and `App` decides out of
+    // *what*: the sheet if one is up, the program if none is. This function is
+    // handed no state and still maps one key to one action, which is what
+    // `SPEC.md` §11.2 B12 asks of it.
+    assert_eq!(
+        action_for(&press(KeyCode::Esc), Regions::default()),
+        Some(Action::Escape),
+        "Esc no longer asks to leave the frontmost thing"
+    );
 }
 
 #[test]

--- a/crates/vigia/tests/palette.rs
+++ b/crates/vigia/tests/palette.rs
@@ -481,15 +481,11 @@ fn nothing_a_reader_has_to_read_is_drawn_in_colour_eight() {
 
         // Exempt: backgrounds by contract, and unset on this palette anyway.
         // The word patch and the gutter tone exist only where the wash does,
-        // and `ansi` draws no wash at any depth. The chips are the same
-        // contract one row up: pills are backgrounds, and this palette draws
-        // flat chrome.
+        // and `ansi` draws no wash at any depth.
         added_word: _,
         removed_word: _,
         added_gutter: _,
         removed_gutter: _,
-        chip: _,
-        chip_accent: _,
 
         // Exempt: marks and fills, none of them text, none of them colour 8.
         pulse: _,

--- a/crates/vigia/tests/render.rs
+++ b/crates/vigia/tests/render.rs
@@ -7956,49 +7956,6 @@ fn icons_are_opt_in_and_every_row_gets_one() {
     );
 }
 
-/// #323: the chrome's pills. The header's first segment wears the loud one,
-/// its later segments the quiet one, the separator dot stays on the pane
-/// between them, and below truecolour there is no pill anywhere, through the
-/// same resolve that drops every background.
-#[test]
-fn the_chrome_wears_pills_at_truecolour_and_none_below() {
-    let view = emphasised_view();
-    let shown = chrome();
-
-    let theme = vigia::Theme::dark().resolve(vigia::Depth::Truecolor);
-    let backend = themed_screen(64, 18, &view, &shown, &theme);
-    let buffer = backend.buffer();
-    let header = row_text(&backend, 0);
-    let at = header.find("vigia").expect("the worktree name is drawn") as u16;
-    assert_eq!(
-        buffer[(at, 0)].bg,
-        theme.chip_accent.bg.expect("dark declares an accent pill"),
-        "the worktree segment does not wear the loud pill"
-    );
-    let dot = header.find(" · ").expect("a separator is drawn") as u16 + 1;
-    let pills = [theme.chip.bg.unwrap(), theme.chip_accent.bg.unwrap()];
-    assert!(
-        !pills.contains(&buffer[(dot, 0)].bg),
-        "the separator dot was swallowed by a pill"
-    );
-    let counted = header.find("changed").expect("the count is drawn") as u16;
-    assert_eq!(
-        buffer[(counted, 0)].bg,
-        theme.chip.bg.expect("dark declares a pill"),
-        "a later segment does not wear the quiet pill"
-    );
-
-    let flat = vigia::Theme::dark().resolve(vigia::Depth::Ansi256);
-    let backend = themed_screen(64, 18, &view, &shown, &flat);
-    let buffer = backend.buffer();
-    for x in 0..64u16 {
-        assert!(
-            !pills.contains(&buffer[(x, 0)].bg),
-            "a pill survived below truecolour at column {x}"
-        );
-    }
-}
-
 /// #326: a linked path is one cell carrying the whole OSC 8 wrapper with its
 /// width forced to the label's, tui-link's shape; rootless or switched off it
 /// is exactly the plain cells it always was.
@@ -8068,5 +8025,122 @@ fn a_linked_path_is_one_cell_carrying_the_uri() {
             !row_text(&plain, y).contains('\x1b'),
             "a rootless chrome leaked an escape into row {y}"
         );
+    }
+}
+
+/// A linked path claims its columns with `ForcedWidth`, and ratatui's differ
+/// walks straight past every column that claim covers: it emits the first cell
+/// and advances, with none of the shrink protection its `None` arm carries.
+/// So the **buffer's** record of those columns is the only thing that can ever
+/// force them repainted, and it had better be the truth.
+///
+/// Read against the buffer rather than the backend on purpose: the backend is
+/// what the terminal was *told*, and the skipped columns are exactly what it
+/// was never told about. The defect lived in the gap between the two
+/// ([#340](https://github.com/breferrari/vigia/issues/340)): a shorter path
+/// drawn where a longer one had been compared blank-to-blank across the
+/// uncovered tail, so nothing was emitted and the old path's end stayed on
+/// screen as `settings.jsonodebase.md`.
+#[test]
+fn a_linked_paths_covered_columns_record_what_the_terminal_shows() {
+    let area = Rect::new(0, 0, 80, 18);
+    let long = "src/engine/a-very-long-module-name.rs";
+    let short = "src/a.rs";
+    let mut shown = chrome();
+    shown.links = true;
+    shown.root = "/tree".to_owned();
+    let theme = vigia::Theme::dark();
+
+    let drawn = |path: &str, added: u32| {
+        let view = View {
+            rows: vec![file(path, added, 0)],
+            files: 1,
+            ..two_regions(1)
+        };
+        let mut buf = Buffer::empty(area);
+        vigia::render(&mut buf, area, &view, &theme, Glyphs::default(), &shown);
+        buf
+    };
+
+    let buf = drawn(long, 42);
+    let (at, row) = (0..18u16)
+        .flat_map(|y| (0..80u16).map(move |x| (x, y)))
+        .find(|at| buf[*at].symbol().contains(long))
+        .expect("the long path was not linked at all");
+    let claimed = match buf[(at, row)].diff_option {
+        ratatui::buffer::CellDiffOption::ForcedWidth(width) => width.get(),
+        other => panic!("a linked path claimed nothing: {other:?}"),
+    };
+    // Every column the claim covers records the character the terminal shows
+    // there, so the frame after this one can tell what is on screen.
+    let shadow: String = (at + 1..at + claimed)
+        .map(|x| buf[(x, row)].symbol())
+        .collect();
+    let label: String = buf[(at, row)].symbol().to_owned();
+    let label = label
+        .rsplit_once("\u{1b}]8;;")
+        .expect("a closing wrapper")
+        .0
+        .rsplit_once("\u{1b}\\")
+        .expect("an opening wrapper")
+        .1
+        .to_owned();
+    assert_eq!(
+        shadow,
+        label.chars().skip(1).collect::<String>(),
+        "the covered columns do not record the label the terminal is showing"
+    );
+
+    // And a shorter path in the same slot leaves nothing of a longer one
+    // behind it: blanks in both frames are what the differ cannot see.
+    let buf = drawn(short, 1);
+    let (at, row) = (0..18u16)
+        .flat_map(|y| (0..80u16).map(move |x| (x, y)))
+        .find(|at| buf[*at].symbol().contains(short))
+        .expect("the short path was not linked at all");
+    for x in at + short.chars().count() as u16..at + claimed {
+        assert!(
+            buf[(x, row)].symbol().trim().is_empty(),
+            "column {x} still records a longer path's tail"
+        );
+    }
+}
+
+/// The sheet composites over the regions, so nothing may claim columns inside
+/// it: a claim reaching in makes the differ skip the sheet's own cells, and the
+/// row underneath shows through. Reported from a real pane (#340).
+#[test]
+fn nothing_claims_columns_the_sheet_is_drawn_over() {
+    let view = View {
+        rows: vec![
+            file("src/engine/a-very-long-module-name-indeed.rs", 42, 7),
+            file("src/render/another-quite-long-name.rs", 11, 3),
+        ],
+        files: 2,
+        ..two_regions(2)
+    };
+    let mut shown = chrome();
+    shown.links = true;
+    shown.root = "/tree".to_owned();
+    shown.sheet = Some(0);
+    let theme = vigia::Theme::dark();
+    let backend = themed_screen(120, 30, &view, &shown, &theme);
+    let buffer = backend.buffer();
+
+    let sheet = vigia::regions(Rect::new(0, 0, 120, 30), &shown, &view)
+        .sheet
+        .expect("the fixture pane drew no sheet");
+    for y in sheet.top..sheet.top + sheet.height {
+        for x in 0..sheet.left {
+            let claimed = match buffer[(x, y)].diff_option {
+                ratatui::buffer::CellDiffOption::ForcedWidth(width) => u32::from(width.get()),
+                _ => 1,
+            };
+            assert!(
+                u32::from(x) + claimed <= u32::from(sheet.left),
+                "the cell at {x},{y} claims {claimed} columns and reaches into the \
+                 sheet, so the differ will skip the sheet's own cells there"
+            );
+        }
     }
 }

--- a/crates/vigia/tests/scroll.rs
+++ b/crates/vigia/tests/scroll.rs
@@ -748,7 +748,7 @@ fn a_screen_with_no_room_for_a_body_still_resolves() {
 /// so an added arm with the next tag is **not** in the driven set and the gate is
 /// red until it is driven; and forgetting to bump this number is caught by that
 /// same comparison the moment two variants share a tag or one is skipped.
-const VARIANTS: usize = 18;
+const VARIANTS: usize = 19;
 
 /// One number per [`Action`] variant, from an exhaustive `match`.
 ///
@@ -783,6 +783,7 @@ fn tag(action: Action) -> usize {
         Action::ListRow(_) => 15,
         Action::DiffTo(_) => 16,
         Action::Redraw => 17,
+        Action::Escape => 18,
     }
 }
 
@@ -839,6 +840,7 @@ fn only_the_action_that_reads_the_height_is_given_one() {
     // one cannot be skipped.
     let actions = [
         Action::Quit,
+        Action::Escape,
         Action::Scroll(SPAN as isize * 3),
         Action::Scroll(-(SPAN as isize)),
         Action::ScrollList(1),

--- a/crates/vigia/tests/sheet.rs
+++ b/crates/vigia/tests/sheet.rs
@@ -206,14 +206,19 @@ fn the_shell_starts_with_no_sheet_and_question_mark_is_what_opens_one() {
         Some(Action::ToggleSheet),
         "`?` is not bound to the sheet"
     );
-    // **`Esc` is still Quit**, which is B12's one refusal and the reason it gave:
-    // teaching `Esc` to dismiss would put it one keystroke from ending the
-    // program. A gate rather than a comment, because this is the arm a later
-    // reader is likeliest to 'improve'.
+    // **`Esc` asks to leave the frontmost thing, and B12's refusal was
+    // reversed by its own reason** ([#340](https://github.com/breferrari/vigia/issues/340)).
+    // That refusal said teaching `Esc` to dismiss *"would put it one keystroke
+    // from ending the program"*, and keeping it as Quit is what actually did:
+    // a reader pressed `Esc` to put this sheet away and the monitor exited,
+    // which is the worst place for that to happen, because the sheet is the
+    // surface somebody opens precisely when they are unsure what a key does.
+    // The rule B12 was protecting is untouched: `key_action` is still handed
+    // no state, and this is still one key with one meaning.
     assert_eq!(
         action_for(&press(KeyCode::Esc), Regions::default()),
-        Some(Action::Quit),
-        "`Esc` stopped quitting, so the sheet has taught the wrong reflex"
+        Some(Action::Escape),
+        "`Esc` no longer asks to leave the frontmost thing"
     );
 
     let scratch = Scratch::large_diff("sheet-open", FILES, 40);
@@ -1280,8 +1285,9 @@ fn every_gesture_the_readme_teaches_is_named_on_the_sheet() {
 ///
 /// The payloads are arbitrary. Both callers compare discriminants or ask
 /// [`reach_of`], and neither reads a value.
-const ALL_ACTIONS: [Action; 19] = [
+const ALL_ACTIONS: [Action; 20] = [
     Action::Quit,
+    Action::Escape,
     Action::Scroll(1),
     Action::ScrollList(1),
     Action::Page(1),
@@ -1336,8 +1342,11 @@ enum Reach {
 /// arms below are the whole of `Action`, and adding a variant reddens the build.
 fn reach_of(action: &Action) -> Reach {
     match action {
-        // The way out, and `q`, `Esc`, `Ctrl+C`, `Ctrl+D` are all keys.
+        // The way out, and `q`, `Ctrl+C`, `Ctrl+D` are all keys.
         Action::Quit => Reach::Keyboard,
+        // `Esc`, which leaves the sheet if one is up and the program if none
+        // is. A key, and the sheet's `leaving` group names it.
+        Action::Escape => Reach::Keyboard,
         // `a`, and the sheet's own row for it. No mouse gesture reaches it.
         Action::ToggleStaged => Reach::Keyboard,
         // `j`/`k`/arrows, and the wheel and the step buttons.
@@ -1552,6 +1561,7 @@ fn mouse_phrases() -> Vec<&'static str> {
             | Action::ToggleStaged
             | Action::ToggleSingle
             | Action::ToggleSheet
+            | Action::Escape
             | Action::Redraw => Vec::new(),
         });
     }
@@ -2479,7 +2489,7 @@ fn the_roomy_rung_is_the_size_the_ruling_states() {
         // written as the prefix both spellings share, so nothing else here can
         // see it. These three phrases exist only at the wide spelling.
         for wide in [
-            "q  Esc  Ctrl+C  Ctrl+D",
+            "q  Ctrl+C  Ctrl+D",
             "first / last changed file",
             "scroll the pinned file list",
         ] {
@@ -4610,4 +4620,42 @@ fn the_arrows_are_named_at_the_wide_spelling_and_not_the_tight_one() {
         "the tight spelling names the arrows, which takes the keyboard-only rung \
          from 35 columns to 37 and costs panes of 35 and 36 their gestures:\n{drawn}"
     );
+}
+
+/// `Esc` closes the sheet when one is up and quits when none is, which is the
+/// half of [#340](https://github.com/breferrari/vigia/issues/340) a keymap gate
+/// cannot see: `input::key_action` answers the same action either way, and
+/// which thing is frontmost is `App`'s question.
+#[test]
+fn escape_puts_the_sheet_away_before_it_puts_the_program_away() {
+    let scratch = Scratch::large_diff("sheet-escape", FILES, 40);
+    let worktree = scratch.worktree();
+    let mut frame = worktree.frame();
+    materialise(&mut frame);
+    let mut app = App::new();
+    let height = 20;
+
+    app.apply(Action::ToggleSheet, &mut frame, height)
+        .expect("open the sheet");
+    assert!(chrome(&app).sheet.is_some(), "the fixture opened no sheet");
+
+    // With a sheet up, `Esc` takes the sheet and leaves the program running.
+    let running = app
+        .apply(Action::Escape, &mut frame, height)
+        .expect("escape from the sheet");
+    assert!(
+        running,
+        "`Esc` ended the program while the gestures sheet was open"
+    );
+    assert!(
+        chrome(&app).sheet.is_none(),
+        "`Esc` left the sheet up, so it dismissed nothing"
+    );
+
+    // With none up, it is still the way out: a reader who has learned `Esc`
+    // does not have to learn a second key to leave.
+    let running = app
+        .apply(Action::Escape, &mut frame, height)
+        .expect("escape from the pane");
+    assert!(!running, "`Esc` no longer leaves the program");
 }

--- a/docs/THEME.md
+++ b/docs/THEME.md
@@ -37,8 +37,6 @@ What follows groups the keys by surface. The docblocks in `crates/vigia/src/them
 |---|---|
 | `chrome` | the header and footer lines |
 | `chrome_dim` | secondary chrome text: key hints, the follow marker, readouts, and the chrome rows' background |
-| `chip` | the pill behind a chrome segment: the header's branch and count, the footer's readouts; truecolour only |
-| `chip_accent` | the louder pill: the header's worktree name, the footer's state |
 | `note` | a stand-in for content there is no diff for: binary, conflict |
 | `alert` | something went wrong and the reader should know |
 


### PR DESCRIPTION
Fixes #340, and folds in the two README PRs (#338, #339) so everything the reader is looking at lands together.

## The stale-cell mechanism, and the two defects it caused

`put_linked` (#326) puts a whole OSC 8 link in one cell and declares its span with `CellDiffOption::ForcedWidth`. It then blanked the covered cells. ratatui's differ walks straight past a claimed span (`buffer/diff.rs`: advance `pos`, emit the first cell) with none of the shrink protection its `None` arm carries, so the buffer's record of those columns is the **only** thing that can ever force them repainted, and blanking them made the buffer say "empty" where the terminal was showing a path.

- **The covered columns now record the label.** A shorter path drawn where a longer one had been now differs across the uncovered tail, so it is emitted and the old tail goes. The shadow is never itself emitted, by construction: it exists so the *next* frame can tell what these columns show.
- **Nothing claims columns the sheet composites over.** `sheet_plan` was already a pure function of things known before painting, so it is computed once, up front, handed to the painter, and reused at the paint site rather than recomputed. A path whose link would reach under the sheet draws as plain text: what a reader loses is a link on a path the sheet is covering anyway.

Both are gated at the **buffer** rather than the backend, which is the half that matters: the backend is what the terminal was told, and the skipped columns are precisely what it was never told about. `a_linked_paths_covered_columns_record_what_the_terminal_shows` was mutation-checked (stub the shadow write, it fails).

## `Esc` leaves the frontmost thing

`Esc` quit the program from inside the gestures sheet, which is the worst place for it: the sheet is what a reader opens *because* they are unsure what a key does. B12's refusal is reversed **by its own reason** — it said dismissing *"would put it one keystroke from ending the program"*, and keeping it as Quit is what did.

B12's structural claim is intact. `input::key_action` is still handed no shell state and still maps one key to one action; the new `Action::Escape` has one meaning, the one every terminal program gives `Esc`, and *which thing is frontmost* is a question only `App` can answer, so `App` answers it. `q`, `Ctrl+C` and `Ctrl+D` are untouched.

Gated at both levels: the keymap, and `App::apply` (sheet up → sheet closes and the program keeps running; none up → it ends). The sheet's own `leaving` group tells the truth now, and **no field maximum moves**, so no width rung and no geometry gate does: the wide keys field is still 22, held by `J  K  Shift+↑  Shift+↓` which tied the old `q  Esc  Ctrl+C  Ctrl+D` exactly.

## The pills are removed

Reported as *"this looks bad... it's just a background and it's not even properly padded in some cases"*, and that is right. They were my call in #323: crush's pill shape lifted onto a dense monospace header, where it reads as highlight bars rather than structure, and the footer padded inconsistently because it computed spans differently from the header (`185MiB` fell outside its pill). `chip`/`chip_accent`, `chip_row`, `chip_span` and `footer_chips` are gone, along with the picture's pills and their prose. Refining them is a design piece, not a mid-regression patch; the header and footer are back to what shipped before.

## Folded in

#338's four false README statements (the precedence table's palette, glyphs and view rows, all of which contradicted prose in the same file) and the picture catching up: the sparklines now use the binary's own cyan stops rather than the green they were first mocked in. #339's missing prose: the wash and word emphasis, the sparkline ramp, and the path being a link. Both PRs close with this.

## Not fixed, and not claimed

The stale `›` continuation markers down the diff's right edge. Same signature, plausibly the same mechanism, but **it does not reproduce under tmux on either the released or this build**, so it stays open on #340. Worth checking against this branch on a real pane: if it is the same cause it is gone, and if it is not, the reproduction is the next thing to find.

## Checks

45 suites green, clippy and fmt clean. Verified live against a fixture with the reported path shapes: no bleed, both run headings correct, markers only on genuinely clipped rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
