### PR TITLE
the rules the record needed, and the two that made it grow

### DIFF
--- a/.claude/skills/take-next/SKILL.md
+++ b/.claude/skills/take-next/SKILL.md
@@ -217,7 +217,7 @@ Check the label before planning. An issue labelled **`decision`** is one whose a
 When the issue is labelled `decision`:
 
 - **The deliverable is the ruling and its reasoning**, written where the next reader will hit it — the `SPEC.md` section the issue names, plus its §10 bullet closed. A ruling filed only in the issue is not filed: the issue closes and `SPEC.md` still reads as an omission.
-- **Both branches get written.** *"Declined"* is a result, and the case for the road not taken is recorded rather than dropped, because it will be raised again. #50 says this in its own acceptance and it is the general rule.
+- **The ruling goes in the contract. The road not taken goes in `RULINGS.md`.** *"Declined"* is a result and the case for it is worth keeping, but keeping both branches in `SPEC.md` means the contract grows on a refusal as surely as on a build, so no outcome ever fails to add to it. `SPEC.md` gets the ruling in the fewest words that can be falsified; the rejected branch and its evidence go to the ledger, under its budget, or nowhere.
 - **A ruling of *yes* is the first half of the pass, not the end of it.** The build gets its **own issue and its own PR**, so the ruling is never blocked by an implementation, and then **this same pass takes that issue and ships it**. Stopping at the ruling is what this bullet used to say and it was wrong: #167 ruled that `?` opens a gestures sheet, filed #206 for the build, and released **0.11.1 with nothing on screen**. The reader pressed `?`, got nothing, and had to go and find out that the tool had been *told* about a feature it did not have. Two PRs, one pass, in that order.
 - **The only reason to stop after the ruling is size, and it is a claim about the build rather than about the rules.** If the build genuinely will not fit one fresh context (the test three sections down), stop there and say so — but say it in the **first line of the report**, in the form *"nothing the reader can see has changed yet; the build is #N"*. A pass that ends with the tool doing exactly what it did before is allowed. A pass that ends that way quietly is not.
 - **The report opens with what a reader can now do that they could not before.** If the honest answer is *nothing*, that is the first sentence, not a detail three paragraphs down. This is the line that would have caught the case above, and no gate can see it: the suite was green, the plan was delivered in full, and the feature did not exist.
@@ -469,12 +469,14 @@ Then polish, and let the **diff** pick the instrument rather than your appetite.
 - **Anything larger, or anything the rest of the system stands on** — `/harden` **until dry**. It runs `/simplify` as one of its own phases, so do not run one first and then the other. It also carries its own plan-fidelity phase: tell it the diff above was already done, so it records the result instead of repeating it.
 - **The surface picks the bar, the way the diff picks the instrument.** Engine and invariant work hardens until dry — that rigor earned its keep in the frame path and it stays. Look-and-feel work (the Phase 8 class: layout, colour, keys, chrome) defaults to `/simplify` plus snapshot review plus **a screenshot in the PR**, because the judge of feel is a human eye and it rules in five seconds; a three-agent audit loop on an inset spends a night where a look decides. The escalation is one-way: feel work that touches the frame path, the watch, or any invariant's surface takes the engine bar for that part.
 
-Whichever runs, pass the docs carve-out into the invocation, because `/simplify` reduces and the comments explaining *why* something works are the ones nobody can reconstruct from the code:
+Whichever runs, pass the docs rule into the invocation. `/simplify` is the only instrument that reduces, and freezing docs against it is what took the comments to 60% of the shell crate: the ratio could only ever climb. What actually needs protecting is a class, not a volume, so protect the class:
 
