### PR TITLE
The version raise counts only the lines it moved

### DIFF
--- a/.github/scripts/raise-version.sh
+++ b/.github/scripts/raise-version.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Moves the workspace version and the internal dependency's pin to one number,
+# and verifies that both moved.
+#
+# Lives in a file rather than inline in the workflow so it can be driven
+# against a manifest from a test. The verification was got wrong inline: it
+# counted the new number anywhere in the file, and the manifest also pins the
+# release tool, so the first minor to land on the tool's own number counted
+# three lines instead of two and refused a release that was correct.
+#
+# Usage: raise-version.sh <next> [manifest]
+#   next      the version to write, three numeric components
+#   manifest  the workspace Cargo.toml (default: ./Cargo.toml)
+set -eu
+
+[ "$#" -ge 1 ] || { echo "::error::no version was passed"; exit 1; }
+next="$1"
+manifest="${2:-Cargo.toml}"
+
+# Both strings in one pass, because moving one and not the other is the failure
+# the release job is arranged around. Each pattern is anchored to the start of a
+# line and matches exactly one line in the manifest. Written through a copy
+# rather than `sed -i`, whose argument shape differs between GNU and BSD sed.
+raised="${manifest}.raised"
+sed -E \
+    -e "s|^version = \"[^\"]+\"|version = \"${next}\"|" \
+    -e "s|^(vigia-core = \{ path = \"crates/vigia-core\", version = )\"[^\"]+\"|\1\"${next}\"|" \
+    "$manifest" > "$raised"
+mv "$raised" "$manifest"
+
+# Verify the edit rather than trusting the substitution, because a sed that
+# matched nothing exits 0 and leaves the old version in place. Whole lines and
+# fixed strings, so a line elsewhere in the file that happens to hold the same
+# number is not counted. `|| true`, because `grep -c` exits 1 when it counts
+# nothing and `set -e` would then kill the script on the assignment, before the
+# diagnostic below could say which line failed to move.
+found=$(grep -cxF \
+    -e "version = \"${next}\"" \
+    -e "vigia-core = { path = \"crates/vigia-core\", version = \"${next}\" }" \
+    "$manifest" || true)
+if [ "${found:-0}" != "2" ]; then
+    echo "::error::expected both version strings at ${next}, found ${found}"
+    grep -nE '^version = |^vigia-core = ' "$manifest"
+    exit 1
+fi

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -344,27 +344,12 @@ jobs:
           echo "::notice::${{ inputs.bump }}: $current -> $next"
 
       # Both strings, in one step, because moving one and not the other is the
-      # failure this whole job is arranged around. The patterns are anchored to
-      # the start of a line and each matches exactly one line in the manifest.
+      # failure this whole job is arranged around. The edit and its check live
+      # in the script so a test can drive them against a manifest.
       - name: raise the version
         run: |
           set -euo pipefail
-          next='${{ steps.version.outputs.next }}'
-          sed -i -E "s|^version = \"[^\"]+\"|version = \"${next}\"|" Cargo.toml
-          sed -i -E "s|^(vigia-core = \{ path = \"crates/vigia-core\", version = )\"[^\"]+\"|\1\"${next}\"|" Cargo.toml
-
-          # Verify the edit rather than trusting the substitution, because a sed
-          # that matched nothing exits 0 and leaves the old version in place.
-          # `|| true`, because `grep -c` exits 1 when it counts nothing and
-          # `set -e` would then kill the step on the assignment, before the
-          # diagnostic below could say which line failed to move. Exactly the
-          # case the diagnostic exists for is the case it was unreachable in.
-          found=$(grep -cE "\"${next}\"" Cargo.toml || true)
-          if [ "${found:-0}" != "2" ]; then
-            echo "::error::expected both version strings at ${next}, found ${found}"
-            grep -nE '^version = |^vigia-core = ' Cargo.toml
-            exit 1
-          fi
+          sh .github/scripts/raise-version.sh '${{ steps.version.outputs.next }}'
           cargo update --workspace
 
       # The gate that makes the sed above safe, run before anything is pushed.

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -1335,6 +1335,94 @@ fn the_readme_states_the_grammar_count_the_dump_holds() {
     );
 }
 
