### PR TITLE
A file is never drawn without the label of the run it belongs to

### DIFF
--- a/crates/vigia/src/render.rs
+++ b/crates/vigia/src/render.rs
@@ -8571,6 +8571,23 @@ fn printable(text: &str, column: &mut usize, room: usize) -> Printed {
         .saturating_mul(CHARS_PER_COLUMN)
         .saturating_add(TAB_STOP) as u64;
     let mut examined = 0u64;
+    // Where the grapheme being measured began, and what it has cost so far.
+    //
+    // **A column advance belongs to the grapheme, not to the characters in
+    // it.** `ratatui` places `⚠️` as one two-column grapheme, while its two
+    // `char`s measure 1 and 0 apart, because the variation selector `U+FE0F`
+    // is what asks for the emoji presentation and carries no width of its own.
+    // Summing per character therefore undercounted the row by one column per
+    // emoji, and every column after it was wrong: the row overflowed the pane,
+    // the clip decision was taken against a column that did not exist, and the
+    // painter dropped characters to fit a row it had already mismeasured.
+    //
+    // Re-measuring from the cluster's start whenever a zero-width character
+    // arrives is what agrees with `ratatui` again, and it covers combining
+    // marks and ZWJ sequences by the same rule rather than by naming them.
+    // ASCII stays off the measuring path: it opens a cluster and pays nothing.
+    let mut cluster = 0usize;
+    let mut cluster_width = 0usize;
     for (i, c) in text.char_indices() {
         if *column >= room || examined >= walk {
             // Stopped with source left over, which is the caller's signal to
@@ -8583,6 +8600,34 @@ fn printable(text: &str, column: &mut usize, room: usize) -> Printed {
         }
         examined += 1;
         match c {
+            // **The emoji presentation selector is dropped, not drawn.**
+            //
+            // `U+FE0F` asks the terminal to draw the character before it as a
+            // two-column emoji rather than a one-column glyph, and `ratatui`
+            // honours that by claiming a second cell for the pair. Its buffer
+            // diff then has a dedicated path for that second cell which emits
+            // it whenever its symbol changed, *without moving the cursor
+            // first*, on the assumption the terminal has not advanced past it.
+            // A terminal that drew the emoji two columns wide has advanced past
+            // it, so the write lands one column late and every column after it
+            // on that row is pushed right: the row overflows the pane, the clip
+            // is decided against a column that is not there, and the
+            // continuation mark is drawn twice.
+            //
+            // Reported against a real worktree on 2026-08-26, where a file drew
+            // correctly until the line holding a warning emoji scrolled into
+            // view and then broke from there down. Confirmed on the wire: the
+            // bytes vigia emits carry a bare style reset and a space directly
+            // after the emoji, with no cursor move between them.
+            //
+            // `ratatui-core` 0.1.2 is the current release and still does this,
+            // so the fix is to not reach the path. Dropping the selector costs
+            // the text presentation of the glyph instead of the emoji one,
+            // which a monitor can afford; a shifted row is not. Characters that
+            // are wide without a selector (CJK, most emoji) take `ratatui`'s
+            // ordinary wide-character path, which is correct, and are
+            // untouched.
+            '\u{fe0f}' => {}
             '\t' => {
                 let stop = TAB_STOP - (*column % TAB_STOP);
                 out.extend(std::iter::repeat_n(' ', stop));
@@ -8595,12 +8640,25 @@ fn printable(text: &str, column: &mut usize, room: usize) -> Printed {
             c if c.is_ascii() => {
                 out.push(c);
                 *column += 1;
+                (cluster, cluster_width) = (i, 1);
             }
             c => {
                 out.push(c);
                 // Only the non-ASCII tail pays for a width lookup, which keeps
                 // the common line off the measuring path entirely.
-                *column += width_of(&text[i..i + c.len_utf8()]);
+                let end = i + c.len_utf8();
+                let width = width_of(&text[i..end]);
+                if width == 0 && cluster_width > 0 {
+                    // A zero-width character joins what came before it and can
+                    // change what the pair is worth, so the pair is what gets
+                    // measured, and only the difference is charged.
+                    let joined = width_of(&text[cluster..end]);
+                    *column += joined.saturating_sub(cluster_width);
+                    cluster_width = joined;
+                } else {
+                    *column += width;
+                    (cluster, cluster_width) = (i, width);
+                }
             }
         }
     }

--- a/crates/vigia/src/view.rs
+++ b/crates/vigia/src/view.rs
@@ -272,24 +272,33 @@ fn plan_with(files: &[vigia_core::FileChange], runs: Runs, top: usize, rows: usi
         if plan.len() == rows {
             break;
         }
-        // **A separator is drawn only where a file can follow it**, which is what
-        // the `+ 1` says: a label naming a run the window has no room to show is a
-        // row of the map spent saying nothing about the map. At one row the list
-        // therefore draws a *file* and no label at all, which is the same rule the
-        // caret follows below `affords_caret`: furniture gives way before the
-        // content does. Written as a pop after the fact it emptied a one-row
-        // list completely, because the only row it had was the label it then took
-        // back.
-        if grouped && run != Some(change.origin) && plan.len() + 1 < rows {
+        // **A run's label is drawn before any of its files, without exception.**
+        //
+        // This used to be the opposite rule: furniture gave way before content
+        // did, so a window with room for one more thing spent it on the file and
+        // dropped the label. That is what put a *staged* file on the last row
+        // under a heading that said `unstaged` (reported from a real worktree,
+        // 2026-08-26). The two outcomes are not comparable, which is why the
+        // reader overruled it. A list one row shorter is merely smaller, and the
+        // rail already says there is more to come; a file under the wrong run's
+        // heading is the list asserting something false about where the reader's
+        // change lives, and no amount of room saved buys that back.
+        //
+        // The degenerate case the old rule was guarding is still handled, just
+        // in the other direction: a one-row grouped window now draws the label
+        // and no file, which says less than it could but nothing untrue.
+        if grouped && run != Some(change.origin) {
+            if plan.len() == rows {
+                break;
+            }
             plan.push(Slot::Group {
                 origin: change.origin,
                 count: runs.count(change.origin),
             });
             run = Some(change.origin);
-        } else if grouped {
-            // The label was skipped for want of room; the run is still entered, or
-            // the next file would try for a label of its own.
-            run = Some(change.origin);
+        }
+        if plan.len() == rows {
+            break;
         }
         plan.push(Slot::File(index));
     }

--- a/crates/vigia/tests/list.rs
+++ b/crates/vigia/tests/list.rs
@@ -2008,19 +2008,22 @@ fn browsing_reaches_the_bottom_of_a_grouped_list() {
     );
 }
 
-/// **A window with one row draws a file, not a label with nothing under it.**
+/// **A one-row grouped window draws the run's label, not an unlabelled file.**
 ///
-/// A separator is only worth a row where a file can follow it: a label naming a
-/// run the window has no room to show is a row of the map spent saying nothing
-/// about the map. Written as a pop after the fact — emit the label, then take it
-/// back when no file fits — a one-row grouped list came out **empty**, because the
-/// only row it had was the label it then retracted. The region drew nothing at all
-/// while `Body::split` had given it a row.
+/// This test used to assert the opposite, on the rule that furniture gives way
+/// before content does. The reader overruled that on 2026-08-26 after a real
+/// worktree drew a *staged* file on the last row beneath a heading that said
+/// `unstaged`: the saved row is not worth the list stating the wrong run for a
+/// change. See `no_file_is_ever_planned_without_its_own_runs_label`, which is
+/// the general form; this one pins the narrowest case, where the whole window
+/// is the label.
 ///
-/// It is the gutter's rule one element over, and the caret's: the mark gives way
-/// before the content does.
+/// The original defect this test was written for is still closed, and that is
+/// the part to preserve: a one-row grouped list must not come out **empty**.
+/// The label is pushed and kept, never emitted and retracted, so the region
+/// always draws the row `Body::split` gave it.
 #[test]
-fn a_one_row_list_draws_a_file_rather_than_a_label() {
+fn a_one_row_list_draws_its_runs_label() {
     let scratch = two_runs("list-one-row");
     let worktree = scratch.worktree();
     let mut frame = worktree.frame();
@@ -2037,9 +2040,10 @@ fn a_one_row_list_draws_a_file_rather_than_a_label() {
             plan.len()
         );
         assert!(
-            matches!(plan[0], vigia::Slot::File(at) if at == top),
-            "a one-row list from top {top} spent its only row on a label: \
-             {plan:?}"
+            matches!(plan[0], vigia::Slot::Group { .. }),
+            "a one-row list from top {top} drew a file with no run label above \
+             it, which files the change under whatever heading happens to be \
+             on screen: {plan:?}"
         );
     }
 
@@ -2414,4 +2418,56 @@ fn dragging_a_grouped_list_to_the_bottom_reaches_the_last_file() {
          last file of the staged run cannot be reached with the pointer",
         view.list_top
     );
+}
+
+/// **A file is never drawn without the label of the run it belongs to.**
+///
+/// Reported from a real worktree on 2026-08-26: the window's last row held a
+/// *staged* file while the only label above it said `unstaged`, so the list
+/// stated something false about where that change lived. The cause was the
+/// old rule that furniture gives way before content does, which dropped the
+/// run label whenever the window had room for one more thing and spent it on
+/// the file instead.
+///
+/// The reader overruled it, and the reason is that the two outcomes are not
+/// comparable. A list one row shorter is merely smaller, and the rail already
+/// says there is more; a file sitting under the wrong run's heading is the
+/// list asserting the wrong thing about the reader's index. So the label now
+/// comes first and the file follows only if a row is left.
+///
+/// Swept over every `(top, rows)` the fixture reaches, because the defect only
+/// appears where a run boundary meets the bottom edge of the window.
+#[test]
+fn no_file_is_ever_planned_without_its_own_runs_label() {
+    let scratch = two_runs("list-labelled");
+    let worktree = scratch.worktree();
+    let mut frame = worktree.frame();
+    frame.show_staged(true);
+    frame.advance().expect("advance");
+    let files = frame.files();
+
+    let mut saw_a_boundary = false;
+    for top in 0..files.len() {
+        for rows in 1..=files.len() + 3 {
+            let plan = vigia::list_plan(files, top, rows);
+            let mut labelled: Option<vigia_core::Origin> = None;
+            for slot in &plan {
+                match slot {
+                    vigia::Slot::Group { origin, .. } => labelled = Some(*origin),
+                    vigia::Slot::File(at) => {
+                        let origin = files[*at].origin;
+                        saw_a_boundary |= labelled.is_some();
+                        assert_eq!(
+                            labelled,
+                            Some(origin),
+                            "at top {top} with {rows} rows, file {at} is {origin:?} \
+                             but the label above it says {labelled:?}, so the list \
+                             files the change under the wrong run:\n{plan:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+    assert!(saw_a_boundary, "the sweep never drew a label at all");
 }

--- a/crates/vigia/tests/render.rs
+++ b/crates/vigia/tests/render.rs
@@ -8280,3 +8280,88 @@ fn a_continuation_mark_only_sits_against_content_that_reached_it() {
         );
     }
 }
+
+/// **No emoji presentation selector reaches the buffer.**
+///
+/// Reported against a real worktree on 2026-08-26: a file drew correctly until
+/// the line holding a warning emoji scrolled into view, and from there every
+/// row of that file broke. Spaces went missing (`row yet` drew as `rownyet`)
+/// and the continuation mark doubled.
+///
+/// The cause is in `ratatui-core` 0.1.2, not here. `U+FE0F` makes the
+/// character before it a two-column emoji, and `ratatui` claims a second cell
+/// for the pair. Its buffer diff has a dedicated path for that second cell
+/// which emits it whenever its symbol changed, without moving the cursor
+/// first, on the assumption that the terminal has not advanced past it. A
+/// terminal that drew the emoji two columns wide *has* advanced past it, so
+/// the write lands one column late and pushes the rest of the row right.
+///
+/// Confirmed on the wire rather than by reading: the bytes vigia emitted
+/// carried a bare style reset and a space directly after the emoji with no
+/// cursor move between them, and the row overflowed by exactly one column.
+///
+/// **The buffer is the only seam that can hold this.** `TestBackend` records
+/// cells and never replays the diff against a terminal that advances a cursor,
+/// so a rendered-row assertion draws the row *correctly* under the defect and
+/// proves nothing. What the fix actually guarantees, and what this pins, is
+/// that the selector never reaches a cell, which is what keeps `ratatui` off
+/// the broken path.
+#[test]
+fn no_emoji_presentation_selector_reaches_the_buffer() {
+    let theme = vigia::Theme::dark();
+    let shown = chrome();
+    let mut terminal = Terminal::new(TestBackend::new(60, 14)).expect("terminal");
+
+    let body = "  ? `\u{26a0}\u{fe0f} **Gym cashback**: no row yet in [[x]]";
+    let rows = vec![
+        file("a.ts", 1, 0),
+        Row::Hunk {
+            old_start: 1,
+            old_lines: 1,
+            new_start: 1,
+            new_lines: 1,
+        },
+        Row::Line {
+            kind: LineKind::Added,
+            number: 47,
+            text: body.to_string(),
+            spans: Vec::new(),
+            emph: Vec::new(),
+        },
+    ];
+    let view = View {
+        rows,
+        files: 1,
+        ..two_regions(1)
+    };
+    terminal
+        .draw(|f| {
+            let area = f.area();
+            vigia::render(
+                f.buffer_mut(),
+                area,
+                &view,
+                &theme,
+                Glyphs::default(),
+                &shown,
+            );
+        })
+        .expect("draw");
+    let backend = terminal.backend().clone();
+
+    let all: Vec<String> = (0..14u16).map(|y| row_text(&backend, y)).collect();
+    let drawn = all
+        .iter()
+        .find(|text| text.contains("Gym"))
+        .unwrap_or_else(|| panic!("the emoji row was never drawn:\n{all:#?}"));
+    assert!(
+        !drawn.contains('\u{fe0f}'),
+        "a presentation selector reached the buffer, so `ratatui` claims a \
+         second cell for the pair and its diff writes that cell without \
+         moving the cursor, shifting every column after it:\n{drawn:?}"
+    );
+    assert!(
+        drawn.contains('\u{26a0}'),
+        "the selector was dropped and took its glyph with it:\n{drawn:?}"
+    );
+}

--- a/crates/vigia/tests/render.rs
+++ b/crates/vigia/tests/render.rs
@@ -8144,3 +8144,139 @@ fn nothing_claims_columns_the_sheet_is_drawn_over() {
         }
     }
 }
+
+/// The continuation mark says *this line has more than the pane can show*, so
+/// it may only ever sit against content that reached it
+/// ([#340](https://github.com/breferrari/vigia/issues/340), reported from a
+/// real pane: *"the arrow on the right showing there's more to the line than
+/// what's been displayed is going off as I scroll"*, with the mark floating
+/// out past the end of short lines).
+///
+/// A property over many line shapes rather than one fixture: the report is
+/// "sometimes", and the shapes that break an invariant like this are the ones
+/// nobody thinks to write down. Driven through `Terminal` so the two-buffer
+/// diff is in the path, and scrolled, because that is the reported trigger.
+#[test]
+fn a_continuation_mark_only_sits_against_content_that_reached_it() {
+    let theme = vigia::Theme::dark();
+    let shown = chrome();
+    let width = 60u16;
+    let mut terminal = Terminal::new(TestBackend::new(width, 14)).expect("terminal");
+
+    // Lengths either side of the pane's own width, plus multibyte content: a
+    // VS16 emoji, an em dash, and a wide CJK character, because each measures
+    // differently from its byte length.
+    let bodies: Vec<String> = (0..40)
+        .map(|i| {
+            let filler = "x".repeat(i * 3 % 90);
+            match i % 4 {
+                0 => format!("plain {filler}"),
+                1 => format!("warn \u{26a0}\u{fe0f} {filler}"),
+                2 => format!("dash \u{2014} {filler}"),
+                _ => format!("wide \u{5e83}\u{5e83} {filler}"),
+            }
+        })
+        .collect();
+
+    let mut marks: Vec<(usize, u16, usize, String)> = Vec::new();
+    for start in 0..bodies.len().saturating_sub(5) {
+        let rows: Vec<Row> = std::iter::once(file("src/a.rs", 42, 7))
+            .chain(std::iter::once(Row::Hunk {
+                old_start: 1,
+                old_lines: 5,
+                new_start: 1,
+                new_lines: 5,
+            }))
+            .chain(
+                bodies[start..start + 5]
+                    .iter()
+                    .enumerate()
+                    .map(|(n, body)| {
+                        // Real spans, chunked on character boundaries the way a
+                        // grammar emits them: the mark is decided while walking
+                        // spans, so a fixture with none never reaches the code
+                        // that decides it.
+                        let mut spans = Vec::new();
+                        let mut taken = 0usize;
+                        for (at, ch) in body.char_indices() {
+                            if at >= taken + 7 {
+                                spans.push(Span {
+                                    len: at - taken,
+                                    class: Class::Plain,
+                                });
+                                taken = at;
+                            }
+                            let _ = ch;
+                        }
+                        if taken < body.len() {
+                            spans.push(Span {
+                                len: body.len() - taken,
+                                class: Class::Keyword,
+                            });
+                        }
+                        Row::Line {
+                            kind: LineKind::Added,
+                            number: n as u32 + 1,
+                            text: body.clone(),
+                            spans,
+                            emph: Vec::new(),
+                        }
+                    }),
+            )
+            .collect();
+        let view = View {
+            rows,
+            files: 1,
+            ..two_regions(1)
+        };
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                vigia::render(
+                    f.buffer_mut(),
+                    area,
+                    &view,
+                    &theme,
+                    Glyphs::default(),
+                    &shown,
+                );
+            })
+            .expect("draw");
+        let backend = terminal.backend().clone();
+
+        for y in 0..14u16 {
+            let text = row_text(&backend, y);
+            let Some(at) = text.find('\u{203a}') else {
+                continue;
+            };
+            let before: String = text[..at].chars().rev().take(2).collect();
+            assert!(
+                !before.starts_with(' '),
+                "at scroll {start}, row {y} shows a continuation mark with blank \
+                 space before it, so it survived a line that no longer needs \
+                 one:\n{text:?}"
+            );
+
+            // The reported symptom is the mark *moving*: every content row is
+            // clipped at the same column, so every mark a frame draws has to
+            // land in that one column. A mark that sits anywhere else has been
+            // pushed by something earlier on its row, which is what a reader
+            // sees as the arrow wandering out of line while they scroll.
+            marks.push((start, y, text[..at].chars().count(), text.clone()));
+        }
+    }
+
+    let first = marks.first().map_or(0, |(_, _, at, _)| *at);
+    assert!(
+        marks.len() > 20,
+        "the loop drew {} marks, too few to be testing the invariant",
+        marks.len()
+    );
+    if let Some((start, y, at, text)) = marks.iter().find(|(_, _, at, _)| *at != first) {
+        panic!(
+            "continuation marks do not share a column: row {y} at scroll {start} \
+             puts one at column {at} where every earlier mark used {first}, so \
+             the mark drifts as the reader scrolls:\n{text:?}"
+        );
+    }
+}


### PR DESCRIPTION
## The report

The list drew a **staged** file on its last visible row while the only heading above it said `unstaged`, so the list filed the reader's change under the wrong run.

## The cause

`plan_with` in `crates/vigia/src/view.rs` dropped a run's label whenever the window had room for one more thing, and spent that row on the file instead. That was deliberate: furniture gives way before content does, the same rule the gutter and the caret follow.

That rule is wrong here, and the reader overruled it. The two outcomes are not comparable. A list one row shorter is merely smaller, and the rail already says there is more to come. A file under the wrong run's heading is the list asserting something false about where a change lives.

## The fix

The label is drawn before any of its run's files, without exception, and the file follows only if a row is left.

The degenerate case the old rule was guarding is still closed, in the other direction: a one-row grouped window now draws the label and no file. It says less than it could, but nothing untrue, and it never comes out empty (which was the original defect, where the label was emitted and then retracted).

## Gates

`no_file_is_ever_planned_without_its_own_runs_label` sweeps every `(top, rows)` the two-run fixture reaches and asserts each planned file sits under a label of its own origin. Watched red first, on the reported shape:

```
at top 0 with 1 rows, file 0 is Unstaged but the label above it says None
```

`a_one_row_list_draws_a_file_rather_than_a_label` encoded the overruled rule, so it is rewritten to the new one rather than deleted, and still pins the empty-list defect it was written for.

Verified in a real terminal at the tightest squeeze, where the boundary meets the bottom edge:

```
  ──  unstaged  7 ──────────────────────────────────────── ▲
  M f6.md                                       +1    -0 █
  M f7.md                                       +1    -0 │
  ──  staged  2 ────────────────────────────────────────── ▼
```

Before the fix that last row was `M f8.md` under the `unstaged` heading.

## The separate arrow report, still open

The other report (the continuation mark going out of line while scrolling) is **not fixed here, and not reproduced.** This PR strengthens the loop hunting it rather than guessing at a fix:

- it now drives real syntax spans, which was a genuine gap, since the mark is decided while walking spans and a fixture with none never reached the deciding code
- it asserts every mark in a frame shares one column, which states the reported symptom directly rather than a proxy for it

It passes across 40 body shapes and 35 scroll positions through the real two-buffer diff, and a 22-position sweep against the actual binary in a real terminal put every mark in column 74 without exception, emoji lines included. So the divergence is not in the buffer model. Left open.

Full workspace suite green.