### PR TITLE
the README says what it means by "no modes"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ An agent edits **fast**, **wide**, and while you are reading something else. The
 |---|---|
 | 🤖 **Built for the pane beside the agent** | Zero input required. It follows the newest change and scrolls to it on its own |
 | 🪶 **Cheap enough to leave open for a week** | Zero wakeups while idle, under 5% memory drift over 24 hours |
-| 🎯 **The diff, and nothing else** | No branches, no commits, no stash list, no staging *actions*, no modes |
+| 🎯 **The diff, and nothing else** | No branches, no commits, no stash list, no staging *actions*. No modes either: `vigia` has toggles, but no key ever changes meaning, so there is never a state you have to be in or get out of |
 | 📐 **Fits half a laptop screen** | Legible at 40 columns, because that is the actual pane you have |
 
 > [!NOTE]


### PR DESCRIPTION
An outside review filed "no modes" as a false claim, listing `m`, `r`, `s`, `a`, `f` and `?` as modes documented directly below it. I nearly fixed it as a correction. It is not one.

`SPEC.md` defines a mode as **a state in which keys change meaning**, and defends that definition in five separate places, because it is what reconciles the sheet, the rail, single-file and the staged run with B4's refusal of selection and focus:

> **The sheet is not a mode, which is what reconciles it with B4.** No key changes meaning while it is up: `q` still quits, `j` still scrolls the diff behind it, a digit still jumps. B4 refused selection and focus because *"selection implies focus, focus implies a second mode, and modes are reviewer-class"*, and what makes that defect real is keys meaning different things depending on where focus sits. Here that is impossible by construction rather than by discipline.

Under that definition the claim is true, and it is load-bearing rather than decorative.

The actual defect is that the README never gives the definition. A reader arrives with the ordinary meaning of "mode", counts seven toggles under a line that says there are none, and concludes the document lies. That will keep happening to every reader who has not read `SPEC.md`, which is every new reader.

So the cell carries the definition. One clause, no claim dropped.

Three runtime gates read `README.md` and all pass unchanged: `sheet.rs::readme_gestures` (the `**Keys**` and `**Mouse**` tables), `package.rs` (the grammar count against the dump), and `palette.rs` (the theme recipe). Full workspace suite green.
