### PR TITLE
ci complete no longer fails a draft on its own skipped legs

### DIFF
--- a/.github/scripts/ci-complete.sh
+++ b/.github/scripts/ci-complete.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Judges whether every required leg of `ci.yml` ran and passed.
+#
+# Lives in a file rather than inline in the workflow so it can be driven with
+# fabricated results from a test. The shape it has to get right is narrow and
+# was got wrong inline: a draft skips every leg by design, and judging those
+# skips as failure turns the required check red on every push to a draft.
+#
+# Usage: ci-complete.sh <draft> <result>...
+#   draft   "true" when the event is a draft pull request
+#   result  one leg's result, in workflow order
+set -eu
+
+draft="${1:?draft flag}"
+shift
+
+[ "$#" -gt 0 ] || { echo "::error::no leg results were passed"; exit 1; }
+
+total=0
+skipped=0
+for result in "$@"; do
+    total=$((total + 1))
+    [ "$result" = "skipped" ] && skipped=$((skipped + 1))
+    echo "leg $total: $result"
+done
+
+# A draft skips its legs on purpose, and the full matrix runs on
+# `ready_for_review`. Only the whole set counts: a draft that skipped some legs
+# and ran others is the partial run this gate exists to catch.
+if [ "$draft" = "true" ] && [ "$skipped" -eq "$total" ]; then
+    echo "draft: all $total legs skipped by design, the matrix runs when it is marked ready"
+    exit 0
+fi
+
+for result in "$@"; do
+    if [ "$result" != "success" ]; then
+        echo "::error::a required leg reported '$result' rather than success"
+        exit 1
+    fi
+done
+
+echo "all $total legs passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,35 +336,27 @@ jobs:
   # notice an absent matrix would go absent with it, which is the failure it
   # exists to catch wearing the fix's clothes.
   #
-  # It carries no draft guard, deliberately. On a draft every `needs` job is
-  # skipped and this reports failure, which is correct: a draft has not been
-  # checked, and the check list should say so rather than showing seven skips that
-  # read as a clean run.
+  # It carries no draft guard and still runs on a draft, so the required check
+  # always reports rather than going absent. What it must not do is judge a
+  # draft's skips as failure: that turned the check red on every push to a
+  # draft, and a draft cannot be merged in any case, so the run it would be
+  # protecting cannot happen. `ready_for_review` is in this workflow's trigger
+  # list so the full matrix runs the moment the work is claimed finished.
   ci-complete:
     name: ci complete
     if: always()
     needs: [lint, test, benches, pure-rust, musl]
     runs-on: ubuntu-latest
     steps:
-      # Every result, not just failures: `skipped` and `cancelled` are the two
-      # this exists for and neither is a failure. Printed before it is judged, so
-      # a red build says which leg was missing rather than only that one was.
+      - uses: actions/checkout@v5
+      # The judgement lives in a script so a test can drive it with fabricated
+      # results. Inline, the draft case was unreachable from any gate.
       - name: every leg ran and passed
         run: |
-          echo 'lint=${{ needs.lint.result }}'
-          echo 'test=${{ needs.test.result }}'
-          echo 'benches=${{ needs.benches.result }}'
-          echo 'pure-rust=${{ needs.pure-rust.result }}'
-          echo 'musl=${{ needs.musl.result }}'
-          for result in \
+          sh .github/scripts/ci-complete.sh \
+            '${{ github.event.pull_request.draft }}' \
             '${{ needs.lint.result }}' \
             '${{ needs.test.result }}' \
             '${{ needs.benches.result }}' \
             '${{ needs.pure-rust.result }}' \
             '${{ needs.musl.result }}'
-          do
-            if [ "$result" != "success" ]; then
-              echo "::error::a required leg reported '$result' rather than success"
-              exit 1
-            fi
-          done

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -1988,3 +1988,88 @@ fn the_readme_states_the_grammar_count_the_dump_holds() {
          Whichever moved, they have to move together"
     );
 }
