### PR TITLE
the written layer has a ceiling, and the ceiling only falls

### DIFF
--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -2127,3 +2127,51 @@ fn the_ci_workflow_runs_the_script_the_gate_proves() {
          no longer covers where it runs"
     );
 }
+
+/// What each document is allowed to weigh, in bytes.
+///
+/// These are ratchets. Lower one when a pass removes prose; never raise one.
+/// Raising it is the move that has no natural stopping point, which is how the
+/// contract reached half a megabyte with the rule that was supposed to prevent
+/// it already written down.
+///
+/// The targets these are walking toward: 90_000 for the spec, 40_000 each for
+/// the roadmap and the ledger. The spec's is set by it staying read-before-code
+/// for everyone, which makes it the contributor on-ramp and not a barrier routed
+/// around. 90_000 rather than something rounder because a floor of roughly
+/// 72_000 is forced by structures that cannot move: §3's invariant table, whose
+/// row shape `preflight.sh` greps; the ruling lead-ins themselves; and §7, which
+/// has no lead-in structure to lean on.
+const WRITTEN_LAYER_BUDGET: [(&str, usize); 3] = [
+    ("SPEC.md", 582_202),
+    ("ROADMAP.md", 298_185),
+    ("RULINGS.md", 106_735),
+];
+
+/// Each document weighs no more than its budget.
+///
+/// A structural gate rather than a timed one: an exact count, no slack, running
+/// in debug so it holds on every `cargo test --workspace` rather than only on
+/// the release legs.
+#[test]
+fn the_written_layer_stays_under_its_budget() {
+    let root = repo_root();
+    let mut over = Vec::new();
+
+    for (name, ceiling) in WRITTEN_LAYER_BUDGET {
+        let bytes = read(&root.join(name)).len();
+        if bytes > ceiling {
+            over.push(format!(
+                "  {name}: {bytes} bytes against a ceiling of {ceiling}"
+            ));
+        }
+    }
+
+    assert!(
+        over.is_empty(),
+        "the written layer grew past its budget:\n{}\n\nLower the ceiling when prose \
+         comes out. Raising it to fit what was added is the move this gate exists to \
+         refuse.",
+        over.join("\n")
+    );
+}


### PR DESCRIPTION
`SPEC.md` went from 7 KB to 582 KB in twenty-eight days. `RULINGS.md` was split out of it on 2026-08-05 to hold exactly that growth, with the rule for what lives where written down at the top of the new file, and the spec tripled afterwards.

That is the argument for a gate rather than a rule. A rule that depends on a session choosing brevity loses every single time it is invoked, because in any individual case the argument for keeping the paragraph genuinely is the better one. The proof is recent: the commit that *removed* the wrap cap grew the spec by 232 bytes, written deliberately short by a session that had just finished briefing on this problem.

## What this is

A budget on the three documents, in the repo's structural tier: an exact count, no `VIGIA_BUDGET_SLACK`, running in debug so it holds on every `cargo test --workspace` rather than only on the release legs. `soak.rs` is the precedent for a gate that reads a non-`.rs` repo file.

**The ceilings start at today's sizes, which makes it a ratchet rather than a wall.** It cannot fail on the commit that introduces it, and it cannot be satisfied by adding. Lowering a ceiling is how a reduction pass records what it removed. Raising one is the move with no natural stopping point, and the failure message says so where whoever is tempted will be standing.

## Where the numbers are going

90_000 for the spec, 40_000 each for the roadmap and the ledger.

The spec's target follows from it staying read-before-code for everyone, which makes it the contributor on-ramp rather than a barrier that gets routed around. 90_000 rather than something rounder because a floor near 72_000 is forced by structures that cannot move: §3's invariant table, whose row shape `preflight.sh` greps; the 435 ruling lead-ins themselves; and §7, which has 138 code citations and no lead-in structure to lean on. Setting it at 60_000 would have forced rulings to be dropped to meet a number, which is the failure the whole pass exists to end.

## What is not in this PR

The reduction itself. The inventory that will be its acceptance test is built — 435 lead-ins, 19 `B` ids, 11 `I` ids, 19 headings, the 14 assertions that claim the spec names a specific figure, and every §-citation from `crates/**` — but the cut is judgement work on prose, and a wrong cut there is both expensive and hard to see in a diff. It wants a reading, not a script.

Checked by mutation: dropping the spec's ceiling by one byte fails the gate, naming the file, the size and the ceiling.