+/// Drives the version raise against `manifest`, in a scratch directory of its
+/// own. Returns whether it passed and the manifest it left behind.
+#[cfg(unix)]
+fn raise_version(case: &str, next: &str, manifest: &str) -> (bool, String) {
+    let script = repo_root().join(".github/scripts/raise-version.sh");
+    let dir =
+        std::env::temp_dir().join(format!("vigia-raise-version-{}-{case}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap_or_else(|e| panic!("create {}: {e}", dir.display()));
+    let path = dir.join("Cargo.toml");
+    std::fs::write(&path, manifest).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+
+    let passed = Command::new("sh")
+        .arg(&script)
+        .arg(next)
+        .arg(&path)
+        .output()
+        .unwrap_or_else(|e| panic!("run {}: {e}", script.display()))
+        .status
+        .success();
+    let left = read(&path);
+    let _ = std::fs::remove_dir_all(&dir);
+    (passed, left)
+}
+
+/// The raise moves both version strings and counts only the lines it moved.
+#[cfg(unix)]
+#[test]
+fn the_version_raise_counts_the_lines_it_moved_and_nothing_else() {
+    // The shape that refused a correct release: the manifest also pins the
+    // release tool, and a minor landed on the tool's own number.
+    let pinned = "[workspace.package]\n\
+                  version = \"0.31.1\"\n\
+                  \n\
+                  [workspace.dependencies]\n\
+                  vigia-core = { path = \"crates/vigia-core\", version = \"0.31.1\" }\n\
+                  \n\
+                  [workspace.metadata.dist]\n\
+                  cargo-dist-version = \"0.32.0\"\n";
+    let (passed, left) = raise_version("pinned", "0.32.0", pinned);
+    assert!(
+        passed,
+        "a version equal to a pinned tool's is refused, and the release with it:\n{left}"
+    );
+    assert!(
+        left.contains("\nversion = \"0.32.0\"\n")
+            && left.contains("vigia-core = { path = \"crates/vigia-core\", version = \"0.32.0\" }")
+            && left.contains("cargo-dist-version = \"0.32.0\""),
+        "the raise moved the wrong lines:\n{left}"
+    );
+
+    // The real manifest, so the patterns are known to match the lines they
+    // claim to, and to touch nothing else in it.
+    let before = repo_file("Cargo.toml");
+    let (passed, after) = raise_version("real", "9.9.9", &before);
+    assert!(
+        passed,
+        "the raise refuses the repository's own manifest:\n{after}"
+    );
+    let moved: Vec<&str> = before
+        .lines()
+        .zip(after.lines())
+        .filter(|(was, is)| was != is)
+        .map(|(_, is)| is)
+        .collect();
+    assert_eq!(
+        moved,
+        [
+            "version = \"9.9.9\"",
+            "vigia-core = { path = \"crates/vigia-core\", version = \"9.9.9\" }",
+        ],
+        "the raise changed lines other than the two it is for"
+    );
+
+    // And the check still fails the case it exists for: a line the pattern does
+    // not match stays at the old number, and the raise says so instead of
+    // handing a half-moved manifest to the commit.
+    let unmoved = "[workspace.package]\n\
+                   version = \"0.31.1\"\n\
+                   \n\
+                   [workspace.dependencies]\n\
+                   vigia-core = { version = \"0.31.1\", path = \"crates/vigia-core\" }\n";
+    let (passed, left) = raise_version("unmoved", "0.32.0", unmoved);
+    assert!(
+        !passed,
+        "a dependency line the pattern cannot move passed the check:\n{left}"
+    );
+}
+
 /// Drives the judgement `ci complete` runs, with fabricated leg results.
 #[cfg(unix)]
 fn ci_complete(draft: &str, legs: &[&str]) -> bool {


### PR DESCRIPTION
The `bump and release` dispatch of 2026-09-02 failed in its first step and nothing after v0.31.1 has shipped. The bump verified its edit by counting every line of `Cargo.toml` holding the new version and expecting two. The manifest also pins `cargo-dist` at 0.32.0, so a minor that landed the crate on the same number counted three, and the job exited before anything was tagged or built.

## What changes

- The edit and its check move into `.github/scripts/raise-version.sh`, on the same footing as `ci-complete.sh`: a script a test can drive. The workflow step calls it and then runs `cargo update`.
- The check matches whole lines as fixed strings, for exactly the two lines the sed writes. A line elsewhere in the file that happens to hold the same number is no longer counted.
- The sed writes through a copy rather than in place, because the in-place flag's argument shape differs between GNU and BSD sed and the script now runs under the macOS leg too.
- `package.rs` gains `the_version_raise_counts_the_lines_it_moved_and_nothing_else`, `cfg(unix)` like the `ci-complete.sh` gate beside it. It drives the script three ways: a manifest whose tool pin equals the next version passes, the repository's own manifest changes exactly its two version lines and nothing else, and a dependency line the pattern cannot move still fails.

## Verification

- The script run under Git Bash against the same three manifests: the pinned one passes with the tool pin untouched, the real manifest diffs on lines 9 and 45 only, the unmoved one exits 1 with the diagnostic. The old count reads 3 on the pinned manifest, which is the failure in the run log.
- `cargo test -p vigia --test package` on Windows: 17 passed. The new test compiles out on this platform and runs on the Linux and macOS legs.
- `cargo clippy -p vigia --test package` with `-D warnings` is clean. `--all-targets` on this Windows machine fails on two pre-existing lints in the Windows half of `signal.rs`, which the Ubuntu clippy job cannot reach; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
