### PR TITLE
A list that is entirely staged says so, and reads as staged

### DIFF
--- a/crates/vigia/src/view.rs
+++ b/crates/vigia/src/view.rs
@@ -199,11 +199,13 @@ pub fn list_plan(files: &[vigia_core::FileChange], top: usize, rows: usize) -> V
 /// files, the staged run's heading, and **none of the staged files** — the run the
 /// reader pressed `a` for, announced and then empty.
 ///
-/// The two separators are drawn whenever both runs have files, which is the same
-/// condition [`list_plan`] groups on and is resolved the same way, so the request
-/// and the plan cannot disagree about how many rows a window needs.
+/// A separator is drawn per run that has files, which is the same condition
+/// [`list_plan`] groups on and is resolved the same way, so the request and the
+/// plan cannot disagree about how many rows a window needs. That is two for a
+/// list holding both runs and one for a list that is entirely staged.
 pub fn list_rows_wanted(files: &[vigia_core::FileChange]) -> usize {
-    files.len() + if Runs::of(files).grouped() { 2 } else { 0 }
+    let runs = Runs::of(files);
+    files.len() + runs.separators()
 }
 
 /// How many files each run holds, counted once.
@@ -243,8 +245,37 @@ impl Runs {
     }
 
     /// Whether the list draws run separators at all.
+    ///
+    /// **The question is whether a staged run exists, not whether both runs
+    /// do.** It used to be both, and that made the view which most needs to
+    /// announce itself, the one where *everything* is staged, the one that said
+    /// nothing: no heading, and `None` for
+    /// [`Heading::origin`](crate::render) to match on, which takes the ink for
+    /// unstaged. A reader could not tell it from the default view (reported
+    /// 2026-08-26).
+    ///
+    /// Dropping the labels is still right for a list that is entirely unstaged,
+    /// because unstaged is what a reader is looking at unless something says
+    /// otherwise, and a label on every row of the only run there is says
+    /// nothing. It is wrong for a list that is entirely staged, where the same
+    /// silence states the opposite of the truth.
     fn grouped(self) -> bool {
-        self.unstaged > 0 && self.staged > 0
+        self.staged > 0
+    }
+
+    /// How many separators a grouped list draws: one per run that has files.
+    ///
+    /// Two while both runs hold files, and one for a list that is entirely
+    /// staged. Kept here rather than spelled `2` at the call site because
+    /// [`list_rows_wanted`] sizes the region from it, and a region sized for
+    /// more separators than the plan draws leaves a blank row while one sized
+    /// for fewer drops the tail of the last run
+    /// ([#313](https://github.com/breferrari/vigia/issues/313)).
+    fn separators(self) -> usize {
+        if !self.grouped() {
+            return 0;
+        }
+        usize::from(self.unstaged > 0) + usize::from(self.staged > 0)
     }
 
     fn count(self, origin: Origin) -> usize {

--- a/crates/vigia/tests/list.rs
+++ b/crates/vigia/tests/list.rs
@@ -2471,3 +2471,61 @@ fn no_file_is_ever_planned_without_its_own_runs_label() {
     }
     assert!(saw_a_boundary, "the sweep never drew a label at all");
 }