+
+/// Drives the judgement `ci complete` runs, with fabricated leg results.
+fn ci_complete(draft: &str, legs: &[&str]) -> bool {
+    let script = repo_root().join(".github/scripts/ci-complete.sh");
+    std::process::Command::new("sh")
+        .arg(&script)
+        .arg(draft)
+        .args(legs)
+        .output()
+        .unwrap_or_else(|e| panic!("run {}: {e}", script.display()))
+        .status
+        .success()
+}
+
+/// A draft's skipped legs are not a failure, and everything else still is.
+///
+/// The judgement was inline in the workflow and judged a draft's skips as
+/// failure, so the required check went red on every push to a draft. The cases
+/// below are the ones that distinguish "nothing ran because it is a draft" from
+/// "something did not run", which is the whole of what this gate has to know.
+#[test]
+fn ci_complete_passes_a_draft_that_skipped_everything_and_nothing_else() {
+    const OK: [&str; 5] = ["success"; 5];
+
+    assert!(ci_complete("false", &OK), "a full green run has to pass");
+    assert!(
+        ci_complete("true", &["skipped"; 5]),
+        "a draft skips every leg by design and the matrix runs on ready_for_review"
+    );
+
+    for (draft, legs, why) in [
+        (
+            "false",
+            ["success", "skipped", "success", "success", "success"],
+            "a leg that skipped on a ready PR is the absent matrix this gate exists for",
+        ),
+        (
+            "true",
+            ["skipped", "success", "skipped", "skipped", "skipped"],
+            "a draft that ran some legs and skipped others is a partial run",
+        ),
+        (
+            "false",
+            ["success", "failure", "success", "success", "success"],
+            "a failing leg fails the gate",
+        ),
+        (
+            "true",
+            ["skipped", "failure", "skipped", "skipped", "skipped"],
+            "a draft cannot launder a failing leg through its skips",
+        ),
+        (
+            "false",
+            ["success", "cancelled", "success", "success", "success"],
+            "a cancelled leg never reported and is not a pass",
+        ),
+    ] {
+        assert!(!ci_complete(draft, &legs), "{why}");
+    }
+
+    assert!(
+        !ci_complete("false", &[]),
+        "no results at all means the workflow stopped passing them, not that every leg passed"
+    );
+}
+
+/// The workflow calls the script the gate above proves.
+///
+/// Without this the script could be correct and unreached, which is the same
+/// shape as the defect it replaced.
+#[test]
+fn the_ci_workflow_runs_the_script_the_gate_proves() {
+    let ci = read(&repo_root().join(".github/workflows/ci.yml"));
+    assert!(
+        ci.contains(".github/scripts/ci-complete.sh"),
+        "ci.yml does not run ci-complete.sh, so its judgement is gated in a test and unused in CI"
+    );
+    for leg in ["lint", "test", "benches", "pure-rust", "musl"] {
+        let arg = format!("needs.{leg}.result");
+        assert!(
+            ci.contains(&arg),
+            "ci.yml does not pass {arg} to the script, so that leg is judged by nothing"
+        );
+    }
+}

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -1990,6 +1990,13 @@ fn the_readme_states_the_grammar_count_the_dump_holds() {
 }
 
 /// Drives the judgement `ci complete` runs, with fabricated leg results.
