### PR TITLE
a fixture settles before anything measures it

### DIFF
--- a/crates/vigia-core/tests/support/mod.rs
+++ b/crates/vigia-core/tests/support/mod.rs
@@ -740,6 +740,59 @@ pub struct Scratch {
     path: PathBuf,
 }
 
+/// Wait until nothing under `root` is still moving.
+///
+/// The owning form is [`Scratch::settled`]; this one is for a measurement that
+/// already holds a path rather than the fixture.
+pub fn settle_tree(root: &Path) {
+    const STILL_FOR: Duration = Duration::from_millis(40);
+    const GIVE_UP_AFTER: Duration = Duration::from_secs(10);
+
+    let deadline = Instant::now() + GIVE_UP_AFTER;
+    let mut last = tree_fingerprint(root);
+    loop {
+        std::thread::sleep(STILL_FOR);
+        let now = tree_fingerprint(root);
+        if now == last {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the fixture at {} was still changing after {GIVE_UP_AFTER:?}, so nothing \
+             measured against it would be measuring the test",
+            root.display()
+        );
+        last = now;
+    }
+}
+
+/// Every entry under `root` with the two facts a write moves.
+///
+/// Read errors are folded into the reading rather than raised: an entry can
+/// vanish between the walk and the stat while git is renaming, and that is
+/// exactly the motion being waited out.
+fn tree_fingerprint(root: &Path) -> Vec<(PathBuf, u64, Option<std::time::SystemTime>)> {
+    let mut found = Vec::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(dir) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(meta) = std::fs::symlink_metadata(&path) else {
+                continue;
+            };
+            if meta.is_dir() {
+                pending.push(path.clone());
+            }
+            found.push((path, meta.len(), meta.modified().ok()));
+        }
+    }
+    found.sort();
+    found
+}
+
 impl Scratch {
     /// Create an initialised repository with deterministic config.
     pub fn new(name: &str) -> Self {
@@ -1169,6 +1222,25 @@ impl Scratch {
     pub fn commit_all(&self, message: &str) {
         self.git(&["add", "-A"]);
         self.git(&["commit", "-q", "-m", message]);
+    }
+
+    /// Wait until nothing under the fixture is still moving.
+    ///
+    /// `git commit` returns before the filesystem is done with it: objects are
+    /// written to a temp name and renamed, and the entry that held the temp
+    /// disappears afterwards. A test that starts measuring on the next line
+    /// opens its window over a tree still settling and then attributes what it
+    /// sees to the thing it was testing. The gap is too small to observe on an
+    /// idle machine and is not on a loaded runner.
+    ///
+    /// Two consecutive identical readings, because one reading proves only that
+    /// a moment existed. Panics rather than giving up quietly: a fixture that
+    /// never settles is a broken fixture, and measuring it anyway is the defect
+    /// this exists to prevent.
+    #[must_use]
+    pub fn settled(self) -> Self {
+        settle_tree(self.root());
+        self
     }
 
     /// Open the working tree through the crate under test.

--- a/crates/vigia-core/tests/watch.rs
+++ b/crates/vigia-core/tests/watch.rs
@@ -81,7 +81,11 @@ fn committed_scratch(name: &str) -> Scratch {
     let scratch = Scratch::new(name);
     scratch.write("a.txt", "x\n");
     scratch.commit_all("initial");
-    scratch
+    // The watcher is created on the caller's next line, so the commit's own
+    // `.git/index`, `.git/HEAD` and `.git/refs` writes must have landed before
+    // it starts. They are relevant by `watched_in_git_dir`, and arriving late
+    // they open a burst the test then reads as its own subject.
+    scratch.settled()
 }
 
 #[test]
@@ -327,6 +331,7 @@ fn writes_to_ignored_paths_never_produce_a_tick() {
     scratch.write(".gitignore", "target/\n");
     scratch.write("a.txt", "x\n");
     scratch.commit_all("initial");
+    let scratch = scratch.settled();
 
     let worktree = scratch.worktree();
     let mut watcher = worktree.watch(WatchOptions::default()).expect("watch");
@@ -455,5 +460,51 @@ fn a_stop_that_lands_mid_burst_still_returns_none() {
     assert_eq!(
         got, None,
         "a stop landed while a burst was open and returned a tick instead of ending the wait"
+    );
+}
+
+/// `settled` returns only once the tree has stopped changing.
+///
+/// The fixtures it guards fail on a loaded runner and not on an idle one, so
+/// the symptom cannot be reproduced here. What can be pinned is the mechanism:
+/// a tree still being written to holds the wait open, and a still one does not.
+#[test]
+fn settling_waits_for_a_tree_that_is_still_being_written() {
+    let scratch = committed_scratch("watch-settle-mechanism");
+    let root = scratch.root().to_path_buf();
+
+    let writing = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let stop = std::sync::Arc::clone(&writing);
+    let churn = std::thread::spawn(move || {
+        for i in 0..u32::MAX {
+            if !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                return;
+            }
+            let _ = std::fs::write(root.join(format!("churn_{i}.txt")), "x");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    });
+
+    // Long enough that a settle which never waits cannot span it.
+    std::thread::sleep(Duration::from_millis(200));
+    let started = std::time::Instant::now();
+    writing.store(false, std::sync::atomic::Ordering::Relaxed);
+    churn.join().expect("churn thread");
+    let scratch = scratch.settled();
+    let waited = started.elapsed();
+
+    assert!(
+        waited >= Duration::from_millis(40),
+        "settling returned in {waited:?}, which is less than one sampling interval, \
+         so it never took a second reading and cannot have compared two"
+    );
+
+    // And a tree nobody is writing to settles without a second thought.
+    let quiet = std::time::Instant::now();
+    let _ = scratch.settled();
+    assert!(
+        quiet.elapsed() < Duration::from_secs(1),
+        "a still tree took {:?} to settle, so the wait is not bounded by the tree",
+        quiet.elapsed()
     );
 }

--- a/crates/vigia/tests/writes.rs
+++ b/crates/vigia/tests/writes.rs
@@ -70,7 +70,7 @@ use ratatui::layout::Rect;
 use vigia::{Action, App, Glyphs, PaintStats, Pointing, Theme, body_layout, render};
 use vigia_core::{Frame, Highlighter, History, WARM_FILES, WatchOptions, Worktree};
 
-use support::{Scratch, made_link};
+use support::{Scratch, made_link, settle_tree};
 
 /// Small on purpose. This gate counts filesystem entries rather than
 /// milliseconds, so the hundred-file fixture the budget gates share would buy it
@@ -578,6 +578,10 @@ fn the_monitor_writes_nothing_while_it_runs() {
     // which is why nothing here watches for it.
     let linked = made_link(&scratch, "src/mod_0.rs", "link_to_mod_0.rs");
 
+    // The fixture's own git writes must have landed before the window opens,
+    // or the tail of the commit lands inside it and reads as a write by the
+    // monitor.
+    settle_tree(&root);
     let before = snapshot(&root);
     if linked {
         assert!(
@@ -654,6 +658,10 @@ fn the_snapshot_sees_a_write_that_does_happen() {
     let scratch = Scratch::large_diff("writes-detected", FILES, LINES);
     let root = scratch.root().to_path_buf();
 
+    // The fixture's own git writes must have landed before the window opens,
+    // or the tail of the commit lands inside it and reads as a write by the
+    // monitor.
+    settle_tree(&root);
     let before = snapshot(&root);
 
     // **A different length, deliberately.** Two writes of the same length inside


### PR DESCRIPTION
Three macOS and musl failures share one cause: the fixture is still being written when the test starts measuring, so the tail of its own `git commit` lands inside the window and is attributed to whatever the test was actually about.

`git commit` returns before the filesystem is done with it. Objects are written to a temp name and renamed, and the entry that held the temp disappears afterwards.

| test | what it measured too early |
|---|---|
| `an_idle_worktree_produces_no_tick_and_accepts_nothing` | the commit's `.git/index`, `.git/HEAD` and `.git/refs` writes, which `watched_in_git_dir` treats as relevant, arriving after the watcher registers |
| `git_object_churn_never_produces_a_tick` | the same, read as the `.git/objects` writes the test is named for |
| `the_monitor_writes_nothing_while_it_runs` | `.git/objects` shrinking from 256 to 224 bytes 3.6ms after the before-snapshot, with **zero events delivered to the watch**: git dropping a temp entry, read as a write by a monitor that had not written anything |

`writes_to_ignored_paths_never_produce_a_tick` shares the shape and was not on the list.

## The fix

`Scratch::settled` and `settle_tree` wait for two consecutive identical readings of the tree. One reading proves only that a moment existed. Read errors during the walk are folded into the reading rather than raised, since an entry vanishing mid-rename is exactly the motion being waited out. A fixture that never settles panics rather than being measured anyway.

## The gate pins the mechanism, not the symptom

The symptom is a loaded-runner one. Seventy runs here under CPU load, filesystem-event load, two-core constraint and sixteen-thread oversubscription reproduced it zero times, so there is nothing local to watch go red.

What can be pinned is the mechanism. `settling_waits_for_a_tree_that_is_still_being_written` holds a tree open with a writing thread and asserts the wait spans at least one sampling interval, so a settle that never takes a second reading cannot pass; then it asserts a still tree returns promptly, so the wait is bounded by the tree rather than by a sleep. Checked by mutation: a settle that returns immediately fails it.

## Not in scope

#352 is the opposite shape and is untouched. There the bulk rewrite settles too fast for the sampled window rather than too slow for the measurement.

Full workspace suite green across 46 test binaries. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean by exit code.