+
+/// **A list that is entirely staged still says so, and its rows still read as
+/// staged.**
+///
+/// Reported from a real worktree on 2026-08-26: with both changed files staged
+/// and nothing unstaged, the list drew no `staged` heading at all and the kind
+/// letters took the ordinary ink rather than the staged one. Unstaging one file
+/// made both headings and both inks appear. So the view that most needs to
+/// announce itself, the one where *everything* is staged, was the one that said
+/// nothing, and it was indistinguishable from the default unstaged view.
+///
+/// One decision caused both halves. `Runs::grouped` asked whether **both** runs
+/// held files, and `Heading::origin` is `grouped.then_some(entry.origin)`, so a
+/// single-run view dropped its run's identity entirely: no label to draw, and
+/// `None` for the ink to match on, which falls to the unstaged case.
+///
+/// Dropping it is right for a list that is entirely unstaged, because unstaged
+/// is what a reader is looking at unless told otherwise. It is wrong for a list
+/// that is entirely staged, which is the one case where the absence of a label
+/// states the opposite of the truth. So the question is now whether a staged run
+/// exists at all.
+#[test]
+fn an_entirely_staged_list_announces_itself() {
+    let scratch = support::Scratch::new("list-all-staged");
+    for i in 0..3 {
+        scratch.write(&format!("src/f{i}.rs"), "one\ntwo\nthree\n");
+    }
+    scratch.git(&["add", "-A"]);
+    scratch.git(&["commit", "-m", "init"]);
+    for i in 0..3 {
+        scratch.write(&format!("src/f{i}.rs"), "one\nSTAGED\nthree\n");
+    }
+    scratch.git(&["add", "-A"]);
+
+    let worktree = scratch.worktree();
+    let mut frame = worktree.frame();
+    frame.show_staged(true);
+    frame.advance().expect("advance");
+    let files = frame.files();
+    assert_eq!(files.len(), 3, "the fixture is not three staged files");
+
+    let plan = vigia::list_plan(files, 0, 8);
+    assert!(
+        plan.iter().any(|slot| matches!(
+            slot,
+            vigia::Slot::Group { origin: staged_origin, .. } if *staged_origin == vigia_core::Origin::Staged
+        )),
+        "an entirely staged list drew no staged heading, so it reads as the \
+         default unstaged view:\n{plan:?}"
+    );
+    // And the region must be sized for the heading it now draws, or the label
+    // is announced and the run's tail falls off the bottom (#313).
+    assert_eq!(
+        vigia::list_rows_wanted(files),
+        files.len() + 1,
+        "the list asks for a row count that does not include its one heading"
+    );
+}


### PR DESCRIPTION
## The report

With both changed files staged and nothing unstaged, the list drew **no `staged` heading**, and the kind letters took the ordinary ink rather than the staged green. Unstaging one file made both headings and both inks appear.

That is the tell. The view that most needs to announce itself, the one where everything is staged, was the one that said nothing, and it was indistinguishable from the default unstaged view.

## The cause

One decision caused both halves. `Runs::grouped` asked whether **both** runs held files:

```rust
fn grouped(self) -> bool {
    self.unstaged > 0 && self.staged > 0
}
```

and `Heading::origin` is `grouped.then_some(entry.origin)`. So a single-run view dropped its run's identity entirely: no label to draw, and `None` for the ink to match on, which falls through to the unstaged case in `file_row`.

## The fix

The question is now whether a staged run exists at all.

Dropping the labels is still right for a list that is entirely unstaged, because unstaged is what a reader is looking at unless something says otherwise, and a label on every row of the only run there is says nothing. It is wrong for a list that is entirely staged, where the same silence states the opposite of the truth.

Separator count follows the same rule rather than being spelled `2` at the call site: one per run that has files. `list_rows_wanted` sizes the region from it, and a region sized for more separators than the plan draws leaves a blank row, while one sized for fewer drops the tail of the last run (#313).

## Gates

`an_entirely_staged_list_announces_itself` was watched red on the reported shape:

```
an entirely staged list drew no staged heading, so it reads as the default unstaged view:
[File(0), File(1), File(2)]
```

It also pins the row count, so the heading cannot be announced at the cost of the run's tail.

This is the case my previous sweep in #342 could not reach: it ran over a two-run fixture, so a list with only one run was never planned.

## Verified in a real terminal

Entirely staged, after:

```
  ──  staged  2 ──────────────────────────────────────────────
▸ M one.swift                          ■■■■■■■■■■■■    +1    -1
  M two.swift                          ■■■■■■■■■■■■    +1    -1
```

with the kind letter emitting `38;2;63;185;80`, the staged green. Before, there was no heading row at all and the letter took the ordinary ink.

Mixed runs are unchanged:

```
  ──  unstaged  7 ────────────────────────────────────────────
  M f6.md ...
  M f7.md ...
  ──  staged  2 ──────────────────────────────────────────────
  M f8.md ...
```

Full workspace suite green.