+///
+/// Unix only, and the test below is scoped to match. The script is POSIX shell
+/// run by a job whose `runs-on` is `ubuntu-latest`, so Windows never executes
+/// it; driving it there through Git Bash failed on the extended-length path
+/// `canonicalize` returns. `the_ci_workflow_runs_the_script_the_gate_proves`
+/// pins that `runs-on` on every platform, so this scoping cannot go stale.
+#[cfg(unix)]
 fn ci_complete(draft: &str, legs: &[&str]) -> bool {
     let script = repo_root().join(".github/scripts/ci-complete.sh");
     std::process::Command::new("sh")
@@ -2004,10 +2011,13 @@ fn ci_complete(draft: &str, legs: &[&str]) -> bool {
 
 /// A draft's skipped legs are not a failure, and everything else still is.
 ///
+/// See [`ci_complete`] for why this is Unix only.
+///
 /// The judgement was inline in the workflow and judged a draft's skips as
 /// failure, so the required check went red on every push to a draft. The cases
 /// below are the ones that distinguish "nothing ran because it is a draft" from
 /// "something did not run", which is the whole of what this gate has to know.
+#[cfg(unix)]
 #[test]
 fn ci_complete_passes_a_draft_that_skipped_everything_and_nothing_else() {
     const OK: [&str; 5] = ["success"; 5];
@@ -2072,4 +2082,21 @@ fn the_ci_workflow_runs_the_script_the_gate_proves() {
             "ci.yml does not pass {arg} to the script, so that leg is judged by nothing"
         );
     }
+
+    // The gate that drives the script is Unix only, which is sound exactly
+    // while the job stays on a Unix runner. Asserted here because this test
+    // runs on every platform and that one does not.
+    let (_, after) = ci
+        .split_once("  ci-complete:")
+        .expect("ci.yml declares the ci-complete job");
+    let runs_on = after
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("runs-on:"))
+        .map(str::trim)
+        .expect("ci-complete declares a runner");
+    assert_eq!(
+        runs_on, "ubuntu-latest",
+        "ci-complete moved to {runs_on:?}, so the Unix-only gate over its script \
+         no longer covers where it runs"
+    );
 }


### PR DESCRIPTION
## What is broken

Nineteen of the last twenty-nine failed CI runs had every leg `skipped` and `ci complete` fail anyway. That is two thirds of all CI failures, and it is deterministic rather than flaky: it fires on every push to a draft PR. The five working jobs carry `if: github.event.pull_request.draft != true` and skip. The aggregator carries only `if: always()`, runs, and judges those skips as failure.

Verified against run 32999138417, whose log reads `lint=skipped test=skipped benches=skipped pure-rust=skipped musl=skipped` and then exits 1.

## The reason it was that way, and why it does not reach the case

The missing guard was deliberate and documented. The reason given was that a draft has not been checked, so the check list should say so rather than showing skips that read as a clean run.

That is right about the danger and wrong about this case. A draft cannot be merged at all, so the merge it would be protecting cannot happen, and `ready_for_review` is already in this workflow's trigger list so the full matrix runs the moment the work is claimed finished. The guard was paying two thirds of CI's red for a hole another mechanism already closes.

## What did not change

The job still runs on a draft rather than skipping alongside its legs. A skipped required check can be read as satisfied by branch protection, which is the failure the original comment was right about. The aggregator keeps reporting; only its verdict moves.

## What changed

The judgement moved to `.github/scripts/ci-complete.sh`, because inline in the workflow it was unreachable from any gate. Only the whole set counts: a draft that skipped every leg passes, and a draft that ran some legs and skipped others is the partial run this gate exists to catch. A failing or cancelled leg still fails in every case, draft or not.

## Verification

`ci_complete_passes_a_draft_that_skipped_everything_and_nothing_else` drives the script over seven result shapes. It was watched failing before the fix existed.

Checked by mutation in both directions, because a gate that only ever sees the fixed code proves nothing about its bounds:

| mutation | result |
|---|---|
| restore the original judgement | red on the draft case |
| tolerate any draft regardless of skips | red on the partial-skip case |

`the_ci_workflow_runs_the_script_the_gate_proves` asserts the workflow actually calls the script and passes all five leg results to it, since a correct and unreached judgement is the same shape as the defect it replaces.

`cargo test --workspace` green, `cargo fmt --check` and `cargo clippy -D warnings` clean by exit code, and `package.rs`'s nineteen-escaping-files count is untouched because a shell script is not a test file.

## This PR is its own demonstration

Opened as a draft on purpose. With the old judgement its `ci complete` would be red on skipped legs. With this one it should be green, and marking it ready then runs the full matrix against the code.

Closes #267.
