### PR TITLE
ci complete accepts the empty draft flag a push sends

### DIFF
--- a/.github/scripts/ci-complete.sh
+++ b/.github/scripts/ci-complete.sh
@@ -7,11 +7,14 @@
 # skips as failure turns the required check red on every push to a draft.
 #
 # Usage: ci-complete.sh <draft> <result>...
-#   draft   "true" when the event is a draft pull request
+#   draft   "true" for a draft pull request. Empty on a push, where the event
+#           carries no pull request at all, and anything but "true" means the
+#           legs were expected to run.
 #   result  one leg's result, in workflow order
 set -eu
 
-draft="${1:?draft flag}"
+[ "$#" -ge 1 ] || { echo "::error::no arguments were passed"; exit 1; }
+draft="$1"
 shift
 
 [ "$#" -gt 0 ] || { echo "::error::no leg results were passed"; exit 1; }

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -2025,6 +2025,13 @@ fn ci_complete_passes_a_draft_that_skipped_everything_and_nothing_else() {
     const OK: [&str; 5] = ["success"; 5];
 
     assert!(ci_complete("false", &OK), "a full green run has to pass");
+    // A push carries no pull request, so the workflow passes an empty draft
+    // flag. Reading that as "not a draft" is the whole of it, and reading it as
+    // an error turned every push to `main` red.
+    assert!(
+        ci_complete("", &OK),
+        "a push has no pull request and its draft flag is empty, which is not an error"
+    );
     assert!(
         ci_complete("true", &["skipped"; 5]),
         "a draft skips every leg by design and the matrix runs on ready_for_review"
@@ -2056,6 +2063,16 @@ fn ci_complete_passes_a_draft_that_skipped_everything_and_nothing_else() {
             ["success", "cancelled", "success", "success", "success"],
             "a cancelled leg never reported and is not a pass",
         ),
+        (
+            "",
+            ["skipped", "skipped", "skipped", "skipped", "skipped"],
+            "a push is never a draft, so legs that all skipped on one did not run and should have",
+        ),
+        (
+            "",
+            ["success", "failure", "success", "success", "success"],
+            "a failing leg on a push fails the gate like any other",
+        ),
     ] {
         assert!(!ci_complete(draft, &legs), "{why}");
     }
@@ -2076,6 +2093,14 @@ fn the_ci_workflow_runs_the_script_the_gate_proves() {
     assert!(
         ci.contains(".github/scripts/ci-complete.sh"),
         "ci.yml does not run ci-complete.sh, so its judgement is gated in a test and unused in CI"
+    );
+    // The gate above drives the script with whatever a test passes. This pins
+    // the shape production actually sends, which is where it broke: on a push
+    // the expression below expands to nothing at all.
+    assert!(
+        ci.contains("github.event.pull_request.draft }}'"),
+        "ci.yml does not pass the draft expression to the script, so the gate's draft \
+         cases are testing an argument production never sends"
     );
     for leg in ["lint", "test", "benches", "pure-rust", "musl"] {
         let arg = format!("needs.{leg}.result");


### PR DESCRIPTION
Every push to `main` has failed since #347 merged, with all five legs reporting `success` and `ci complete` failing anyway. Run 33013521692 is the shape: seven green jobs, then `.github/scripts/ci-complete.sh: 14: 1: draft flag`.

On a push the event carries no pull request, so `github.event.pull_request.draft` expands to nothing. The script read its first argument with `${1:?draft flag}`, and that treats an empty value as unset, so it exited 2 before judging any leg.

An empty flag means the legs were expected to run, which is every case that is not a draft pull request. The two guards that were doing real work are kept and separated: no arguments at all is still an error, and no leg results is still an error.

## Why the gate did not catch it

It had seven cases and none of them was a push. It drove the script with `"false"` where production sends `""`, so every draft case was testing an argument production never sends. That is the same defect class the original PR was fixing, one layer up: a judgement that is correct and unreached.

Four cases added, including the two a push produces (all green, and one failing leg), plus a push whose legs all skipped, which is still an error because a push is never a draft. `the_ci_workflow_runs_the_script_the_gate_proves` now also pins that the workflow passes the draft expression at all, so the gate and production cannot drift apart on the argument again.

Checked by mutation: restoring `${1:?draft flag}` fails the new push case.
