### PR TITLE
a stop ends the wait even when a burst is open

### DIFF
--- a/crates/vigia-core/src/watch.rs
+++ b/crates/vigia-core/src/watch.rs
@@ -347,9 +347,12 @@ impl<'repo> Watcher<'repo> {
                     Ok(message) => {
                         self.stats.wakeups += 1;
                         match self.accept(message) {
-                            // Stopped mid-burst: report what we already have,
-                            // so the caller draws before it shuts down.
-                            None => break,
+                            // A stop ends the wait whether or not a burst is
+                            // open. Returning the partial burst instead would
+                            // make a stop mean "one more tick, then stop",
+                            // which is neither what `Stop` documents nor what a
+                            // timeout built on it can read.
+                            None => return None,
                             Some(accepted) if accepted.relevant => {
                                 events += 1;
                                 // Only an event that named a file adds one. An

--- a/crates/vigia-core/tests/watch.rs
+++ b/crates/vigia-core/tests/watch.rs
@@ -409,3 +409,51 @@ fn a_stopper_unblocks_a_waiting_watcher() {
     );
     stopper.join().expect("stopper thread");
 }
+
+/// A stop unblocks with `None` even when a burst is already open.
+///
+/// The burst loop used to break out and fall through to its `Some(Tick)`, so a
+/// stop meant "one more tick, then stop" whenever anything was mid-arrival.
+/// `tick_within` builds its timeout on a stop, so a timeout could report a tick
+/// that had not arrived in time.
+///
+/// The quiet window is widened well past the default 16ms on purpose: the stop
+/// has to land *inside* the burst, and against the default it lands after the
+/// burst has already closed on its own and proves nothing.
+#[test]
+fn a_stop_that_lands_mid_burst_still_returns_none() {
+    const QUIET: Duration = Duration::from_millis(500);
+
+    let scratch = committed_scratch("watch-stop-midburst");
+    let worktree = scratch.worktree();
+    let mut watcher = worktree
+        .watch(WatchOptions {
+            quiet: QUIET,
+            max_delay: Duration::from_secs(5),
+        })
+        .expect("watch");
+
+    let stop = watcher.stopper();
+    // Opens a burst the quiet window will hold open long enough to stop inside.
+    scratch.write("a.txt", "y\n");
+    let stopper = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(60));
+        stop.stop();
+    });
+
+    let started = std::time::Instant::now();
+    let got = watcher.next_tick();
+    let waited = started.elapsed();
+    stopper.join().expect("stopper thread");
+
+    // Proves the stop is what ended the wait rather than the quiet window:
+    // closing on quiet would take QUIET, and this returns in about 60ms.
+    assert!(
+        waited < QUIET,
+        "the burst closed on its own after {waited:?}, so this never tested a stop"
+    );
+    assert_eq!(
+        got, None,
+        "a stop landed while a burst was open and returned a tick instead of ending the wait"
+    );
+}


### PR DESCRIPTION
## The mechanism

`next_tick`'s burst loop broke out on a `Stop` and fell through to its `return Some(Tick)`, so a stop meant "one more tick, then stop" whenever anything was mid-arrival.

Three docstrings in the product already said otherwise. `Stop::stop` is documented as "wake the watcher and make its current `next_tick` return `None`", and `app.rs` and `lib.rs` both restate it. The mid-burst flush was the undocumented half, and its stated reason was to let the caller draw before shutting down. Nothing in the product holds a `Stop` handle, and `lib.rs` says so outright where the watch loop ends. The flush served a caller that does not exist.

What it did serve was the flake. `tick_within` builds its timeout out of a stop, and its own docstring claims `None` means the watcher was still waiting when time ran out. That was false whenever a burst was open: the timeout returned a partial tick instead, which reads as a tick that arrived in time.

Both reported `watch.rs` failures are that. On a loaded runner the fixture's own `.git/index`, `.git/HEAD` and `.git/refs` writes are relevant by `watched_in_git_dir`, land after the watcher registers, and open a burst for the timeout to land inside. That is the reported `Tick { events: 4, coalesced_for: 121.2ms, paths: [] }`, whose empty path list is the tell: those events name no worktree file.

## What is not changed

Neither failing test, and no assertion anywhere. One line makes four docstrings true and both tests correct as written. `.git/objects` filtering was never the problem; `watched_in_git_dir` already returns false for it.

## The gate, and an earlier draft of it that proved nothing

`a_stop_that_lands_mid_burst_still_returns_none` widens the quiet window well past the default 16ms on purpose. Against the default, a stop scheduled after the burst opens lands once the burst has already closed on its own, and the returned tick is an ordinary one. An earlier draft of this gate did exactly that and passed for the wrong reason, with a `coalesced_for` of 16.08ms that matched the quiet window rather than the stop.

It now asserts the wait ended in less than the quiet window, so it cannot degenerate back into that case. Against the old behaviour it fails with `Tick { events: 1, coalesced_for: 60.06ms }`, where 60ms is the stop and 500ms would have been the window.

## Verification

Full workspace suite green, 46 test binaries. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean by exit code.

Separately: the flake does not reproduce on Linux. Seventy runs of the `watch.rs` binary idle, under CPU load, under filesystem-event load on the temp directory the fixtures use, constrained to two cores, and on one core with sixteen test threads, produced zero failures. Load was never the variable. It only decides whether a burst is open, and the returned tick is deterministic once one is.

## What this does not close

Addresses the three `watch.rs` failures in #337. The musl `budgets.rs::the_frame_budget_holds_through_a_bulk_rewrite` failure listed in the same issue is a different test failing its own fixture-validity guard, and is untouched here.