-> Documentation is non-negotiable during `/simplify`. Do not shorten, remove, or
-> fold module-header docblocks, function doc comments, or `Why:` / invariant
-> notes. If a simplification would delete context about why something works, skip
-> the simplification.
+> Documentation is in scope for `/simplify` and is judged by the same rule as
+> code: a comment exists where the code cannot explain itself. Keep why the
+> obvious approach is wrong, an invariant a caller must hold, and a cost invisible
+> at the call site. Where a comment exists because the code is unclear, the fix is
+> clearer code and the comment goes with it. Delete restatements of the code,
+> issue numbers, ruling ids, and any account of the change rather than the thing.
 
 **And pass the read-only carve-out, because an agent that builds competes with you for the machine.** On 2026-08-18 four review agents were told to measure and each ran an optimised build (`lto = "thin"`, `codegen-units = 1`) concurrently with the session's own, one against a probe worktree carrying a 3.4G `CARGO_TARGET_DIR`. The machine was audibly saturated before anything in the loop noticed, because a session's picture of the machine is its own actions only. It costs nothing in review quality to prevent: round 2 of #245's audit ran read-only with the numbers pasted into the brief and was just as sharp as the round that built.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,35 @@ So, when a reader asks for something:
 - **A reason that collapses reopens the question.** It does not get replaced by a better reason for the same conclusion. That happened to [#123](https://github.com/breferrari/vigia/issues/123) and the decline outlived both of its bases.
 - **Reach a decline early or not at all.** The reason either holds under checking or it does not, and that is cheap. Hours spent after that point are spent justifying, and the tell is prose getting longer while the argument does not get stronger.
 - **Size the rigor to the surface, and do not escalate past it.** Look and feel is `/simplify` plus a screenshot; the audit loop is for the frame path and the invariants. `ROADMAP.md` has said so since Phase 8 opened and it was overridden anyway.
+- **A limit you were not asked for is a refusal wearing a yes.** Everything above covers *no*. It did not cover [#272](https://github.com/breferrari/vigia/issues/272): nobody declined to build wrapping, a session built it and imported `delta --wrap-max-lines`' default of two as a cap, and the reader had to say twice that he never asked for it. What ships is what was asked for and nothing narrower. A bound taken from a neighbouring tool's default is that tool's decision, not a ruling here.
+- **Never cite a session's own prior decision as a constraint on the reader.** Evidence, yes. Decisions he made, yes, and naming them is a service. A ruling a session wrote is a record of what was done, not permission withheld.
 
-Refusals deserve more scrutiny than builds, not less: a bad build is loud and a bad refusal is silent, so the mistake that survives longest here is the one no gate can see.
+Refusals deserve more scrutiny than builds, not less, and an unrequested limit deserves the most of all: a refusal is at least visible, while a feature delivered narrower than it was asked for leaves nothing to see.
+
+## Rulings say who made them
+
+Every ruling and every constant in `SPEC.md` names its author:
+
+```
+Ruled 2026-08-26, reader.
+Ruled 2026-08-26, session.
+```
+
+**Unattributed means a session inferred it, and an inferred ruling does not bind the reader.** Two words, and it turns *"why will you not do this"* from an argument into a lookup.
+
+Mark the origin of the **ruling**, not of the symptom. "Reported from the pane" describes where a complaint came from and says nothing about who chose the constraint attached to it. #272's cap was reader-reported and session-decided, and writing only the first is what let it be quoted back at him as his own.
+
+## Rulings can be revoked
+
+When the reader overrules a ruling, **delete it in the same commit as the change.** Not annotated, not marked superseded, not kept with a note about what it used to say.
+
+A rule that survives being overruled re-fires on the next session, and he argues it again from zero. #272's cap was overruled and still sat in the source, the spec and a gate a day later. If it is not deleted, the override did not happen.
+
+## The spec is present tense
+
+`SPEC.md` says what holds now. When a ruling is replaced, the old text goes: git has it, and `RULINGS.md` takes the trail when the trail is still needed to apply the rule.
+
+**Annotating in place is not an option, and this is structural rather than a preference.** In any single case the argument for keeping the paragraph is the better one. Enough better arguments in a row is how a contract stops being readable, and how a commit that *removed* a feature still grew the file.
 
 ## Releasing
 
@@ -156,3 +183,6 @@ Pick the level from the diff. On `0.x` a new feature **and** a breaking public A
 - **No em-dashes** in anything published under Brenno's name: README prose, release notes, issue and PR bodies, commit messages. Use a period, a comma, a colon, or parentheses.
 - Probe capability by behaviour, never by asking. A single green run is not evidence when the defect is non-deterministic.
 - Verify the whole artifact, not just the property you were fixing.
+- **A comment exists where the code cannot explain itself.** Why the obvious approach is wrong, an invariant a caller must hold, a cost invisible at the call site. Not a restatement of the code, not issue numbers, not ruling ids, not the history of the comment's own corrections. Those belong in the commit message and the tracker, which already hold them. The test: would this make sense to a reader in two years with no knowledge of the session that wrote it? A docblock longer than the item it documents means one of the two is wrong.
+- **A title says what is broken or what to build.** One clause, no *because*. The body carries the reason. `Band saturates at half on a steady worktree`, not `A steady worktree saturates half the band, because the factor above the mean was never measured on this signal`.
+- **Prose width follows where it renders, never the file you were last reading.** GitHub turns a single newline in an issue or PR body into a real line break, so a body hard-wrapped at 80 arrives broken mid-sentence. One long line per paragraph there. Commit bodies wrap at 72. Check with `gh api repos/OWNER/REPO/pulls/N -H "Accept: application/vnd.github.html+json" --jq '.body_html' | grep -c '<br'`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -480,6 +480,9 @@ Milestone: [Phase 8](https://github.com/breferrari/vigia/milestone/8)
 | ✅ | The columns left of the diff's scrollbar read as neither wash nor track | [#214](https://github.com/breferrari/vigia/issues/214) |
 | ✅ | The row wash has no left bar, and the reason it was refused expired with #119 | [#218](https://github.com/breferrari/vigia/issues/218) |
 | ⬜ | Text cannot be selected or copied, because the shell holds the mouse | [#177](https://github.com/breferrari/vigia/issues/177) |
+| ⬜ | Bulk-rewrite settle guard fails on loaded musl runners | [#352](https://github.com/breferrari/vigia/issues/352) |
+| ⬜ | The masthead graph draws a flat track and one spike, and the spike does not sit in the band | [#348](https://github.com/breferrari/vigia/issues/348) |
+| ✅ | `cargo install vigia` fails on a yanked `bisync` pinned through gix 0.86 | [#349](https://github.com/breferrari/vigia/issues/349) |
 | ✅ | A long line cannot be read to its end, and the ruling against wrapping was made without a toggle in it | [#272](https://github.com/breferrari/vigia/issues/272) |
 | ⬜ | The pulse leaves the last edited file after a second, and it used to stay | [#345](https://github.com/breferrari/vigia/issues/345) |
 | ✅ | The pointer's mark is the loudest weight in the list, and the file the diff is inside has none | [#193](https://github.com/breferrari/vigia/issues/193) |
@@ -621,6 +624,10 @@ Milestone: [Shelf](https://github.com/breferrari/vigia/milestone/5)
 Everything on the deferral shelf below has a milestone here, so shelved work is still reachable by a milestone-filtered query rather than only readable in prose. The shelf carries the *reason*; this table carries the *state*.
 
 **It carried the name "Phase 5 — deferred findings" until 2026-08-06, and the number is retired because it was a lie with a good excuse.** A phase number claims a place in a sequence; this is a shelf, permanently open, never "next", and the file spent a paragraph fighting its own name. The sections above run 4 → 6 → 7 → 8 in the order they are meant to be taken, and the shelf sits after all of them because it holds no place among them at all. What survives the rename: the milestone URL keeps `/5`, and older issues, notes and the dated cells below cite "Phase 5" — every such citation means this shelf. The exclusion mechanism never rested on the name: `take-next` step 1 skips it by the `Shelf:` description prefix, which is unchanged, and a title with no phase number now also sorts last by that query's own fallback, so the two guards finally agree instead of one covering for the other.
+
+**A shelf item comes off it when daily use asks for it, and the asking is the whole test.** That sentence used to live here, was deleted at some point, and survives only as a quotation in two pull-forward rows below, which is a rule that exists solely as its own citation. Restated because a filter nobody can read is not one, and because the sixty-odd rows under it are what happens when the entry trigger fires on every audit and the exit trigger fires on a judgement nobody is scheduled to make.
+
+**The occasion is the pull-forward, and the question is one line: would this be built if it were not already written down?** Ask it of an item when something reaches for it, not on a schedule nobody keeps. An item that cannot answer yes is not waiting for a phase, it is declined, and closing it as such is a result rather than a loss. Five declines in a hundred and twenty-seven closed issues is not a shelf being filtered; it is a shelf being filled.
 
 **If a second shelf is ever created, its milestone description must begin `Shelf:`.** Until [#83](https://github.com/breferrari/vigia/issues/83) the never-next rule lived only in this paragraph, which is prose, and `take-next` step 1 is a query: it read the milestone list, saw three peers, and offered the shelf as the next phase. The marker is what a query can read, and this paragraph is where whoever creates the next one is standing, so it is stated here rather than only in the skill. Comparison 6 of that skill's pre-flight is the check that fires when the two disagree.
 


### PR DESCRIPTION
Rules only. No behaviour change, no code touched.

## What a session could not learn from this repo

**A limit you were not asked for is a refusal wearing a yes.** The existing "Bias to building" doctrine is good and covers *no, I will not*. It did not cover #272: nobody declined to build wrapping, a session built it and imported `delta --wrap-max-lines`' default of two as a cap, and the reader had to say twice that he never asked for it. A refusal is at least visible. A feature delivered narrower than it was asked for leaves nothing to see.

**A session's own prior decision is never a constraint on the reader.** Evidence yes, and his own decisions yes, since naming those is a service. A ruling a session wrote is a record of what was done, not permission withheld.

**Rulings say who made them.** A record that captures what was ruled and why, but not who, lets a session's decision become binding on its owner; after a few weeks nobody can tell the two apart. Worse than absent is partial: the existing convention marks the origin of the *symptom* rather than of the *ruling*, so "reported from the pane" is true of the complaint and false of the constraint attached to it. That is how #272's cap was quoted back at him as his own. Unattributed now means a session inferred it, and an inferred ruling does not bind.

**Rulings can be revoked**, deleted in the same commit as the change rather than annotated. #272's cap was overruled and still sat in the source, the spec and a gate a day later. If it is not deleted, the override did not happen.

**The spec is present tense**, and structurally rather than as a preference. In any single case the argument for keeping the paragraph is the better one, which is why a preference loses every time it is invoked.

Three house rules follow: a comment exists where the code cannot explain itself, a title says what is broken in one clause with no *because*, and prose width follows where it renders rather than the file last read. On the last one, GitHub turns a single newline in a PR body into a real line break, so a body wrapped at 80 arrives broken mid-sentence. This PR's body is one line per paragraph and measures zero.

## The two instructions that made the written layer grow

Both were written down, both were followed, and between them no outcome failed to add to the record.

The docs carve-out told `/simplify` that documentation is non-negotiable. `/simplify` is the only instrument that reduces, so the comment ratio could only ever climb; it is 60% of the shell crate today. The intent behind it is real, because a free hand deletes the note saying "this looks redundant but is not" and a later pass then deletes the code that note protected. But that protects a class, not a volume, so it now protects the class.

The `decision` route said both branches get written into `SPEC.md`. The contract therefore grew on a refusal as surely as on a build. The ruling stays in the contract, in the fewest words that can be falsified; the road not taken goes to `RULINGS.md`, which exists for exactly that.

## The shelf filter, restored as a rule rather than a quotation

`ROADMAP.md` quoted *"the shelf's own filter is only if daily use asks for them"* in two pull-forward rows, and the original sentence was gone from the file. A rule that exists only as its own citation is not one. Restated, with an occasion attached: ask of an item, when something reaches for it, whether it would be built if it were not already written down. An entry trigger that fires on every audit and an exit trigger that fires on a judgement nobody is scheduled to make is how sixty items arrive.

Also closes the drift `preflight.sh` comparison 7 reports: #352, #348 and #349 had no roadmap row.

## Verification

Full workspace suite green across 46 binaries, `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean by exit code, and `preflight.sh` comparison 7 clean against the working tree via its own test seam.
