### PR TITLE
The skill says each rule once, and the harness enforces what prose could not

### DIFF
--- a/.claude/scripts/leak-guard.mjs
+++ b/.claude/scripts/leak-guard.mjs
@@ -1,16 +1,21 @@
 #!/usr/bin/env node
-// PreToolUse guard: block a `gh pr|issue|release create|edit|comment` whose body
-// carries an agent-session artifact, before it reaches a PUBLIC repo. The rule
-// this enforces already lived in CLAUDE.md; this is the part that does not
-// depend on a session remembering it. Exit 2 blocks the call; anything the
-// guard cannot parse or read fails OPEN (exit 0) — a guard must never block
-// work by breaking.
+// PreToolUse guard: block a `gh pr|issue|release create|edit|comment` or a
+// `git commit` whose text carries an agent-session artifact, before it reaches
+// a PUBLIC repo. The rule this enforces already lived in CLAUDE.md; this is the
+// part that does not depend on a session remembering it. A commit is covered
+// because a squash merged to a public `main` stays reachable by SHA forever.
+// Exit 2 blocks the call; anything the guard cannot parse or read fails OPEN
+// (exit 0), because a guard must never block work by breaking.
 //
 // Classes checked (each is a class of artifact, not one incident):
 //   - claude.ai session URLs and Claude-Session: trailers
 //   - local absolute paths (machine layout + username)
 //   - a --body-file whose newlines were destroyed (PowerShell array-join
 //     flattening: one giant line where a document should be)
+//
+// The path handed to --body-file, --file or -F is dropped from the inline scan
+// first: it says where the body sits and never lands in it, and a scratch
+// directory under the user's profile is exactly the shape the path class matches.
 
 import { readFileSync } from "node:fs";
 import { isAbsolute, resolve } from "node:path";
@@ -34,9 +39,11 @@ try {
 } catch {
 	process.exit(0);
 }
-if (typeof command !== "string" || !/\bgh\s+(pr|issue|release)\s+(create|edit|comment)\b/.test(command)) {
-	process.exit(0);
-}
+if (typeof command !== "string") process.exit(0);
+
+const publishes = /\bgh\s+(pr|issue|release)\s+(create|edit|comment)\b/.test(command);
+const commits = /\bgit\s+commit\b/.test(command);
+if (!publishes && !commits) process.exit(0);
 
 const block = (what, hits) => {
 	console.error(
@@ -47,12 +54,14 @@ const block = (what, hits) => {
 	process.exit(2);
 };
 
-const inlineHits = PATTERNS.filter(([, re]) => re.test(command)).map(([label]) => label);
+const m = /(?:--body-file|--file|-F)[= ]\s*(?:"([^"]+)"|'([^']+)'|(\S+))/.exec(command);
+const bodyFile = m ? (m[1] ?? m[2] ?? m[3]) : null;
+const inline = m ? command.replace(m[0], " ") : command;
+
+const inlineHits = PATTERNS.filter(([, re]) => re.test(inline)).map(([label]) => label);
 if (inlineHits.length > 0) block("this command's inline body", inlineHits);
 
-const m = /--body-file[= ]\s*(?:"([^"]+)"|'([^']+)'|(\S+))/.exec(command);
-if (!m) process.exit(0);
-const bodyFile = m[1] ?? m[2] ?? m[3];
+if (!bodyFile) process.exit(0);
 
 let body = "";
 try {
@@ -63,7 +72,7 @@ try {
 }
 
 const hits = PATTERNS.filter(([, re]) => re.test(body)).map(([label]) => label);
-if (body.length > 300 && !body.trim().includes("\n")) {
+if (publishes && body.length > 300 && !body.trim().includes("\n")) {
 	hits.push("flattened body: one line where a document should be (PowerShell array-join; use [System.IO.File]::WriteAllText with a `n join)");
 }
 if (hits.length > 0) block(bodyFile, hits);

--- a/.claude/scripts/record-guard.mjs
+++ b/.claude/scripts/record-guard.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Stop guard: a pass whose pull request has merged ends with a record in the
+// vault, or is told so, once. The record is the requirement and the tool is
+// only the route, so the check is on the note rather than on the call: any
+// note under the project's notes that names the branch's issue counts, filed
+// by hand or not.
+//
+// Fails OPEN on anything it cannot read. Never fires on `main`, on a branch
+// whose name carries no issue number, or before that branch's pull request has
+// merged, because until then there is nothing to record. Blocks at most once
+// per session, so a note the vault refuses cannot hold a session hostage.
+//
+// Test seams, never set in a real run: RECORD_GUARD_STATE stands in for the
+// pull request state `gh` would report, and VIGIL_VAULT points at a fixture.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+let input;
+try {
+	input = JSON.parse(readFileSync(0, "utf8"));
+} catch {
+	process.exit(0);
+}
+if (input?.stop_hook_active) process.exit(0);
+
+const cwd = typeof input?.cwd === "string" ? input.cwd : process.cwd();
+const run = (cmd, args) => {
+	try {
+		return execFileSync(cmd, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+	} catch {
+		return null;
+	}
+};
+
+const branch = run("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+if (!branch || branch === "main" || branch === "HEAD") process.exit(0);
+const issue = /(?:^|[^0-9])([0-9]{1,5})(?:[^0-9]|$)/.exec(branch)?.[1];
+if (!issue) process.exit(0);
+
+const state = process.env.RECORD_GUARD_STATE ?? run("gh", ["pr", "view", "--json", "state", "--jq", ".state"]);
+if (state !== "MERGED") process.exit(0);
+
+const projectDir = process.env.CLAUDE_PROJECT_DIR ?? cwd;
+let project = "";
+try {
+	project = readFileSync(join(projectDir, ".om-project"), "utf8").trim();
+} catch {
+	process.exit(0);
+}
+const vault = process.env.VIGIL_VAULT ?? resolve(projectDir, "..", "vigil-mind");
+const notes = join(vault, "projects", project, "notes");
+if (!existsSync(notes)) process.exit(0);
+
+const names = new RegExp(`#${issue}(?![0-9])`);
+let recorded = false;
+try {
+	recorded = readdirSync(notes)
+		.filter((name) => name.endsWith(".md"))
+		.some((name) => names.test(readFileSync(join(notes, name), "utf8")));
+} catch {
+	process.exit(0);
+}
+if (recorded) process.exit(0);
+
+const marker = join(tmpdir(), `${project}-record-guard-${input?.session_id ?? "session"}`);
+if (existsSync(marker)) process.exit(0);
+try {
+	writeFileSync(marker, "");
+} catch {
+	process.exit(0);
+}
+
+console.error(
+	`The pull request for #${issue} has merged and no note under projects/${project}/notes names #${issue}.\n` +
+		`Record the work before finishing: record_work through vigil, or file the note by hand in the vault. ` +
+		`This fires once per session; if the note exists elsewhere, finish and say where.`,
+);
+process.exit(2);

--- a/.claude/scripts/record-guard.mjs
+++ b/.claude/scripts/record-guard.mjs
@@ -37,7 +37,9 @@ const run = (cmd, args) => {
 
 const branch = run("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
 if (!branch || branch === "main" || branch === "HEAD") process.exit(0);
-const issue = /(?:^|[^0-9])([0-9]{1,5})(?:[^0-9]|$)/.exec(branch)?.[1];
+// `issue-<n>-<slug>` is the convention and `<n>-<slug>` the older one. A number
+// anywhere else in a name, such as a date, is not an issue.
+const issue = /^(?:issue-)?([0-9]{1,5})(?:-|$)/.exec(branch)?.[1];
 if (!issue) process.exit(0);
 
 const state = process.env.RECORD_GUARD_STATE ?? run("gh", ["pr", "view", "--json", "state", "--jq", ".state"]);

--- a/.claude/scripts/scan-guard.mjs
+++ b/.claude/scripts/scan-guard.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// PreToolUse guard: refuse a `find` whose start path is `/`. Under Git Bash on
+// Windows `/` is the MSYS root, so `~/.cargo` is not under it and no match is
+// possible, and `/proc/registry` mounts the Windows registry as directories,
+// so the walk enumerates the hives through live Win32 calls and never ends.
+// Six of these, left orphaned, burned 26.8 CPU-hours in five hours. Exit 2
+// blocks the call; anything the guard cannot read fails OPEN.
+
+import { readFileSync } from "node:fs";
+
+let command = "";
+try {
+	command = JSON.parse(readFileSync(0, "utf8"))?.tool_input?.command ?? "";
+} catch {
+	process.exit(0);
+}
+if (typeof command !== "string") process.exit(0);
+
+// `find`, its option flags, then a start path that is `/` alone. `find /c/Dev`
+// and `find . -path /x` are not this.
+const rooted = /(?:^|[\s;&|(])find\s+(?:-[A-Z]\s+)*\/(?=\s|$)/;
+const m = rooted.exec(command);
+if (!m) process.exit(0);
+
+// A walk bounded by `timeout` is what CLAUDE.md asks for instead.
+if (/\btimeout\s+\S+\s*.$/.test(command.slice(0, m.index + 1))) process.exit(0);
+
+console.error(
+	"BLOCKED: `find /` walks the MSYS root, which mounts the Windows registry under /proc and never terminates.\n" +
+		"Point Glob or Grep at an explicit path, or bound the scan with `timeout`. (CLAUDE.md; this hook is its enforcement.)",
+);
+process.exit(2);

--- a/.claude/scripts/scan-guard.mjs
+++ b/.claude/scripts/scan-guard.mjs
@@ -22,8 +22,11 @@ const rooted = /(?:^|[\s;&|(])find\s+(?:-[A-Z]\s+)*\/(?=\s|$)/;
 const m = rooted.exec(command);
 if (!m) process.exit(0);
 
-// A walk bounded by `timeout` is what CLAUDE.md asks for instead.
-if (/\btimeout\s+\S+\s*.$/.test(command.slice(0, m.index + 1))) process.exit(0);
+// A walk bounded by `timeout` is what CLAUDE.md asks for instead. The bound
+// has to sit on this command: a `timeout` in an earlier command of the same
+// line, past a `;` or a pipe, bounds nothing here.
+const simple = command.slice(0, m.index + 1).split(/\n|;|&&|\|\|?/).pop() ?? "";
+if (/(?:^|\s)timeout\s/.test(simple)) process.exit(0);
 
 console.error(
 	"BLOCKED: `find /` walks the MSYS root, which mounts the Windows registry under /proc and never terminates.\n" +

--- a/.claude/scripts/selftest.sh
+++ b/.claude/scripts/selftest.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env sh
+# Self-test for the hooks in this directory. Offline, needs node only.
+#
+#   sh .claude/scripts/selftest.sh
+#
+# Each guard reads a tool call as JSON on stdin and exits 2 to block it, so a
+# case is one fabricated call and the exit code it must produce. A guard that
+# cannot be shown blocking has not been tested, and neither has one that cannot
+# be shown letting ordinary work through.
+set -u
+FAIL=0
+HERE="$(dirname "$0")"
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+# The guards run under node, which on Windows cannot open an MSYS path such as
+# /tmp/x, and a guard that cannot read fails open. Every path a guard sees is
+# handed over in the form node can use.
+W() { cygpath -m "$1" 2>/dev/null || printf '%s' "$1"; }
+FIXW=$(W "$FIX")
+
+ok() { printf '  ok   %s\n' "$1"; }
+no() { printf '  FAIL %s\n    expected exit %s, got %s\n' "$1" "$2" "$3"; FAIL=$((FAIL + 1)); }
+
+# The JSON a PreToolUse hook receives for a Bash call, with the command escaped
+# by jq so quotes and backslashes in a case survive.
+bash_call() { jq -n --arg c "$1" '{tool_name: "Bash", tool_input: {command: $c}}'; }
+
+expect() { # guard, expected exit, name, json
+  bash_call "$4" | node "$HERE/$1" >/dev/null 2>&1
+  got=$?
+  [ "$got" -eq "$2" ] && ok "$3" || no "$3" "$2" "$got"
+}
+
+echo "scan-guard:"
+expect scan-guard.mjs 2 "find rooted at / is blocked" 'find / -name "*.rs"'
+expect scan-guard.mjs 2 "find with a flag before / is blocked" 'find -L / -name x'
+expect scan-guard.mjs 2 "find / after a separator is blocked" 'cd x && find / -type d'
+expect scan-guard.mjs 0 "a bounded find is allowed" 'timeout 10 find / -name x'
+expect scan-guard.mjs 0 "find under a real path is allowed" 'find /c/Dev/vigia -name "*.rs"'
+expect scan-guard.mjs 0 "find in the checkout is allowed" 'find . -name "*.rs"'
+expect scan-guard.mjs 0 "a / that is not a start path is allowed" 'ls / && grep -r foo /c/x'
+
+echo "leak-guard:"
+printf 'A clean body.\n\nTwo paragraphs.\n' > "$FIX/clean.md"
+printf 'A body.\n\nClaude-Session: https://claude.ai/code/session_01abc\n' > "$FIX/trailer.md"
+printf 'See https://claude.ai/code/session_01abc for the trail.\n' > "$FIX/url.md"
+expect leak-guard.mjs 0 "a publish with a clean body file is allowed" "gh pr create --title t --body-file $FIXW/clean.md"
+expect leak-guard.mjs 2 "a publish whose body carries the trailer is blocked" "gh pr create --title t --body-file $FIXW/trailer.md"
+expect leak-guard.mjs 2 "a publish whose body carries a session URL is blocked" "gh issue comment 1 --body-file $FIXW/url.md"
+expect leak-guard.mjs 2 "an inline body with a session URL is blocked" 'gh pr comment 1 --body "see https://claude.ai/code/session_01abc"'
+expect leak-guard.mjs 0 "a body-file path under the profile is not a leak" 'gh pr create --title t --body-file "C:\Users\someone\AppData\Local\Temp\x\body.md"'
+expect leak-guard.mjs 2 "a commit message carrying the trailer is blocked" 'git commit -m "subject" -m "Claude-Session: https://claude.ai/code/session_01abc"'
+expect leak-guard.mjs 2 "a commit message file carrying the trailer is blocked" "git commit -F $FIXW/trailer.md"
+expect leak-guard.mjs 0 "a clean commit is allowed" 'git commit -m "The version raise counts only the lines it moved"'
+expect leak-guard.mjs 0 "a clean commit from a file under the profile is allowed" "git commit -F $FIXW/clean.md"
+expect leak-guard.mjs 0 "a command that neither publishes nor commits is ignored" 'echo Claude-Session: x'
+
+echo "record-guard:"
+# A Stop call, on a scratch repository whose branch names an issue and whose
+# pull request the seam reports merged, against a vault fixture. The marker the
+# guard leaves goes into the fixture too, so a rerun starts clean.
+REPO="$FIX/repo"; VAULT="$FIX/vault"
+REPOW=$(W "$REPO"); VAULTW=$(W "$VAULT")
+mkdir -p "$REPO" "$VAULT/projects/vigia/notes"
+printf 'vigia\n' > "$REPO/.om-project"
+git -C "$REPO" init -q && git -C "$REPO" -c user.name=t -c user.email=t@t commit -q --allow-empty -m init \
+  && git -C "$REPO" checkout -q -b issue-42-thing
+stop_call() { jq -n --arg cwd "$REPOW" --arg s "$1" '{hook_event_name: "Stop", cwd: $cwd, session_id: $s, stop_hook_active: false}'; }
+stop() { # session, expected, name
+  stop_call "$1" | RECORD_GUARD_STATE=MERGED CLAUDE_PROJECT_DIR="$REPOW" VIGIL_VAULT="$VAULTW" TMP="$FIXW" TEMP="$FIXW" TMPDIR="$FIXW" node "$HERE/record-guard.mjs" >/dev/null 2>&1
+  got=$?
+  [ "$got" -eq "$2" ] && ok "$3" || no "$3" "$2" "$got"
+}
+stop s1 2 "a merged pass with no note is stopped once"
+stop s1 0 "the same session is not stopped twice"
+printf 'Closed #42 with the evidence.\n' > "$VAULT/projects/vigia/notes/2026-01-01-a-note.md"
+stop s2 0 "a note naming the issue satisfies it"
+printf 'Closed #420 instead.\n' > "$VAULT/projects/vigia/notes/2026-01-01-a-note.md"
+stop s3 2 "a note naming a longer number does not"
+git -C "$REPO" checkout -q -b no-issue-here
+stop s4 0 "a branch with no issue number is left alone"
+git -C "$REPO" checkout -q -b issue-7-x
+jq -n --arg cwd "$REPOW" '{cwd: $cwd, session_id: "s5", stop_hook_active: true}' \
+  | RECORD_GUARD_STATE=MERGED CLAUDE_PROJECT_DIR="$REPOW" VIGIL_VAULT="$VAULTW" TMP="$FIXW" TEMP="$FIXW" node "$HERE/record-guard.mjs" >/dev/null 2>&1
+got=$?
+[ "$got" -eq 0 ] && ok "a continuation the hook itself caused is not stopped again" || no "a continuation the hook itself caused is not stopped again" 0 "$got"
+
+echo
+if [ "$FAIL" -eq 0 ]; then echo "all checks passed"; else echo "$FAIL check(s) failed"; fi
+exit "$FAIL"

--- a/.claude/scripts/selftest.sh
+++ b/.claude/scripts/selftest.sh
@@ -36,6 +36,9 @@ expect scan-guard.mjs 2 "find rooted at / is blocked" 'find / -name "*.rs"'
 expect scan-guard.mjs 2 "find with a flag before / is blocked" 'find -L / -name x'
 expect scan-guard.mjs 2 "find / after a separator is blocked" 'cd x && find / -type d'
 expect scan-guard.mjs 0 "a bounded find is allowed" 'timeout 10 find / -name x'
+expect scan-guard.mjs 0 "a timeout with flags is still a bound" 'timeout -k 5 10 find / -name x'
+expect scan-guard.mjs 2 "a timeout on an earlier command bounds nothing here" 'timeout 10 ls; find / -name x'
+expect scan-guard.mjs 2 "a timeout before a pipe bounds nothing after it" 'timeout 10 ls | find / -name x'
 expect scan-guard.mjs 0 "find under a real path is allowed" 'find /c/Dev/vigia -name "*.rs"'
 expect scan-guard.mjs 0 "find in the checkout is allowed" 'find . -name "*.rs"'
 expect scan-guard.mjs 0 "a / that is not a start path is allowed" 'ls / && grep -r foo /c/x'
@@ -79,6 +82,10 @@ printf 'Closed #420 instead.\n' > "$VAULT/projects/vigia/notes/2026-01-01-a-note
 stop s3 2 "a note naming a longer number does not"
 git -C "$REPO" checkout -q -b no-issue-here
 stop s4 0 "a branch with no issue number is left alone"
+git -C "$REPO" checkout -q -b release-2026-09-03
+stop s6 0 "a date in a branch name is not an issue"
+git -C "$REPO" checkout -q -b 42-thing
+stop s7 2 "the older <n>-<slug> branch shape still names its issue"
 git -C "$REPO" checkout -q -b issue-7-x
 jq -n --arg cwd "$REPOW" '{cwd: $cwd, session_id: "s5", stop_hook_active: true}' \
   | RECORD_GUARD_STATE=MERGED CLAUDE_PROJECT_DIR="$REPOW" VIGIL_VAULT="$VAULTW" TMP="$FIXW" TEMP="$FIXW" node "$HERE/record-guard.mjs" >/dev/null 2>&1

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,20 @@
 					{
 						"type": "command",
 						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/scripts/decision-authority.mjs\""
+					},
+					{
+						"type": "command",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/scripts/scan-guard.mjs\""
+					}
+				]
+			}
+		],
+		"Stop": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/scripts/record-guard.mjs\""
 					}
 				]
 			}

--- a/.claude/skills/take-next/SKILL.md
+++ b/.claude/skills/take-next/SKILL.md
@@ -87,7 +87,7 @@ search   the decision you are about to touch
 recall   accumulated constraints; empty early, and empty is not evidence of none
 ```
 
-Consulting the vault is deliberate, not reflexive: know which of the three you are asking for. Strategic context loaded while writing a public commit message is how it leaks, and the commit guard checks for session artifacts only.
+Consulting the vault is deliberate, not reflexive: know which of the three you are asking for. Strategic context loaded while writing a public commit message is how it leaks, and the commit guard catches session artifacts (URLs, trailers, local paths), not strategy.
 
 ## 3. Plan it, in plan mode, before touching code
 

--- a/.claude/skills/take-next/SKILL.md
+++ b/.claude/skills/take-next/SKILL.md
@@ -5,558 +5,225 @@ description: Take the next task from ROADMAP.md and ship it end to end. Use when
 
 # take-next
 
-Take **one** task from `ROADMAP.md` and carry it to done. Not part of a task, not three tasks, not a survey of what could be done.
-
-This is a reconstruction. The original lived in a global skills directory, was never version controlled, and was lost in a machine migration. It lives in the repo now for that reason. Do not move it out.
+Take **one** task from `ROADMAP.md` and carry it to done. Not part of a task, not three tasks, not a survey of what could be done. It lives in the repo so that it is version controlled. Do not move it out.
 
 > [!IMPORTANT]
-> **Run this to the end. After the plan is approved, do not stop to ask.**
+> **Run this to the end. Plan approval at step 3 is the one sanctioned stop.**
 >
-> This skill is invoked and then left alone, frequently overnight. **A step that can only complete by asking a question does not complete** — it halts, and the answer arrives hours later with all the expensive work already done and nothing merged. That has happened: a pass finished 372 green tests, a clean plan diff, 17 killed mutants and before/after budgets, then stopped at the audit to ask permission for something this file already mandates.
+> The skill is invoked and left alone, often overnight. A step that can only complete by asking a question does not complete: the answer arrives hours later with the expensive work done and nothing merged. So the line is **what** versus **how**. What gets built is settled at step 3, where a question is free. Everything after it is execution, and execution questions have answers in this file:
 >
-> **Step 3 is the one exception, and it is not negotiable.** Plan approval is the single sanctioned stop in this skill — "run to the end" starts *after* it. An unattended pass that reaches step 3 **stops and waits**. It does not self-approve, and it does not proceed on the grounds that nobody is awake. **Not wanting to disturb someone is not approval**, and a plan nobody answered is not an approved plan. Halting at step 3 costs a night. Skipping it ships *what* nobody chose and silently disables the plan-fidelity gate downstream, which is the one gate that would have caught it.
+> - **The instruments are pre-authorized.** Invoking this skill is the request to run them, including the review agents `/simplify` and `/harden` spawn. Do not ask again at step 6.
+> - **Where a choice is documented, take the documented one** and say so in the report. That governs *how*. A documented refusal is a conclusion from a reason, and the reason gets checked (step 3).
+> - **Where a choice is open and nobody is there, take the branch that delivers what was asked, finish the pass, and put the question in the report.** "Conservative" never means "build less": under-building costs the reader the thing they asked for and leaves nothing on screen to say so, where over-building costs an afternoon they can see and reject.
 >
-> The line is **what** versus **how**. What gets built is settled at step 3 and the plan is where a question belongs, because it is free there. Everything after it is execution, and execution questions have answers in this file:
+> Four things still stop the pass, and all four are *what*-shaped: a finding that contradicts `SPEC.md` (step 4), discovering the task is two tasks (step 3), anything destructive outside this branch, and **reaching a conclusion that declines or narrows something the reader asked for**. That last one is not settled by plan approval: a decline riding inside a plan is one line in two thousand words, and approving a plan reads as *proceed*, not as *I agree not to get the thing I asked for* (#177). Ask it on its own, in one message, and wait. An unattended session may add. It may not subtract.
 >
-> - **The instruments are pre-authorized.** Invoking this skill *is* the request
-> to run them, including the parallel review agents `/simplify` and `/harden` spawn. A standing "do not spawn agents unless asked" is satisfied by the invocation; it is not a second gate to clear at step 6. See that step.
-> - **Where a choice is documented, take the documented one** and say so in the
-> report. Do not offer it as a menu. This governs *how* to build a thing, and it is not a licence to inherit a **refusal** unexamined: a documented "no" is a conclusion someone reached from a reason, and the reason is checkable. See "The record is evidence, not authority" at step 3.
-> - **Where a choice is genuinely open and nobody is there, take the more
-> conservative branch, finish the pass, and put the question in the report.** A finished pass with a flagged decision beats an unfinished one with a pending question, because the flag survives and the prompt does not. **On a request from use, the conservative branch is the one that delivers it.** Reading "conservative" as "build less" is backwards here and it inverted this rule on #177: over-building costs an afternoon he can see and reject, and under-building costs him the thing he asked for while leaving nothing on screen to say it is missing. Build it, and put the doubt in the report.
->
-> Four things still stop the pass, and they are all *what*-shaped: a finding that contradicts `SPEC.md` (step 4 says stop and decide which is wrong), discovering the task is really two tasks, anything destructive or irreversible outside this branch, and **reaching a conclusion that declines or narrows something the reader asked for**. Those are worth waiting for. Nothing else is.
->
-> **That fourth one is not settled by plan approval, and this is the exception to "what gets built is settled at step 3".** A decline riding inside a plan is one line in two thousand words, and approving a plan reads as *proceed*, not as *I agree not to get the thing I asked for*. On #177 that is exactly what happened: the plan carried `B20 (new) — in-app drag selection of drawn cells: no` as a bullet, approval came back, and a refusal the reader never weighed went into the contract. **Ask that question on its own, in one message, and wait.** Halting there costs a night; the alternative cost him the feature and left a ruling in `SPEC.md` saying he should not have it. An unattended session may add. It may not subtract.
->
-> **"Ship it as is" is never one of the options.** It is the self-authored triage step 6 refuses, wearing a question mark.
+> Step 3 is a real stop. An unattended pass that reaches it presents the plan and waits. It does not self-approve, and nobody being awake is not a yes. **"Ship it as is" is never one of the options.**
 
 ## 1. Find your place
 
-Do not guess and do not scroll the code looking for where things stopped. One command finds the work:
-
 ```sh
-# The earliest ELIGIBLE milestone that still HAS open issues, then its issues.
-gh api "repos/{owner}/{repo}/milestones?state=open&per_page=100" --jq '
-  [ .[]
-    | select(.open_issues > 0)
-    | select((.description // "") | startswith("Shelf:") | not)
-    | { order: (((.title | [scan("^Phase +([0-9]+)")[]] | first) // "9999") | tonumber), title: .title }
-  ] | sort_by(.order, .title) | .[0].title // empty'
-gh issue list --state open --milestone "<that title>"
+sh .claude/skills/take-next/next.sh            # the milestone to take from, then its open issues
+sh .claude/skills/take-next/next.sh --ranked   # the whole take order the answer came from
+sh .claude/skills/take-next/preflight.sh       # does the spec still agree with the tracker
 ```
 
-**Not "the earliest open milestone".** A finished phase leaves its milestone open until someone closes it, so the earliest *open* milestone can be one with zero open issues, and the query then returns nothing and the session has no work to take. That happened the first time this was tried: Phase 1 was complete, merged, and still open, so `take-next` found the plan and then found nothing in it.
+The script picks the earliest **eligible** milestone. Three rules, each with the failure it exists to stop:
 
-**And not "the earliest" by whatever the API hands back, either.** That query used to sort on `due_on`, and **every milestone here has none** — sorting a set on a key that is null for every member does not define an order, so `[0]` was whichever one the API happened to return first. It gave the right answer by luck while there were two open milestones and the lower number was the one to take. The Phase 4 re-housing ended that: number order and execution order came apart, and the shelf, which must **never** be selected, stopped being separable from the phases by number alone — it sat between Phase 4 and Phase 6 while all three had work, and it is below both survivors now that Phase 4 is closed. **What it actually cost is one occurrence and one near miss**, which is worth stating precisely because the case for the fix does not need more: the [#66](https://github.com/breferrari/vigia/issues/66) session recorded that step 1 returned the wrong phase and shipped Phase 4 work regardless, so the wrong answer was caught; the pass that fixed this was handed `Phase 5` outright and caught it only by reading the roadmap prose the query cannot see. Neither was caught by anything automatic, and that is the finding — not a tally.
+1. **Order is the phase number that begins the title**, because the milestone due date is null on every row here and a sort on a null key returns whatever the API sent first. A title not beginning `Phase <n>` sorts last rather than vanishing. That is cheaper than vanishing, not safe: a milestone renamed off the pattern skips its turn silently, which comparison 6 catches.
+2. **A description beginning `Shelf:` is never selected.** A shelf is permanently open and never next. Mark a shelf that way and nothing else.
+3. **A milestone with no open issues is not a place to look**, so a finished phase left open cannot answer. An empty answer is not an error: it means what is left is shelved, exhausted, or nothing at all. Read which before acting. Only the first leads anywhere, and taking from the shelf is a deliberate choice made after re-reading the deferral reason, which is a dated claim (#76).
 
-Three rules, so that the next milestone added inherits them rather than the accident:
+`sh .claude/skills/take-next/selftest.sh` asserts all three offline in about three seconds. Run it after any edit to `next.sh`, `preflight.sh` or these rules. **If you finish the last issue in a milestone, close the milestone.**
 
-1. **The order is the phase number in the title.** It is deterministic and it needs no metadata, where `due_on` was the same shape `SPEC.md` §7 keeps finding one domain over: an instrument that looks settled and proves nothing, because a sort key that is null on every row reads exactly like an order and defines none. A title not *beginning* `Phase <n>` sorts **last** rather than being dropped, and the thing holding that line is `// "9999"`, not the choice of `scan`: with the fallback in place `capture` behaves identically, and it is only with the fallback removed that the two come apart. That is the reason `scan` is still the right one to write. Delete the fallback and `scan` fails **loudly** (`null cannot be parsed as a number`) while `capture` silently keeps 2 milestones of 3 — so the form that survives a future edit badly is the one to leave behind. Ties break on the title, so two milestones sharing a number still have a defined order. **Sorting last is a cheaper failure than vanishing, not a safe one:** a milestone renamed off `Phase <n>` still skips its turn silently, which is why comparison 6 below exists.
-2. **A milestone whose description begins with `Shelf:` is never selected.** A shelf is permanently open and never "next", and until #83 that was a fact only prose knew, so no query could act on it. Mark one by starting its description with `Shelf:` — the [Shelf milestone](https://github.com/breferrari/vigia/milestone/5) reads `Shelf: never next. …` — and leave the marker off anything meant to be taken in sequence. (It was titled "Phase 5" until 2026-08-06; older records citing that name mean this shelf, and a title with no phase number also sorts last by rule 1's own fallback, so the description prefix and the sort now agree.)
-3. **An empty result is not an error, and it is not the paragraph above either.** Line 56's "returns nothing" is a milestone left open with zero open issues, which `select(.open_issues > 0)` now discards on its own. Empty *here* means every eligible milestone was discarded that way and what is left is shelved, exhausted, or nothing at all — so read which before acting, because the three want different things and only the first leads anywhere. Shelved work remaining is the point at which taking from the shelf becomes a deliberate choice rather than a default, and the deferral reason is re-read first, because a reason is a dated claim ([#76](https://github.com/breferrari/vigia/issues/76)). Drop the trailing `| .[0].title // empty` to see the ranked list the answer came from; one bare title is the answer without any of its evidence.
+`ROADMAP.md` is the plan; the issues are the truth. If they disagree, the issues win and the roadmap is fixed in the same pass.
 
-**All three rules are asserted by `sh .claude/skills/take-next/selftest.sh`**, which is offline, needs only `jq`, and takes about two and a half seconds, most of it the three cases that run `preflight.sh` end to end against a fixture. Run it after any edit to the query or to the rules beside it. It exists because the first two edits to this command were verified by hand into a GitHub comment, which is verification that dies with the shell it ran in, and because the rationale in rule 1 was **wrong** in its first version and nothing would have caught that. It also fails if the filter here and the filter it tests drift apart, in either direction.
+### Pre-flight
 
-**If you finish the last issue in a milestone, close the milestone.** It is the step that makes the next session's first command work.
+`preflight.sh` reads `SPEC.md` and `ROADMAP.md` from `origin/main`, never the working tree, fetches the whole board, and exits non-zero on any mechanical hit. **Every hit is fixed in this pass**, not noted. It takes about twenty seconds, most of it two shell loops (#371). First it checks the board arrived whole, because a truncated fetch makes comparison 1 cry wolf while 2, 4 and 7 under-report. Then seven comparisons:
 
-`ROADMAP.md` is the plan; the issues are the truth. If they disagree, the issues win and the roadmap is stale, so fix the roadmap in the same pass.
+1. **Untracked.** An invariant the spec declares that no issue title names.
+2. **Orphan.** An issue naming an `I<n>` the spec no longer declares.
+3. **State.** A row marked `✅` whose issue is open, a row not marked done whose issue is closed, or a row citing an issue the tracker does not have.
+4. **Unfiled.** An open issue with no milestone. It is not deprioritised, it is **invisible**: `next.sh` filters by milestone and will never return it.
+5. **Untracked prerequisite.** The open `SPEC.md` §10 bullets are printed for judgement. One whose text orders work (*before*, *first*, *until*, *blocked*) with no issue behind it is a blocker no token match can see. File it, then decide whether it is in scope or is taken first, before planning.
+6. **Milestone drift.** `next.sh`'s answer must be the phase `ROADMAP.md`'s section order would choose, and every open milestone with work must have a `## Phase <n>` section. This is the only comparison that checks the first command's own answer.
+7. **Missing row.** An issue, any state, that the roadmap never mentions.
 
-### Pre-flight: does the spec still agree with the tracker?
+If a finding is a false positive, fix the check rather than learning to skip it. The same holds for this file: **a command here that no longer does what it says is fixed the moment it is found**, in the pass that found it. That is a correction, not instrument work, and the shelf rule in step 4 does not reach it.
 
-That rule is right and nothing enforced it, so drift was only ever caught by someone happening to read both. It went wrong in **both** directions inside one hour: an issue described a design the spec had already moved past, and an issue sat open after the work it tracked had shipped.
+Then take the **topmost unstarted task in the eligible phase**. Do not skip ahead. If a later task genuinely blocks the current one, say so first, then take the blocker. If a task is `🔨 in progress`, check `git status` and the open PRs before starting anything: another session may be mid-flight.
 
-**One command runs it: `sh .claude/skills/take-next/preflight.sh`.** It performs comparisons 1–4, 6 and 7 mechanically, prints §10's open bullets for the judgment in 5, and exits non-zero on any mechanical hit. Before any of them it checks **the board itself**, which is a precondition rather than an eighth comparison: the seven weigh two records against each other, and this one asks whether the tracker record is all here, because a fetch that stops short makes comparison 1 cry wolf while 2, 4 and 7 quietly under-report. Every session used to do this by hand from the blocks below, which is the intention-triggered shape that decays; the blocks stay because the **why** is what a session needs when a finding fires, and the script carries the same traps in code (explicit ref, `tr -d '\r'`, character-class boundaries, no `--paginate`). Mutation-tested in both directions before it was trusted — including one mutation that survived because the *mutation* was wrong (it flipped a row with no issue link, which comparison 3 rightly ignores), which is itself the lesson §7 teaches about instruments.
+### A decline is the most expensive thing this skill can produce
 
-The seven, by hand if the script is unavailable — three commands gather the state; you do the comparing:
+Four Phase 8 passes each spent a full session and delivered a "no", and one has since been reopened because both of its reasons were false. Three rules:
 
-```sh
-git fetch -q origin
+- **A decline is reached early or it is not a decline.** The reason either holds under checking or it does not, and that is a question about facts, which is cheap. Hours spent after the reason is known are spent justifying, and the tell is prose getting longer while the argument does not get stronger.
+- **A decline carries a higher bar than a build.** A bad build is loud; a bad refusal is silent, and no gate can see the feature that does not exist. *"It would cost a wake"*, *"it needs a timer"* and *"no API reports that"* are claims with answers, and all three have been wrong here.
+- **When the reader asked for the thing, the default is build.** If the honest summary is *"possible, affordable, and I would have designed it differently"*, that is a preference. Build it.
 
-# Invariants the spec declares.
-git show origin/main:SPEC.md \
-  | grep -oE '^\| \*\*I[0-9]+[a-z]?\*\*' | grep -oE 'I[0-9]+[a-z]?' | sort -u
-
-# What the tracker holds. The limit is above the whole board on purpose: a
-# fetch that stops short is invisible from inside a comparison, and at 200
-# against 202 issues it dropped #2 and made comparison 1 report I2a untracked.
-gh issue list --state all --limit 1000 --json number,title,state,milestone
-
-# Roadmap rows that claim a state, with the issue they claim it for.
-git show origin/main:ROADMAP.md | grep -oE '^\| *(✅|🔨|⬜) *\|.*\[#[0-9]+\]'
-
-# Open questions the spec has parked. Nothing above can see these: they are
-# prose, and an unanswered one carries neither an `I<n>` token nor an issue.
-git show origin/main:SPEC.md \
-  | sed -n '/^## 10\./,/^## 11\./p' \
-  | grep -E '^- \[ \]' | cut -c1-200
-
-# Ordering language inside those bullets — the ones that are blockers.
-git show origin/main:SPEC.md \
-  | sed -n '/^## 10\./,/^## 11\./p' \
-  | grep -E '^- \[ \]' \
-  | grep -inE 'do (this|that|it) (before|first)|(before|after) the [a-z]+ (test|soak|work|pass)|must (happen|land|come|ship|be done)|blocked (by|on|until)|prerequisite|revisit (together|with)|stand or fall together|confirm against|until [^ ]+ (lands|ships|merges|closes)'
-```
-
-> [!NOTE]
-> **Why that pattern is phrase-shaped and not a word list**
->
-> The obvious version greps bare `before|first|until`, and on this spec it is **80% false positives**: §10 is full of "first paint", "the first frame that draws deep", "the lines before it". A check that nags four times for every real hit gets skipped exactly like one that never fires, which is the failure this whole comparison exists to fix. Tested both directions before landing: against `origin/main` it returns three bullets and all three are genuinely actionable, and against `dbc97aa` — the last commit before [#32](https://github.com/breferrari/vigia/issues/32) closed — it returns the settle-margin bullet, the exact prerequisite that hid for two phases. Widen it only with the same two runs.
-
-Then seven comparisons. Any hit is a finding to fix **in this pass**, not a note:
-
-1. **Untracked** — an invariant the spec declares that no issue title names.
-2. **Orphan** — an issue naming an `I<n>` token the spec no longer declares. This is what catches a rename or a split that left the tracker behind.
-3. **State** — a roadmap row marked `✅` whose issue is open, or a row not marked done whose issue is closed. And a row citing an issue the tracker does not have at all, which for a long time this skipped in silence: a deleted issue, a transferred one and a mistyped `#N` all arrive here looking identical, and none of them is fixed by fetching more.
-4. **Unfiled** — an *open* issue with **no milestone**. This looks least like drift and matters most: the query above filters *by* milestone, so an unmilestoned issue is not deprioritised, it is **invisible** and will never be returned however long it sits. Seven had accumulated before anyone noticed.
-5. **Untracked prerequisite** — an open `SPEC.md` §10 bullet that **no issue names**, and above all one whose text orders work: *before*, *first*, *until*, *blocked*, *prerequisite*. Unlike the four above this wants judgement rather than a token match, so read the five to ten bullets the commands print and say which have nothing behind them. **A §10 bullet that says another task must happen first is a blocker with no tracker entry, and the task it blocks will be taken anyway** — every check above will run clean, because prose carries no `I<n>` and no `#<n>`. That is strictly worse than the unfiled case: an unmilestoned issue is at least *in* the tracker. §10 said *"narrow the settle margin… do this before the soak test"* and nothing tracked it, so [#5](https://github.com/breferrari/vigia/issues/5) sat blocked by name for **two phases** and was only caught by a session happening to read §10 while loading context. File the blocker, then decide whether it is in scope for this pass or a prerequisite to take first — but decide it before planning, not after.
-6. **Milestone drift** — the phase step 1 chose must be the phase `ROADMAP.md` would have chosen, and every open milestone with open issues must have a `## Phase <n>` section. This is the only comparison that checks *this file's own first command*, and it exists because every other one ran clean on the pass that [#83](https://github.com/breferrari/vigia/issues/83) fixed while step 1 was handing that session the shelf. Step 1's answer is now correct **by construction**; comparison 6 is what makes it correct **by evidence**, and the two are not the same claim, which is the distinction §10 draws between a gate that fires and a budget met at its own window.
-
-```sh
-git show origin/main:ROADMAP.md | grep -oE '^## Phase [0-9]+.*' | sed 's/^## //' | tr -d '\r' > /tmp/order.txt
-gh api "repos/{owner}/{repo}/milestones?state=open&per_page=100" > /tmp/ms.json
-jq -r '.[] | select(.open_issues > 0) | .title' /tmp/ms.json | tr -d '\r' > /tmp/withwork.txt
-jq -r '.[] | select(.open_issues > 0) | select((.description // "") | startswith("Shelf:")) | .title' /tmp/ms.json | tr -d '\r' > /tmp/shelved.txt
-
-# What ROADMAP.md's section order says, which is the authority on sequence.
-while IFS= read -r s; do
-  grep -qxF "$s" /tmp/withwork.txt || continue
-  grep -qxF "$s" /tmp/shelved.txt && continue
-  echo "roadmap says: $s"; break
-done < /tmp/order.txt
-
-# Open milestones with work that no ROADMAP section names.
-LC_ALL=C sort /tmp/withwork.txt > /tmp/withwork.sorted
-LC_ALL=C sort /tmp/order.txt > /tmp/order.sorted
-LC_ALL=C comm -23 /tmp/withwork.sorted /tmp/order.sorted
-```
-
-**Two ways it fires, and each catches a different silent failure.** A *disagreement* between step 1's answer and the roadmap's means the `Shelf:` marker was edited off, or gained a leading space, or a phase was renumbered — the marker is remote free text with none of this repo's controls over it, and it is the load-bearing input the diff cannot show you. An *orphan* means a milestone was renamed off `Phase <n>` and now sorts to the 9999 bucket, so its turn is skipped without anything saying so, or a new milestone was created with no roadmap section at all. Mutation-tested on all four before landing, plus the unchanged case, because a check that cannot report "no drift" has not been tested.
-
-**`tr -d '\r'` is not optional here**, and it is the trap two bullets below rather than a new one: `jq` emits CRLF on Windows, `grep -qxF` then fails against every line, and the comparison reports the entire board as orphaned. It did exactly that on the first run of this check.
-
-> [!WARNING]
-> **Read `SPEC.md` and `ROADMAP.md` from `origin/main`, never the working tree**
->
-> The first run of this check read the checkout, which had a feature branch active, and compared branch state against the live tracker. It reported the roadmap as ahead of an issue when on `main` the two agreed — and **#2 was closed on the strength of a line that was not merged.** A check whose answer depends on which branch happens to be checked out is worse than no check.
->
-> Comparing uncommitted state is occasionally what you want. It has to be asked for out loud, never the default.
-
-7. **Missing row** — an issue, any state, that `ROADMAP.md` never mentions at all. The 2026-08-03 sweep found four gaps in exactly this direction while the five comparisons then existing ran clean over the same data: a drift check has a direction, chosen by whichever collection it iterates, and this is the one that iterates the tracker against the roadmap rather than the reverse.
-
-Only the first two directions are cheap to eyeball; run all seven anyway — which is what `preflight.sh` is for. A check that nags forever gets ignored exactly like one that stays silent, so if a finding is a false positive, fix the *check* here rather than learning to skip it.
-
-**Three traps if you match these with `jq`. The first two made the first run report every invariant as drifting in both directions at once; the third silently halves a comparison rather than breaking it:**
-
-- **`\b` does not work.** In a `jq` string, `\b` is the *backspace* character, so `test("\\bI1\\b")` compiles a regex containing two backspaces and matches nothing — silently, and in the "everything is broken" direction. Use an explicit class instead of escaping harder:
-  ```sh
-  B='(^|[^A-Za-z0-9])'; A='([^A-Za-z0-9]|$)'
-  jq -e --arg i "$inv" --arg b "$B" --arg a "$A" 'any(.[]; .title | test($b+$i+$a))'
-  ```
-- **`jq` emits CRLF on Windows.** Its output into a shell loop carries `\r`, so `grep -qxF "$token"` fails against a clean list for every token. Pipe through `tr -d '\r'` before comparing. Comparison 6 hit this on its own first run and reported every milestone as orphaned, which is what the bullet above predicts and is still what it looks like from the outside: a catastrophic finding.
-- **`--paginate` does not compose with `--jq`.** `gh api --paginate --jq` runs the filter **once per page** and concatenates the outputs, so a filter that sorts and takes `.[0]` emits one answer per page rather than one answer. Verified against this repository at `per_page=2`: two lines came back, `Phase 6` and `Phase 7`, which is the ambiguity step 1 exists to remove, reintroduced by the flag that looks like the careful choice. `--slurp` is refused outright alongside `--jq`. So step 1 uses `per_page=100` and no `--paginate`, and it stays that way until something needs more than 100 milestones, at which point the fix is to page and sort in the shell, not to add the flag.
-
-The first two together produce a check that is *100% false positive* while looking like a catastrophic finding. Mutate it once before you trust it: point a comparison at a token you know is tracked and confirm it comes back **clean**. A drift check that cannot report "no drift" has not been tested.
-
-Take the **topmost unstarted task in the earliest *eligible* phase** — eligible in the sense the three rules above give it, not "the earliest open milestone", which is the phrasing this section opens by rejecting twice. Do not skip ahead to something more interesting. If a later task genuinely blocks the current one, say so and take the blocker, but say it out loud first.
-
-If a task is already `🔨 in progress`, check `git status` and the open PRs before starting anything: another session may be mid-flight, and two sessions on one task is worse than one session idle.
-
-### A decline is the most expensive thing this skill can produce, so reach it early or not at all
-
-**Four passes in Phase 8 each spent a full session and delivered a "no"** ([#149](https://github.com/breferrari/vigia/issues/149), [#120](https://github.com/breferrari/vigia/issues/120) twice, [#123](https://github.com/breferrari/vigia/issues/123), [#124](https://github.com/breferrari/vigia/issues/124)), and one of them has since been reopened because both of its reasons were false. That is the worst output shape available here: maximum cost, nothing on screen, and a reader who asked for something getting an essay about why they cannot have it.
-
-Three rules, and they are about *when* and *how hard*, not about being agreeable:
-
-- **A decline is reached in the first part of the pass or it is not a decline.** The reason a thing should not be built either holds under checking or it does not, and that is a question about facts, which is cheap. Hours spent after the reason is known are not spent deciding, they are spent **justifying**, and the tell is that the writing gets longer while the argument does not get stronger. If you have been at it a while and are still assembling the case, the honest reading is that the case is weak.
-- **A decline carries a higher bar than a build**, for the asymmetry step 3 records: a bad build is loud and a bad refusal is silent. The reason has to be a fact that survives being checked, not a consideration that sounds sound. **"It would cost a wake", "it needs a timer", "no API reports that"** are all claims with answers, and all three have been wrong here.
-- **When the reader has asked for the thing, the default is build.** A refusal overrides a direct request from the person whose product it is, so it needs a reason that would still convince them after they have read it. If the honest summary is *"it is possible, it is affordable, and I would have designed it differently"*, that is a preference and the answer is build it.
-
-**And the ruling's prose is sized to the ruling, not to the effort.** A decline that took an afternoon does not earn four paragraphs in `SPEC.md` because it took an afternoon. Long justification of a "no" is the same failure one layer over: it makes the refusal harder to revisit, because the next reader has to argue with a wall of text instead of with one checkable sentence. State the reason in the fewest words that can be falsified, and put the evidence trail in `RULINGS.md` where it belongs.
+A ruling's prose is sized to the ruling, not to the effort: the reason in the fewest words that can be falsified goes to `SPEC.md`, and the evidence trail goes to `RULINGS.md`.
 
 ### A `decision` issue is ruled first and built second, in the same pass
 
-**The label is the reader's and a session may not apply it, infer it, or write the roadmap row that implies it.** An issue arrives labelled `decision` or it is a build, and an issue that reads like a decision while carrying no label is a build with a question in it — answer the question in the report, not in `SPEC.md`. This sentence exists because on 2026-08-29 a pass took [#177](https://github.com/breferrari/vigia/issues/177), a feature request with **no labels at all**, wrote the `ROADMAP.md` row calling it a decision, ruled against it, and closed it — all in one commit. Everything below about how to rule well is unreachable if a session can decide *what kind of issue it is holding*, because the classification is what makes a refusal an acceptable deliverable. **A pass may not create and discharge a decision in the same branch.**
-
-Check the label before planning. An issue labelled **`decision`** is one whose acceptance is **a ruling recorded in `SPEC.md`** rather than a diff — and, when the ruling is *yes*, the build that makes the ruling true, which is the correction 2026-08-17 forced into this section after a ruling shipped in a release that changed nothing a reader could see. Three exist today ([#74](https://github.com/breferrari/vigia/issues/74), [#50](https://github.com/breferrari/vigia/issues/50), [#89](https://github.com/breferrari/vigia/issues/89)) and they were already written that way — #74's exit criteria read *"a ruling: build the seam, or record that direct consumption is accepted"*, and *"if declined: a line in `SPEC.md` §6 saying so, so the next reviewer finds a decision instead of an omission."*
-
-**They had no route, which is the actual defect.** Every step below assumes a diff: plan a build, ship it, scope the checks to the changed files, prove it with gates. Handed a `decision` issue, this skill plans a build for something whose answer might be *"do not build it"* — and #50 sits in a phase that gets **taken in sequence**, so this is reachable rather than hypothetical.
+**The `decision` label is the reader's. A session may not apply it, infer it, or write the roadmap row that implies it.** An issue arrives labelled `decision` or it is a build, and a build that reads like a decision is a build with a question in it: answer the question in the report, not in `SPEC.md`. A branch that both files a decision and rules on it is refused at publish by `.claude/scripts/decision-authority.mjs`.
 
 When the issue is labelled `decision`:
 
-- **The deliverable is the ruling and its reasoning**, written where the next reader will hit it — the `SPEC.md` section the issue names, plus its §10 bullet closed. A ruling filed only in the issue is not filed: the issue closes and `SPEC.md` still reads as an omission.
-- **The ruling goes in the contract. The road not taken goes in `RULINGS.md`.** *"Declined"* is a result and the case for it is worth keeping, but keeping both branches in `SPEC.md` means the contract grows on a refusal as surely as on a build, so no outcome ever fails to add to it. `SPEC.md` gets the ruling in the fewest words that can be falsified; the rejected branch and its evidence go to the ledger, under its budget, or nowhere.
-- **A ruling of *yes* is the first half of the pass, not the end of it.** The build gets its **own issue and its own PR**, so the ruling is never blocked by an implementation, and then **this same pass takes that issue and ships it**. Stopping at the ruling is what this bullet used to say and it was wrong: #167 ruled that `?` opens a gestures sheet, filed #206 for the build, and released **0.11.1 with nothing on screen**. The reader pressed `?`, got nothing, and had to go and find out that the tool had been *told* about a feature it did not have. Two PRs, one pass, in that order.
-- **The only reason to stop after the ruling is size, and it is a claim about the build rather than about the rules.** If the build genuinely will not fit one fresh context (the test three sections down), stop there and say so — but say it in the **first line of the report**, in the form *"nothing the reader can see has changed yet; the build is #N"*. A pass that ends with the tool doing exactly what it did before is allowed. A pass that ends that way quietly is not.
-- **The report opens with what a reader can now do that they could not before.** If the honest answer is *nothing*, that is the first sentence, not a detail three paragraphs down. This is the line that would have caught the case above, and no gate can see it: the suite was green, the plan was delivered in full, and the feature did not exist.
-- **The gate is different.** There is no diff to scope checks to and nothing for `/harden` to audit, so step 5's docs-vs-code split resolves to docs and the fidelity check in step 6 runs against the *plan's promises about the ruling*: every question the issue asked is answered, and each answer names what it rests on.
-- **A ruling that cannot be made is a finding, not a failure.** If it needs a measurement nobody has run or a week of use nobody has had, say so, record what would settle it, and leave the issue open with that written down. #50 needs exactly that, and pretending otherwise produces a guess wearing a ruling's clothes.
+- **The deliverable is the ruling**, in the `SPEC.md` section the issue names, plus its §10 bullet closed. A ruling filed only in the issue is not filed.
+- **The road not taken goes to `RULINGS.md`**, so the contract does not grow on a refusal.
+- **A ruling of *yes* is the first half of the pass.** The build gets its own issue and its own PR, and this pass takes it next. Stopping at the ruling shipped 0.11.1 with a feature the tool had been told about and did not have (#167, #206).
+- **Size is the only reason to stop after the ruling**, and then the report's first line says *"nothing the reader can see has changed yet; the build is #N"*.
+- **A ruling that cannot be made is a finding.** Say what would settle it and leave the issue open with that written down.
 
 ## 2. Load the why before touching code
 
-**Except on a research or look-and-feel row, where the world comes first.** Reading the rulings before surveying anchors the survey to what was already decided, and a session that starts from the spec proposes what the spec already permits, which is how a document recording yesterday's ceiling becomes tomorrow's. It happened on #318: the first read of the field was filtered through three rulings before any survey ran, and the reader had to say *"the specs hold us down too much"* before the aperture opened. On those rows: survey the world, form the outside view, then diff it against the record and reconcile. `SPEC.md` §0 states the same rule from the document's side.
+**Read the repo first.** The issue carries acceptance criteria, `SPEC.md` carries the contract and, unusually, most of the reasoning: §10's open questions carry their measurements and the commit messages argue rather than announce. **On a research or look-and-feel row, the world comes first**: survey outside, form the view, then diff it against the record. Reading the rulings first anchors the survey to what was already decided, which is how a document recording yesterday's ceiling becomes tomorrow's (#318, and `SPEC.md` §0 says the same).
 
-**Read the repo first.** The issue carries acceptance criteria, `SPEC.md` carries the contract, and — unusually for a repo — a great deal of the *reasoning* is here too: §10's open questions carry their measurements, the invariant callouts explain why they split, and the commit messages argue rather than announce. Most "why did we do it this way" questions are answered inside the checkout.
-
-Then reach outside it, through the `vigil` MCP server, for the three things the repo deliberately does **not** hold:
-
-- **What cannot be public.** This repo is public. The competitive read, the market position, the objection this project was started against — none of that belongs in a file anyone can clone, and it is the reason the vault exists at all.
-- **What generalises past this repo.** A `gix` limitation or a measurement trap is true for every Rust project, so it lives where other projects can reach it.
-- **What predates or outlives the code.** Why this is monitor-class rather than review-class was decided before the first commit, and re-deriving it is the most expensive mistake available here.
+Then the `vigil` MCP server, for the three things the repo deliberately does not hold: what cannot be public (the competitive read, the market position), what generalises past this repo (a `gix` limitation, a measurement trap), and what predates the code (why monitor-class rather than review-class).
 
 ```
 search   the decision you are about to touch
-recall   accumulated constraints — empty early, and empty is not evidence of none
+recall   accumulated constraints; empty early, and empty is not evidence of none
 ```
 
-**Consulting the vault is deliberate, not reflexive.** Reaching for it when the answer is in `SPEC.md` wastes a call; reaching for it out of habit while writing a *public* commit message loads strategic context that must never land in one. This repo's own PreToolUse hook (`.claude/scripts/leak-guard.mjs`) blocks a `gh` publish whose body carries a session artifact, but **commit messages have no automatic guard here** — that discipline is yours, and a squash commit merged to a public `main` stays reachable by SHA forever. Know which of the three you are asking for before you ask.
+Consulting the vault is deliberate, not reflexive: know which of the three you are asking for. Strategic context loaded while writing a public commit message is how it leaks, and the commit guard checks for session artifacts only.
 
 ## 3. Plan it, in plan mode, before touching code
 
-**Enter plan mode and write the plan. No code before an approved plan.**
-
-**Approved means a person answered.** Not "the plan is written", not "the plan is obviously right", not "it was late and asking would have woken someone". If this pass is unattended, step 3 is where it ends for the night: present the plan and wait. That is the designed outcome, not a failed pass — step 3 settles *what* gets built, and that was never the session's call to make.
-
-The plan is not ceremony and it is not for you — it is the only artifact the finished work can be *audited against*, and code cannot audit itself.
-
-Without it the completeness check downstream has nothing to compare to. `/harden` carries a plan-fidelity phase that explicitly skips when no written plan exists, so a session that skips planning silently disables the one gate designed to catch under-delivery. That gate exists because a session once passed five clean audit rounds with 501 tests green and had still quietly shipped three promises short.
+**Enter plan mode and write the plan. No code before an approved plan, and approved means a person answered.** The plan is the only artifact the finished work can be audited against: `/harden`'s plan-fidelity phase skips when no written plan exists, and a session once passed five clean audit rounds with 501 tests green while three promises short.
 
 ### The plan states what it stands on
 
-Step 2 sends you to the record before touching code. **The plan is where you show what came back**, and it is the last point at which a contradiction is still free to fix.
-
-Name, in the plan itself:
-
-- the decisions this plan rests on, by title, from `search` / `recall` / `SPEC.md`
-- anything you found that argues **against** the approach, and why you are proceeding regardless
-- an explicit "nothing recorded on this" when the record is empty — a real finding, not a blank to skip past
-
-Consultation at step 2 alone fires exactly once, at the moment you know least about what you will need. Naming the result here moves it to the moment you commit. A choice re-derived from scratch that contradicts a recorded one is the most expensive mistake available in this repo, and the plan is the only place it is visible while it still costs nothing.
+Name, in the plan: the decisions it rests on, by title, from `search`, `recall` and `SPEC.md`; anything found that argues against the approach, and why you proceed regardless; and an explicit *"nothing recorded on this"* when the record is empty, which is a finding rather than a blank.
 
 ### The record is evidence, not authority
 
-`SPEC.md` is the source of truth for **what must hold now**. That is not the same as every sentence in it being beyond question, and the difference is where this skill has gone wrong more than once.
+`SPEC.md` says what must hold now. That is not the same as every sentence in it being beyond question, and three kinds of sentence are not equally solid:
 
-**Try to break the assumption before you build on it. Look at it from the angles the original ruling did not.** A written reason is the best evidence available about what someone knew *at the time they wrote it*, which is exactly as durable as the facts it rested on. Treating it as scripture is how a repo inherits a constraint nobody has believed in for months.
+- **An invariant with a measurement behind it** is load-bearing. **Whether it reaches the case in front of you is a fresh question every time**: quote the row's own words. I1's budget is *0 wakeups while idle*, and nothing a reader's hand is doing is idle. Two features were refused on I1 and its gate could not have caught either.
+- **A refusal** is a conclusion from a moment: a reason and a date, and both expire. **Re-read the reason and check whether it is still true today.** A reason naming an absence (*"no API for this"*, *"the takeover does not enable X"*) expires fastest, because dependencies add things and nobody re-reads a refusal when they do; B10 was declined for a year on a line this repo had simply not written. When the reason collapses, the question reopens. It does not get a fresh reason for the same conclusion (#123).
+- **A budget** is a number chosen against a workload. **Invoked as a reason, it arrives with its current headroom**: not "this costs a wake" but "2.4ms of a 16ms frame". A budget at 19% is a budget with room, and saying so is what stops the number being used as a mood.
 
-Three distinctions worth keeping straight, because they are not equally solid:
+**Do not run a measurement whose only possible use is to justify a no.** Measuring to find out is the most valuable thing in this repo's history: 442.71ms to 8.76ms, found by checking a premise. Measuring to build a case against something a reader asked for produces a number that was never going to change the answer.
 
-- **An invariant with a measurement behind it** (I1's idle cost, I4's streaming bound) is load bearing and is not relitigated casually. But **whether it reaches the case in front of you is a fresh question every single time**, and that is the check that actually gets skipped. Quote the row's own words and see whether they describe your case. Twice in one week here, an invariant was cited to refuse something its budget could never have measured.
-- **A refusal** is a conclusion from a moment. It carries a date and a reason, and both expire. Challenge it by attacking the reason, not by re-arguing taste.
-- **A budget or a threshold** is a number someone chose against a workload. If your workload is not that workload, the number is not evidence about you.
-
-**A budget invoked as a reason to refuse something must be quoted with its current headroom.** Not the limit: the limit *and* where the tool actually sits against it. "This costs a wake" is not an argument when the last measurement says the frame path uses **2.4ms of a 16ms budget**, which is five times over. A budget at 19% is a budget with room, and saying so out loud is what stops the number from being used as a mood.
-
-That is not a licence to spend the headroom carelessly, and it is not an argument against the budgets, which exist because the thesis is a measurable claim. It is a rule about **honesty in citation**: the same paragraph that names the ceiling names the floor the tool is standing on, and then the trade is visible instead of implied. If the honest sentence is *"this would take us from 2.4ms to 2.6ms against a 16ms budget"*, that sentence usually settles the question in favour of building it, which is exactly why it has to be written rather than skipped.
-
-**And do not run a measurement whose only possible use is to justify a no.** Measuring to find out is the most valuable thing in this repo's history: counting instead of building took a fixture from 442.71ms to 8.76ms, and it was found by someone checking a premise rather than defending one. Measuring to build a case against a feature a reader has asked for is the same activity pointed backwards, it costs real time and attention, and it produces a number that was never going to change the answer. If you already know what you want the measurement to show, you are not measuring.
-
-**Refusals deserve more scrutiny than builds, not less, and the reason is asymmetry.** A bad build is loud: tests fail, gates redden, someone reports it within the hour. A bad refusal is silent. Nothing breaks, no gate fires, the feature simply does not exist and no one can see the hole where it should be. So the failure mode that survives longest in a well-gated repo is precisely the one the gates cannot reach, and every instrument in this skill points at code that was written rather than at code that was refused.
-
-**A refusal cited in a plan is quoted, dated, and marked checked or not.** The plan names the refusal's reason in its own words, the date it was ruled, and whether this session re-checked the reason against the world. A refusal relayed without those three is not evidence, and the fidelity gate should read it as an unnamed premise.
-
-**The burden sits on the reason, not on the person asking for the thing.** "It is written down" is not an argument, and neither is "we ruled on this." Both are pointers to an argument, and the argument is what gets checked. When a reader asks for something the record refuses, the first move is to go and re-read *why* it was refused, not to relay the refusal.
-
-**And a refusal that turns out to rest on a false premise is not a decision to defend, it is a bug in the record.** Fix it the way any other defect gets fixed: say what was wrong, reopen the question, and leave both versions visible so the next reader can see the correction rather than only its result.
+**A refusal cited in a plan is quoted, dated, and marked checked or not.** Relayed without those three, it is an unnamed premise.
 
 ### The plan names its premises, and settles the load-bearing ones itself
 
-The section above records what the plan **stands on**: decisions already written down. This one is about what it **assumes**, which is the part nothing has ever checked.
+A premise is what everyone took for granted. Write them as a short ledger before the plan body: what must be true, how it would be falsified, and the answer with its source, one of *measured*, *read in the dependency's source*, *checked against the world*, *recorded in `SPEC.md`*, or *assumed*. **A load-bearing premise is not allowed to stay assumed.** Finding facts is this session's job and never Brenno's: read the source in `~/.cargo/registry`, write the throwaway probe, take the measurement, search the web. A premise about the outside world (*does this library expose that, do terminals honour it, what do the toolkits that solved this already use*) is checked against the outside world and never against memory, because a wrong fact about someone else's library produces a plan that is internally consistent and wrong. Work premises in dependency order.
 
-A premise is a claim that must be true for this to be the right plan at all. It is not a decision, because nobody made it — it is what everyone took for granted. Write them as a short ledger before the plan body:
-
-- **What must be true** for this approach to be correct.
-- **How it would be falsified** — the observation that would end the plan.
-- **The answer and where it came from**: measured, read in the dependency's source, **checked against the world outside this repo**, recorded in `SPEC.md`, or *assumed*.
-
-**A premise the plan is load-bearing on is not allowed to stay `assumed`. Go and find out.** Finding facts is this session's job and never Brenno's: read the source, write the throwaway probe, take the measurement, **search the web**. A question a probe can answer is not a question for the report, and it is certainly not one to leave for an empty room at 3am.
-
-#### A premise about the outside world is checked against the outside world, not against memory
-
-Some premises are not about this code at all. *Does this library expose that?* *Does the protocol carry it?* *Do terminals implement it?* *What do the toolkits that solved this already use?* Those have answers, the answers change, and the one place they are never reliably stored is a model's recollection of them.
-
-**So read the dependency's source in `~/.cargo/registry`, and search the web.** Both, when both apply: the source says what the API is, the web says whether the world it talks to actually honours it. A number taken from two independent implementations is a number nobody has to defend; a number chosen because it felt right is one that gets re-argued every time it is looked at.
-
-Three from one afternoon, all of which changed what shipped:
-
-- *"No mouse protocol reports a held button"* was **confirmed** by reading `crossterm`'s `MouseEventKind`, which is what made a hold-to-repeat clock a design problem rather than a lookup.
-- *"The repeat cadence should be about 400ms then 40ms"* was a guess. Qt's `qscrollbar.cpp` uses `initialDelay = 500` and a `50` repeat, and GTK's `gtk-timeout-repeat` defaults to 50ms. **500/50 shipped**, and it is defensible in a way the guess never was.
-- *"The takeover does not enable focus reporting"* had been written into `SPEC.md` as the mechanism that made a hover highlight impossible. `crossterm` has shipped `EnableFocusChange` and `Event::FocusLost` for years, `?1004h` is implemented by xterm, iTerm2 and kitty, and on Windows the console API delivers focus events unasked. **A feature had been declined for a year-old absence that was never there.**
-
-**The cost of not checking is asymmetric.** A search that confirms what you thought costs a minute. A premise about the outside world that is quietly out of date costs a feature, and it costs it silently, because a wrong fact about someone else's library produces a plan that is internally consistent and wrong.
-
-#### A recorded decision's *reason* is a premise, and it is the one most likely to be stale
-
-The section above says the plan names the decisions it stands on. This says what to do when one of them is a **refusal** you are about to inherit.
-
-**Re-read the reason it was declined for, and check whether it is still true.** Not whether the decision was reasonable, and not whether you would make it again: whether the specific sentence it rests on is a fact today. A decline is a dated claim exactly the way a deferral is ([#76](https://github.com/breferrari/vigia/issues/76)), and it is worse than a deferral in one way, because a deferral advertises that it expires and a ruling reads as settled.
-
-Two shapes to look for, and this repo has produced both inside one week:
-
-- **The reason names an absence.** *"No API for this", "the takeover does not enable X", "nothing would tell it to turn off."* An absence is the claim most likely to have stopped being true, because dependencies add things and nobody re-reads a refusal when they do. §11.2 **B10** declined a hover highlight on *"the takeover does not enable focus reporting"*, which was a description of one line this repo had not written, phrased as though it were physics.
-- **The reason cites an invariant.** Check that the invariant's **letter** reaches the case, not just its spirit. §11.2 B10 and [#166](https://github.com/breferrari/vigia/issues/166) were both refused on I1, and in both the citation was wrong: I1's budget is *0 wakeups while idle*, and neither pointer motion nor a held button is idle, so the gate could never have caught either. **Two refusals, one invariant, zero applicability.**
-
-**And when a reason collapses, the decision reopens.** It does not acquire a new reason. B10's first reason was measured and found false during its own ruling, a second was substituted, and the conclusion never moved: the decline outlived both of its bases. A conclusion that survives while its stated basis is swapped underneath it is motivated reasoning wearing a ruling's clothes, and it is invisible from the inside, because each individual step looks like diligence. If the sentence a refusal rests on turns out not to be true, say so and put the question back on the table, even when that means reversing something written down hours earlier.
-
-Work them in dependency order. A premise whose answer depends on another still-open one is a *later* question, not a parallel one — settle the first, then ask the second with the answer in hand.
-
-**Why this exists**, three occasions from this repo's own notes:
-
-- A row-exact scrollbar was refused as unaffordable, citing I4 and a prior issue as precedent. Brenno pushed back twice and asked for it to be investigated anyway. The invariant was real and had been applied to the wrong operation — counting is not building — and the correct path measured **442.71ms to 8.76ms**. The premise, *"a total requires every file diffed"*, was never written down as a premise, so nothing was in a position to challenge it.
-- An issue's entire premise was wrong in a useful direction, and the note records it as **the third time** an expensive-looking property turned out to be cheap.
-- The measurement that mattered most turned out to be for the implementation that was **not** chosen. Nothing asked for it; it surfaced by accident.
-
-Each was cheap to check before the work and expensive after. **A plan that cannot be wrong about anything has not named its premises.**
-
-Only a genuinely open **decision** — a judgement about what the product should be, which no probe can settle — goes to Brenno, and it goes *in the plan*, where it is free. That is the same line the header already draws between *what* and *how*.
+Only a genuinely open **decision**, a judgement about what the product should be that no probe can settle, goes to Brenno, and it goes in the plan, where it is free.
 
 ### The plan must be diffable
 
-Length is not the bar; **concreteness** is. Every promise has to be checkable later by reading, so write nouns, not intentions:
+Every promise has to be checkable later by reading: modules and files touched, signatures and types, error codes and what emits them, tests by name and by what they assert, deviations from `SPEC.md` named upfront with the reason, and what is out of scope. "Fix the thing" passes any fidelity check because it promised nothing. Scale it to the diff.
 
-- modules and files touched, function signatures, types
-- error codes emitted, and what emits them
-- the tests that will exist, by name and by what they assert
-- any deviation from `SPEC.md`, named upfront with the reason
-- anything explicitly **out** of scope
+### The work has to fit one fresh context
 
-"Fix the thing" is not a plan. It survives any audit precisely because it promised nothing — a plan that cannot be diffed passes the fidelity check while proving nothing, which is worse than having no plan at all, because it *looks* gated.
+**Could a fresh session hold this whole issue, the spec sections it touches, the files it changes and the tests it adds, and still have room to reason about it?** If not, the issue is two issues: split the **issue**, give each child a complete path through spec, code and gates, and name the one it is blocked by. The day #77 was split in three, eleven PRs merged at a sixth of the size under the same gates. The audit is a bad place to learn the scope was wrong, because by then the rounds are paid for.
 
-Scale it to the diff. A two-line fix gets a short plan; it still names the file, the assertion, and the test. A phase gets a long one.
-
-### The work has to fit one fresh context, and this is where you find out
-
-The section above sizes the *plan*. This one sizes the *work*, and it is the check this skill was missing.
-
-**Before the plan is approved, ask: could a fresh session hold this whole issue — the spec sections it touches, the files it changes, the tests it adds — and still have room left to reason about it?** Not "can it be described in one plan", which is always yes. Can it be *held*.
-
-If the honest answer is no, the issue is two issues. Say so now and split the **issue**. *The unit is the issue* still holds — one issue, one branch, one PR — because you are splitting the unit, not fragmenting one unit across PRs. Give each child a complete path through spec, code and gates that is verifiable on its own, and name the one it is blocked by.
-
-**This is not a style preference.** One week in this repo:
-
-| Day | PRs merged | avg additions |
-|---|---|---|
-| 08-01 | 2 | 2394 |
-| 08-02 | 2 | 3379 |
-| 08-03 — the day [#77](https://github.com/breferrari/vigia/issues/77) was split in three | **11** | **531** |
-
-Five times the throughput at a sixth of the size, same standard, same gates. And #77 is what finding out late costs: its audit went 22 findings then 23, flat, which `/harden` reads as *the scope is wrong, not the rigor*. The split was correct, and it came after two full rounds had been spent auditing a diff that was never going to converge. **The audit is a bad place to learn the scope was wrong, because by then the rounds are already paid for.**
-
-**A wide refactor is the exception.** One mechanical change whose blast radius fans across the codebase — retyping a shared symbol, renaming a field every module names — cannot be cut into slices that each land green, because the first slice breaks every call site. Sequence it **expand then contract**: add the new form beside the old so nothing breaks, migrate call sites in batches sized by blast radius (per crate, per module) with each batch its own issue blocked by the expand, then delete the old form in a final issue blocked by every batch. CI stays green batch to batch because the old form still exists. Do not force that shape onto ordinary work, and do not use it as a licence to skip the test above.
+The exception is a wide mechanical refactor whose blast radius fans across the codebase. Sequence it **expand then contract**: add the new form beside the old so nothing breaks, migrate call sites in batches each their own issue, delete the old form last. Do not force that shape onto ordinary work.
 
 ### The plan has to outlive the session
 
-**Comment it on the issue before implementing.** The issue is the only durable surface that exists at planning time — the PR does not exist yet, since there are no commits to open it from, so "put it in the PR body" is unexecutable here and quietly becomes "keep it in my head". Carry it into the PR body at PR time as well, where the reviewer and `/harden`'s fidelity phase will both look for it.
-
-A plan that lives only in the conversation dies at the next compaction, and nobody but this session can ever check the work against it.
+**Comment it on the issue before implementing**, then carry it into the PR body. A plan that lives only in the conversation dies at the next compaction.
 
 ### Deviations
 
-Reality will contradict the plan sometimes; that is normal and not a failure. The failure is deviating quietly.
-
-**Every deviation is a defect unless its justification was written down at the moment it was taken**, naming what the plan got wrong. A reason produced at audit time, about a choice made an hour earlier, is rationalisation — the same self-serving triage this skill refuses everywhere else, and it has a one-pushback half-life. Genuine plan-vs-reality conflicts route through the rule in the next section: stop, decide which side is wrong, change *that* one deliberately, in its own commit, and say which you changed.
-
-At the end of the pass, diff the shipment against the plan and report the result (step 6). Any deviation without a contemporaneous justification gets **corrected in this session** — not logged, not deferred, not carried into the PR as a note.
-
----
+Reality contradicts plans; deviating quietly is the failure. **Every deviation is a defect unless its justification was written down when it was taken.** A reason produced at audit time for a choice made an hour earlier is rationalisation. A plan-versus-reality conflict routes through step 4's rule: stop, decide which side is wrong, change that one in its own commit, and say which.
 
 ## 4. Ship it
 
-- **The tool watches its own build when anyone is at the keyboard.** If Brenno is present, `vigia` runs in a side pane on this worktree for the duration of the pass — the workload [#72](https://github.com/breferrari/vigia/issues/72) says has never been measured is exactly this session, and six of this repo's defects were found by a reader looking at the screen within the hour while eleven green gates sat over one of them. Costs nothing on an unattended overnight pass; the report line in step 9 says which kind this was.
-- **The unit is the issue.** One issue, one branch, one worktree, one PR. Splitting one issue across several PRs fragments review and reads as progress theatre. If the issue is genuinely two things, say so and split the *issue* first.
-- **Work in a worktree, never in the main checkout.** Two long-lived worktrees exist for passes — `../vigia.a` and `../vigia.b`, reused rather than created per issue so their `target/` stays warm — and the main checkout stays parked on `main`, which is what keeps "read from `origin/main`" and "what the working tree shows" from ever being different questions. The rule was earned in one evening, twice: an uncommitted edit sat in a tree another session was committing from, and a branch checkout in the shared tree meant a second session's commit would have landed on the first one's branch. A worktree costs one cold build the first time and nothing after; the shared-checkout failure costs someone else's work.
-- **An instrument run that outlives the pass gets a start-comment on its issue** — what is running, where its output lands, and when it ends — at the moment it starts, not only a report when it finishes. A 24-hour soak recorded only in a commit message was ruled "unauthorised" by a parallel session planning from the machine it was running on; the comment on the window's issue is what reached that session, and pre-flight comparison 0 is the mechanical half that does not rely on being read.
-- **Open the PR as a draft, and open it early.** `gh pr create --draft` the moment there is a branch worth pushing, and carry the step 3 plan into the body. A draft is the cheap place to work: `ci.yml` skips every job while `draft == true`, so pushes cost nothing, and Copilot does not review one. Marking it ready is the expensive event and step 7 owns it. Iterating on a non-draft PR is how one branch here spent **nine CI runs** converging.
-- **Never defer a finding into a new issue to get the PR closed.** If work surfaces something inside the scope of the task, fix it here. A new issue is for something genuinely out of scope, and it needs **all three** of a milestone, a `ROADMAP.md` row, and a shelf entry giving the reason it moved. Miss the milestone and the issue is **invisible**, not deprioritised: the query in step 1 filters by milestone and will never return it. Seven accumulated that way before anyone noticed, so file it in one command rather than intending to come back:
-
-  ```sh
-  gh issue create --title "..." --body-file f.md --milestone "Shelf"
-  ```
-
-That milestone is named literally because it is the shelf that exists today. **The shelf is a class, not a name** — step 1's rule 2 identifies one by a description beginning `Shelf:` — so if a second is ever added, file against the right one rather than against this string.
-- **A finding about the process files to the Shelf, and instrument work is takeable only when a product pass is blocked by it.** An audit that surfaces a defect in a gate, a check, a skill, or a workflow has found something real and not something *next*: it goes to the Shelf with its dated reason like any deferral, never into a phase. The instruments generate findings faster than the product generates users, and a queue that serves both equally serves the mirror — adopted 2026-08-07, the morning after a night of the machine's best work went to a memory meter's baseline while seven look-and-feel rows sat unbuilt. A product pass genuinely blocked by an instrument defect takes the unblock inside its own pass, sized to the blockage, and says so in the report.
-- **An invariant is not landed until a test fails when it is violated.** Write the failing test first, watch it fail, then make it pass. A test that passes against broken code is worse than no test.
+- **The unit is the issue.** One issue, one branch, one worktree, one PR. If the issue is two things, split the issue first.
+- **Work in a worktree, never the main checkout.** `../vigia.a` and `../vigia.b` exist for passes and keep their `target/` warm. Take one with `git -C ../vigia.a checkout -B issue-<n>-<slug> origin/main`. The main checkout stays parked on `main`, so "read from `origin/main`" and "what the tree shows" never become different questions.
+- **If Brenno is present, `vigia` runs in a side pane on this worktree for the pass.** Six defects were found by a reader looking at the screen while eleven green gates sat over one of them. It costs nothing unattended, and step 9 says which kind of pass this was.
+- **An instrument run that outlives the pass gets a start-comment on its issue** the moment it starts: what is running, where its output lands, when it ends.
+- **Open the PR as a draft, early.** `gh pr create --draft` as soon as there is a branch worth pushing, with the plan in the body. `ci.yml` skips every job on a draft and Copilot does not review one, so pushes are free. Marking ready is the metered event, and step 7 owns it.
+- **Never defer a finding into a new issue to get the PR closed.** In scope means fixed here. Out of scope needs all three of a milestone, a `ROADMAP.md` row and a shelf entry with the reason, filed in one command: `gh issue create --title "..." --body-file f.md --milestone "Shelf"`. Without a milestone the issue is invisible to `next.sh`.
+- **A finding about the process files to the Shelf.** A defect in a gate, a check, a skill or a workflow goes there with its dated reason, never into a phase. Instrument work is taken only when a product pass is blocked by it, sized to the blockage. A wrong command in this file is the exception step 1 names.
+- **An invariant is not landed until a test fails when it is violated.** Failing test first, watch it fail, make it pass.
 - **Budgets are tests.** If the task touches the frame path, the budget gate runs.
-- **Do not add a dependency `SPEC.md` does not name.** Propose it into the spec, in its own commit, then use it.
-- If reality contradicts the spec, **stop**. Decide which is wrong, change that one deliberately, in its own commit, and say which you changed.
+- **No dependency `SPEC.md` does not name.** Propose it into the spec in its own commit, then use it.
+- **If reality contradicts the spec, stop.** Decide which is wrong, change that one deliberately, in its own commit, and say which you changed.
 
 ## 5. Scope the checks to the diff
-
-Running the full suite on a docs-only change wastes minutes and proves nothing.
 
 ```sh
 git diff --name-only <base>..HEAD | grep -vE '\.md$|^\.github/ISSUE|^LICENSE'
 ```
 
-Empty means docs-only: skip `cargo test`, `cargo bench` and the budget gates.
-
-**Caveats, because this is where corner-cutting hides:** `Cargo.toml`, `Cargo.lock`, `*.yml` and anything under `.github/workflows` are **never** docs, even when changed alongside markdown. A README tweak plus a "tiny" manifest edit is a code diff. Log the scope decision in the PR body so a reviewer can challenge it.
+Empty means docs-only: skip `cargo test`, `cargo bench` and the budget gates. `Cargo.toml`, `Cargo.lock`, anything under `.github/workflows`, `.github/scripts` or `.claude/scripts` is **never** docs, whatever it is changed alongside. Log the scope decision in the PR body.
 
 ## 6. Prove it, then say so honestly
 
-- `cargo test` green, and name the count
-- budget gates green, and quote the numbers against the budgets
-- state failures plainly; a green summary over a skipped check is a lie with good manners
+- `cargo test` green, with the count. Budget gates green, with the numbers against the budgets. Failures stated plainly: a green summary over a skipped check is a lie with good manners.
+- **Diff the shipment against the plan.** Walk every promise and mark it delivered or not, and say the result out loud even when it is clean. Three shapes shipped behind five clean audit rounds once: **quietly narrowed** (per-file counts promised, paths shipped), **quietly collapsed** (a three-value union became two), **promised and absent** (an error code defined and never emitted). A deviation without a contemporaneous justification is corrected in this pass, not noted.
 
-### Then diff the shipment against the plan
+Then polish, and let the **diff** pick the instrument:
 
-Tests prove the code does what it does. They cannot prove it does what step 3 **said** it would — the plan lives outside the code, so no test run reaches it. This is a completeness check, done by reading both sides.
+- **Under ~200 lines across ≤3 files:** `/simplify` alone. `/harden` states this floor itself and wins if the two disagree.
+- **Larger, or anything the system stands on:** `/harden` until dry. It runs `/simplify` as one of its phases and carries its own plan-fidelity phase, so tell it the plan diff above is done.
+- **The surface picks the bar.** Engine and invariant work hardens until dry. Look-and-feel work (layout, colour, keys, chrome) is `/simplify` plus a screenshot in the PR, because the judge of feel is a human eye. The escalation is one-way: feel work that touches the frame path, the watch or an invariant takes the engine bar for that part.
+- **"Foundational" is not a self-assessment you get to lower.** The frame path, the watch engine, the diff oracle and the budget gates are the whole system. A first-pass "not worth fixing" has a one-pushback half-life here.
 
-Walk every promise the plan made — each module, signature, type, error code, named test, declared scope boundary — and mark it delivered or not. Then report the result out loud, including when it is clean.
+Both instruments spawn parallel review agents, and this invocation authorised them. **Run the agents on Sonnet.** The reviewer personas are pinned to it and the orchestrator keeps the session's model, because the fan-out is what exhausts a session's limit and a Sonnet round found the last publish blocker. Pass two things into every brief:
 
-Three shapes to look for, because these are the three that actually shipped once behind five clean audit rounds and 501 green tests:
+> Documentation is in scope for `/simplify` and is judged by the same rule as code: a comment exists where the code cannot explain itself. Keep why the obvious approach is wrong, an invariant a caller must hold, and a cost invisible at the call site. Delete restatements of the code, issue numbers, ruling ids, and any account of the change rather than the thing.
 
-- **Quietly narrowed** — the plan promised per-file `+N/−M` counts, the shipment showed paths only.
-- **Quietly collapsed** — a three-value discriminated union became two.
-- **Promised and absent** — an error code defined in the plan, never emitted, leaving dead code where it should have been.
+> Read the code. Do not run builds, benchmarks, test suites, or anything else that consumes the machine. Every measurement you need is in this brief. If one is missing, name it and say what it would change, and I will run it and hand it back.
 
-Any deviation lacking a justification **written when it was taken** is a defect, and it gets fixed in this pass. Not noted in the PR, not filed as a follow-up, not explained in the report. Correcting it is the requirement; reporting it is not a substitute. A reason invented now, for a choice made an hour ago, is rationalisation — and this skill does not accept self-authored triage anywhere else either.
-
-Then polish, and let the **diff** pick the instrument rather than your appetite.
-
-> [!IMPORTANT]
-> **Both instruments spawn parallel review agents, and this step authorizes them.**
->
-> `/simplify` runs four — reuse, simplification, efficiency, altitude. `/harden` runs three per round — adversarial, correctness, docs — and repeats until a whole round finds nothing new. That fan-out is the instrument, not an optimisation of it: the skill's own reason is that a solo reviewer tunnel-visions and disjoint remits do not.
->
-> So a standing "do not spawn agents unless asked" **has been satisfied** — by the invocation that started this pass. Do not stop here to ask for it a second time. A session that halts at this step has paid for the whole diff, the plan fidelity check and the mutation run, and banked none of it.
->
-> If the environment refuses the spawn outright rather than asking, that is a different thing and it is reportable: run the audit single-threaded, say in the report that it ran without fan-out, and name what that costs. Degrading loudly is fine. Stopping is not.
-
-- **Under ~200 lines across ≤3 files** — `/simplify` alone. A full audit workflow on a small diff is theatre. (`/harden` states this floor itself and will decline; the number lives there, so if the two ever disagree, harden wins.)
-- **Anything larger, or anything the rest of the system stands on** — `/harden` **until dry**. It runs `/simplify` as one of its own phases, so do not run one first and then the other. It also carries its own plan-fidelity phase: tell it the diff above was already done, so it records the result instead of repeating it.
-- **The surface picks the bar, the way the diff picks the instrument.** Engine and invariant work hardens until dry — that rigor earned its keep in the frame path and it stays. Look-and-feel work (the Phase 8 class: layout, colour, keys, chrome) defaults to `/simplify` plus snapshot review plus **a screenshot in the PR**, because the judge of feel is a human eye and it rules in five seconds; a three-agent audit loop on an inset spends a night where a look decides. The escalation is one-way: feel work that touches the frame path, the watch, or any invariant's surface takes the engine bar for that part.
-
-Whichever runs, pass the docs rule into the invocation. `/simplify` is the only instrument that reduces, and freezing docs against it is what took the comments to 60% of the shell crate: the ratio could only ever climb. What actually needs protecting is a class, not a volume, so protect the class:
-
-> Documentation is in scope for `/simplify` and is judged by the same rule as code: a comment exists where the code cannot explain itself. Keep why the obvious approach is wrong, an invariant a caller must hold, and a cost invisible at the call site. Where a comment exists because the code is unclear, the fix is clearer code and the comment goes with it. Delete restatements of the code, issue numbers, ruling ids, and any account of the change rather than the thing.
-
-**And pass the read-only carve-out, because an agent that builds competes with you for the machine.** On 2026-08-18 four review agents were told to measure and each ran an optimised build (`lto = "thin"`, `codegen-units = 1`) concurrently with the session's own, one against a probe worktree carrying a 3.4G `CARGO_TARGET_DIR`. The machine was audibly saturated before anything in the loop noticed, because a session's picture of the machine is its own actions only. It costs nothing in review quality to prevent: round 2 of #245's audit ran read-only with the numbers pasted into the brief and was just as sharp as the round that built.
-
-> Read the code. Do not run builds, benchmarks, test suites, or anything else that consumes the machine: `cargo build`, `cargo test`, `cargo bench`, `cargo clippy` and the soak are all mine to run, not yours. Every measurement you need is in this brief. If one you need is missing, name it and say what it would change about your finding, and I will run it and hand it back.
-
-Running is the orchestrator's job in both directions: the numbers an agent reasons from come from **one** run, so the audit reads a single consistent picture rather than four builds' worth of contention. This is the same rule as the concurrency clause the soak workflow already carries, applied to review instead of to instruments.
-
-**"Foundational" is not a self-assessment you get to lower.** If the change touches the frame path, the watch engine, the diff oracle, or the budget gates, it is foundational — that is the whole system. Do not accept your own "not worth fixing" on a first pass either: that dismissal has a one-pushback half-life here, and three out of four have historically been wrong.
+Running is the orchestrator's job in both directions: one run, one consistent picture. Four agents building at once saturated this machine before anything in the loop noticed.
 
 ## 7. Mark it ready, and wait for both reviewers
 
-Everything until now happened inside a draft, where pushes are free. **Marking ready is the one expensive action in this skill, it is metered twice, and it should happen once.** `gh pr ready` fires `ready_for_review`, which wakes the full matrix on three platforms *and* Copilot's automatic review, and Copilot is quota-limited rather than merely slow.
-
-So do not mark ready to "see what CI says". Mark it ready when the work is finished, the suite is green locally, and step 6's plan diff is clean. Everything else belongs in the draft.
+**Marking ready is the one expensive action here.** `gh pr ready` fires `ready_for_review`, which wakes the matrix on three platforms and Copilot's automatic review, and Copilot is quota-limited. Mark ready once, when the work is finished, the suite is green locally and the plan diff is clean.
 
 > [!WARNING]
-> **A draft shows no checks, and no checks is not green**
->
-> The jobs are skipped, so the PR page shows an empty check list rather than a passing one. That is the exact shape `SPEC.md` §7 keeps finding — a gate that proves nothing while looking settled — and here it is on the review surface instead of in a test. Nothing in a draft has been verified by CI. The local suite is your only evidence until the checks below have actually run.
+> **A draft's checks prove nothing.** The jobs skip on a draft, and `ci complete` passes a draft that skipped everything, so a draft shows one green check that ran no tests. That is a gate that looks settled and proves nothing. The local suite is the only evidence until the run below has actually happened.
 
 ```sh
-gh pr ready <n>                              # the metered event: CI + Copilot
-gh pr checks <n> --watch --fail-fast         # blocks until the matrix settles
+gh pr ready <n>
+gh run list --branch <branch> --workflow ci --limit 1 --json databaseId,headSha --jq '.[0]'
+gh run watch <id> --exit-status
 ```
 
-**Then wait for Copilot, which nothing watches for you.** It arrives as a review from `copilot-pull-request-reviewer[bot]`, usually in state `COMMENTED`, and the substance is in the **line comments** rather than the review body — reading the body alone is how you conclude it had nothing to say:
+Watch the **run**, not the check list: `gh pr checks --watch` has returned before the matrix started, and a PR reached mergeable without one check having run (#301). The run's `headSha` must equal the PR's head, or the checks are about an earlier revision.
+
+**Then Copilot, which nothing watches for you.** It arrives as a review from `copilot-pull-request-reviewer[bot]`, usually `COMMENTED`, and the substance is in the line comments, which carry the login `Copilot`:
 
 ```sh
-gh api repos/{owner}/{repo}/pulls/<n>/reviews \
-  --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]") | .state'
-
-gh api repos/{owner}/{repo}/pulls/<n>/comments \
-  --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")
-        | "\(.path):\(.line)\n\(.body)\n"'
+gh api repos/{owner}/{repo}/pulls/<n>/reviews --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]") | .state'
+gh api repos/{owner}/{repo}/pulls/<n>/comments --jq '.[] | select(.user.login == "Copilot") | "\(.path):\(.line)\n\(.body)\n"'
 ```
 
-**Do not request a review before checking whether one is coming.** Automatic review fires on `ready_for_review`; an explicit request on top of it spends a second unit of quota on a review already in flight. Poll first, and only request explicitly if nothing has arrived after the checks have settled.
+Do not request a review before checking whether one is coming: an explicit request on top of the automatic one spends a second unit of quota. **Wait at most fifteen minutes after the run settles** (a session's number, 2026-09-03; move it freely). If nothing has arrived, proceed and say so in the report. Quota has run out before, and a wait with no exit condition is a pass that never ends.
 
-### Answering it
+**Every Copilot comment gets one of two visible outcomes:** fixed in the diff, or declined in a reply naming the spec section or invariant it would violate. Silence reads as agreement. Copilot is not authoritative and not dismissible.
 
-Copilot is **not authoritative and not dismissible**, and the two failure modes are symmetric. Applying a wrong suggestion because a reviewer said it is how a considered decision gets undone by a machine that never read `SPEC.md`; waving comments away as noise is the self-authored triage this skill refuses in step 6, with the same one-pushback half-life.
+**Iterating after ready is the expensive shape.** Batch fixes into one push. For real iteration, `gh pr ready <n> --undo` returns to draft, where CI is quiet.
 
-Every comment gets one of two outcomes, and both are visible:
-
-- **Fixed**, in the diff.
-- **Declined**, in a reply saying why — most usefully by naming the spec section or invariant the suggestion would violate, since that is the thing Copilot cannot see.
-
-Silence on a comment is neither, and it reads to the next person as agreement.
-
-### Iterating after ready is the expensive shape
-
-Every push to a ready PR re-runs the matrix. **Batch the fixes into one push.** If the review turns up something that needs real iteration rather than a couple of edits, go back to the cheap surface instead of converging in public:
-
-```sh
-gh pr ready <n> --undo     # back to draft; CI goes quiet again
-```
-
-Fix there, then mark ready once more. Two metered events beat six.
-
-### Merge
-
-When the checks are green and every Copilot comment is fixed or answered:
-
-```sh
-gh pr merge <n> --squash --delete-branch
-```
-
-Squash, because the history here is one commit per PR with the number in the subject. **Green means the run that CI actually performed** — check that the matrix ran on the ready revision rather than reading a check list that is empty because the PR was still a draft when you last looked.
+**Merge** when the run is green on the ready revision and every comment is answered: `gh pr merge <n> --squash --delete-branch`. Under a worktree the local branch delete fails after the merge has landed, so check the PR state before retrying.
 
 ## 8. Close the loop, all four places
 
-Skipping any of these is how the next session loses time.
+1. **The issue.** Close it with the evidence: commit, test count, numbers.
+2. **`ROADMAP.md`.** Flip the status; add to the shelf or the pull-forward log if anything moved.
+3. **`SPEC.md`.** Only if the contract changed. Own commit.
+4. **The vault.** `record_work` for what happened here; `remember` for anything that would help a different project. Both when both are true.
 
-1. **The issue.** Close it, with the evidence: commit, test count, numbers.
-2. **`ROADMAP.md`.** Flip the status. Add to the deferral shelf or pull-forward log if anything moved.
-3. **`SPEC.md`.** Only if the contract actually changed. Own commit.
-4. **The vault**, through the MCP:
-   - `record_work` for what happened here: changes, decisions, what was learned, what is still open, how it was verified.
-   - `remember` for anything that would help someone on a **different** project. A `gix` limitation that would bite any Rust project is a `remember`. "Landed the watch engine" is a `record_work`. Both, when both are true.
-
-**This is the loop's least reliable step, so it carries a fallback and a check.** The write guard has refused a legitimate record nine calls running (the #15 record was filed by hand), and one record returned success while writing its sections into the note as raw tool markup, which sat corrupted for two days. So: if `record_work` refuses or errors after a couple of honest rephrasings, **file the note by hand** in the vault (`projects/vigia/notes/`, matching the dated-note shape) and say so in the report — the record is the requirement, the tool is only the route. And after any success, **read the note back** (`search` for it) and confirm the sections landed as markdown; a success return is not evidence of a clean write.
-
-**Then file the recurrence — this fallback has an exit condition.** Try the narrow shape first: `title` and `summary` alone, then the remaining sections in a second call. If it still refuses, comment the date and the received field list on [breferrari/obsidian-mind#244](https://github.com/breferrari/obsidian-mind/issues/244) rather than only noting it in the report. **A documented workaround suppresses the bug report**: once the failure has a prescribed response it reads as a handled step rather than a defect, which is exactly how this one ran ten days across nine consecutive passes while every session followed the procedure correctly. No session can see the rate from inside its own pass — nine here each saw two or three refusals and concluded it was local. A fallback with no exit condition is a permanent bug wearing a procedure.
+The vault write is the loop's least reliable step. If `record_work` refuses after one narrower retry (title and summary first, the rest in a second call), **file the note by hand** under `projects/vigia/notes/` and say so in the report, then comment the date and the field list on breferrari/obsidian-mind#244, because a documented workaround suppresses the bug report. After any success, read the note back: a success return is not evidence of a clean write. A Stop hook refuses, once, to end a session whose merged pass has no note naming its issue.
 
 ## 9. Report
 
-**The first line is what a reader can now do that they could not before.** One sentence, in the tool's own terms — *"`?` opens a sheet of every gesture"* — and if the honest answer is *nothing yet*, that is the first line instead, naming the issue that will change it. Everything below is evidence for that sentence, and a report that buries it has hidden the only fact the reader was waiting for. It is here because no gate can check it: a pass once ended green, complete against its plan, and shipped a release in which nothing on screen had changed.
+**The first line is what a reader can now do that they could not before**, in the tool's own terms, or *nothing yet* naming the issue that will change it. No gate can check this: a pass once ended green, complete against its plan, and released a version in which nothing on screen had changed.
 
-Then what was taken, what shipped, the numbers, what moved on the roadmap, and what the next task is. Then stop. Do not start it.
+**The second line is the release.** The latest tag, and how many merged PRs sit after it. If this pass's work is not in a release, say so: the reader has believed a feature shipped when it sat 22 commits behind the last tag.
 
-Name the **review outcome** too: whether Copilot commented, how many, and what happened to each. A review whose result nobody states is one nobody can tell you skipped — the same reason step 6's plan diff has to be said out loud.
+Then what was taken, what shipped, the numbers, what moved on the roadmap, and the next task, named and not started. And, each under its own heading:
 
-And a **`vigia observations`** line: anything the pane showed that read wrong while this pass ran, or `none`, or `pane not open — unattended pass`. This is [#72](https://github.com/breferrari/vigia/issues/72)'s instrument, one line at a time; an observation that changes nothing goes to the issue anyway, because the workload evidence is the accumulation and not any single line.
-
-And list **every decision taken without asking**, under its own heading, with the branch chosen and the one not taken. That is where the questions this pass did not stop for go, and it is the half that makes not stopping safe rather than merely faster: an unattended pass that finishes silently has decided things nobody can see. One line each is enough — it is a list to disagree with, not a justification.
-
-Include the **plan-fidelity result** explicitly — "every promise delivered", or the deviations and what was done about them. Silence here reads as clean, and a step whose absence is indistinguishable from success is a step that stops happening.
-
-Say what the record gave you, too: which recorded decisions the work stood on, or that there were none. The same reasoning applies — a consultation nobody reports is a consultation nobody can tell you skipped.
-
-## Anti-patterns
-
-- Surveying the whole roadmap instead of taking one task
-- Taking a later task because it looks more interesting
-- Writing code before an approved plan exists
-- Self-approving a plan because the pass is unattended, or to avoid disturbing someone
-- A plan too vague to diff — it passes the fidelity check by promising nothing
-- A plan that lives only in the conversation, so it dies at the next compaction
-- Justifying a deviation at audit time instead of when it was taken
-- Reporting a deviation instead of correcting it
-- Taking a task while an open `SPEC.md` §10 bullet says something else comes first
-- Closing an issue whose invariant has no failing test
-- Stopping at a ruling of *yes* and leaving the build for a later pass without saying, in the report's first line, that nothing a reader can see has changed
-- Releasing a version whose only content is a ruling, without saying that the binary does what the last one did
-- Filing a follow-up issue to avoid fixing something in scope
-- Running the full suite on a markdown diff, or skipping it on a manifest diff
-- Reporting green without naming what ran
-- Halting on a question this file already answers, above all at the audit
-- Offering "ship it as is" as an option
-- Asking permission for the review agents, which the invocation already gave
-- Letting a review agent build, measure or soak, instead of handing it the numbers you already ran
-- Reissuing a search that has not returned, rather than checking whether it is still running
-- Leaving a pass unfinished with a pending prompt instead of finished with a flagged decision
-- Opening the PR ready, or marking it ready to see what CI says
-- Reading a draft's empty check list as a passing one
-- Requesting a Copilot review that automatic review was already sending
-- Converging on a ready PR one push at a time instead of returning it to draft
-- Ignoring a Copilot comment, or applying one that contradicts `SPEC.md` because a reviewer said it
-- Merging on checks that ran against an earlier revision
-- Finishing without `record_work`
+- **Review outcome.** Whether Copilot commented, how many, and what happened to each.
+- **Plan fidelity.** "Every promise delivered", or the deviations and what was done about them.
+- **Decisions taken without asking.** One line each, the branch chosen and the one not taken. This is the half that makes not stopping safe.
+- **What the record gave.** The recorded decisions the work stood on, or that there were none.
+- **`vigia observations`.** What the pane showed that read wrong, or `none`, or `pane not open, unattended pass` (#72).

--- a/.claude/skills/take-next/next.sh
+++ b/.claude/skills/take-next/next.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Names the milestone the next task is taken from, then lists its open issues.
+#
+# The order is the phase number at the start of the title. It is deterministic
+# and needs no metadata, where the milestone due date was null on every row and
+# so sorted nothing. A title not beginning `Phase <n>` sorts last rather than
+# vanishing, which is what the `// "9999"` fallback holds: with it removed,
+# `scan` fails loudly where `capture` would drop the row in silence, so `scan`
+# is the form to keep. A milestone whose description begins `Shelf:` is never
+# selected, and a milestone with no open issues is not a place to look, so a
+# finished phase left open cannot answer.
+#
+# Usage: next.sh [--ranked]
+#   --ranked  print every eligible milestone in take order, not only the first
+#
+# Test seam: NEXT_MILESTONES_FILE substitutes a fixture for the tracker fetch,
+# and the issue listing is then skipped.
+set -eu
+
+SELECT='[ .[]
+    | select(.open_issues > 0)
+    | select((.description // "") | startswith("Shelf:") | not)
+    | { order: (((.title | [scan("^Phase +([0-9]+)")[]] | first) // "9999") | tonumber), title: .title }
+  ] | sort_by(.order, .title) | .[].title'
+
+if [ -n "${NEXT_MILESTONES_FILE:-}" ]; then
+  ranked=$(jq -r "$SELECT" "$NEXT_MILESTONES_FILE" | tr -d '\r')
+else
+  # per_page=100 and no --paginate: `gh api --paginate --jq` runs its filter
+  # once per page and emits one answer per page.
+  ranked=$(gh api "repos/{owner}/{repo}/milestones?state=open&per_page=100" | jq -r "$SELECT" | tr -d '\r')
+fi
+
+if [ "${1:-}" = "--ranked" ]; then
+  printf '%s\n' "$ranked"
+  exit 0
+fi
+
+title=$(printf '%s\n' "$ranked" | head -n 1)
+if [ -z "$title" ]; then
+  echo "no eligible milestone: what is left is shelved, exhausted, or nothing. Read which before acting."
+  exit 0
+fi
+printf 'milestone: %s\n' "$title"
+[ -n "${NEXT_MILESTONES_FILE:-}" ] && exit 0
+gh issue list --state open --milestone "$title"

--- a/.claude/skills/take-next/preflight.sh
+++ b/.claude/skills/take-next/preflight.sh
@@ -155,7 +155,7 @@ sed -n '/^## 10\./,/^## 11\./p' "$tmp/spec.md" | grep -E '^- \[ \]' | cut -c1-16
 say "6. milestone drift — step 1's answer vs the roadmap's section order:"
 if [ -z "${PREFLIGHT_SPEC_FILE:-}${PREFLIGHT_ROADMAP_FILE:-}" ]; then
   gh api "repos/{owner}/{repo}/milestones?state=open&per_page=100" > "$tmp/ms.json"
-  step1=$(jq -r '[ .[] | select(.open_issues > 0) | select((.description // "") | startswith("Shelf:") | not) | { order: (((.title | [scan("^Phase +([0-9]+)")[]] | first) // "9999") | tonumber), title: .title } ] | sort_by(.order, .title) | .[0].title // empty' "$tmp/ms.json" | tr -d '\r')
+  step1=$(NEXT_MILESTONES_FILE="$tmp/ms.json" sh "$(dirname "$0")/next.sh" | sed -n 's/^milestone: //p' | tr -d '\r')
   grep -oE '^## Phase [0-9]+.*' "$tmp/roadmap.md" | sed 's/^## //' | tr -d '\r' > "$tmp/order.txt"
   jq -r '.[] | select(.open_issues > 0) | .title' "$tmp/ms.json" | tr -d '\r' > "$tmp/withwork.txt"
   jq -r '.[] | select(.open_issues > 0) | select((.description // "") | startswith("Shelf:")) | .title' "$tmp/ms.json" | tr -d '\r' > "$tmp/shelved.txt"

--- a/.claude/skills/take-next/selftest.sh
+++ b/.claude/skills/take-next/selftest.sh
@@ -1,39 +1,37 @@
 #!/usr/bin/env sh
 # Self-test for step 1's milestone selection and pre-flight comparison 6.
 #
-# Why this exists: the selection rule is a jq filter inside a markdown file, so
+# Why this exists: the selection rule is a jq filter inside a shell script, so
 # no cargo test can reach it, and the first two edits to it were verified by
 # hand into a GitHub comment. That verification died with the shell it ran in.
 # CLAUDE.md's rule is that an invariant without a failing test is a wish, and
 # this is the cheapest thing that makes it one.
 #
 # It is offline and hermetic: every case is a fixture, so it needs no network,
-# no `gh`, and no particular state of the tracker. Run it after any edit to the
-# query or to the three rules beside it.
+# no `gh`, and no particular state of the tracker. Run it after any edit to
+# next.sh, preflight.sh, or the rules beside them in SKILL.md.
 #
 #   sh .claude/skills/take-next/selftest.sh
 #
-# Requires `jq` only, which step 1 already requires.
+# Requires `jq` only, which next.sh already requires.
 
 set -u
 FAIL=0
-SKILL="$(dirname "$0")/SKILL.md"
-
-# The filter under test. It is duplicated from SKILL.md deliberately rather than
-# parsed out of it, because a parser that silently matches nothing would make
-# this whole file green against code it never ran. Instead the duplication is
-# asserted below, which fails loudly in both directions.
-SELECT='[ .[]
-    | select(.open_issues > 0)
-    | select((.description // "") | startswith("Shelf:") | not)
-    | { order: (((.title | [scan("^Phase +([0-9]+)")[]] | first) // "9999") | tonumber), title: .title }
-  ] | sort_by(.order, .title) | .[0].title // empty'
+HERE="$(dirname "$0")"
+SKILL="$HERE/SKILL.md"
+NEXT="$HERE/next.sh"
+PRE="$HERE/preflight.sh"
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
 
 ok() { printf '  ok   %s\n' "$1"; }
 no() { printf '  FAIL %s\n    expected: %s\n    actual:   %s\n' "$1" "$2" "$3"; FAIL=$((FAIL + 1)); }
 
+# Every case drives next.sh through its fixture seam, so what is tested is what
+# a session runs rather than a copy of it.
 case_is() { # name, expected, json
-  actual=$(printf '%s' "$3" | jq -r "$SELECT" 2>&1 | tr -d '\r')
+  printf '%s' "$3" > "$FIX/ms.json"
+  actual=$(NEXT_MILESTONES_FILE="$FIX/ms.json" sh "$NEXT" 2>&1 | tr -d '\r' | sed -n 's/^milestone: //p')
   [ "$actual" = "$2" ] && ok "$1" || no "$1" "$2" "$actual"
 }
 
@@ -55,7 +53,7 @@ case_is "lowest eligible phase number wins" \
     {"title":"Phase 6 - measured","description":"","open_issues":4}]'
 
 # The bug: a milestone with no open issues must not be selected, which is the
-# case the paragraph above rule 1 has warned about since the first version.
+# case rule 1 has warned about since the first version.
 case_is "a milestone with no open issues is not selected" \
   "Phase 7 - distribution" \
   '[{"title":"Phase 6 - measured","description":"","open_issues":0},
@@ -115,6 +113,14 @@ case_is "a null description is handled" \
   "Phase 6 - measured" \
   '[{"title":"Phase 6 - measured","description":null,"open_issues":1}]'
 
+# --ranked shows the whole order the answer came from, shelf excluded.
+printf '%s' '[{"title":"Phase 7 - distribution","description":"","open_issues":1},
+  {"title":"Phase 5 - deferred","description":"Shelf: never next.","open_issues":28},
+  {"title":"Phase 6 - measured","description":"","open_issues":4}]' > "$FIX/ms.json"
+ranked=$(NEXT_MILESTONES_FILE="$FIX/ms.json" sh "$NEXT" --ranked 2>&1 | tr -d '\r' | paste -sd '|' -)
+[ "$ranked" = "Phase 6 - measured|Phase 7 - distribution" ] && ok "--ranked lists every eligible milestone in take order" \
+  || no "--ranked lists every eligible milestone in take order" "Phase 6 - measured|Phase 7 - distribution" "$ranked"
+
 echo "mutation (the check must be able to fail):"
 
 # Rule 1 claims the fallback is what stops a milestone vanishing, and that scan
@@ -143,10 +149,6 @@ echo "preflight (the board every comparison reads):"
 # cites an issue no fetch contains. The two are one section because they are the
 # same silence from opposite ends: one is the record arriving short, the other is
 # a row pointing outside whatever arrived.
-PRE="$(dirname "$0")/preflight.sh"
-FIX="$(mktemp -d)"
-trap 'rm -rf "$FIX"' EXIT
-
 cat > "$FIX/spec.md" <<'EOF'
 | **I1** | A thing holds | a budget | a gate |
 ## 10. Open
@@ -213,29 +215,21 @@ esac
 
 echo "drift:"
 
-# The filter above must be the filter SKILL.md tells a session to run. Checking
-# one distinctive line is enough to catch an edit to either side, and it is the
-# line carrying every property asserted above.
-NEEDLE='{ order: (((.title | [scan("^Phase +([0-9]+)")[]] | first) // "9999") | tonumber), title: .title }'
-if grep -qF "$NEEDLE" "$SKILL" 2>/dev/null; then
-  ok "the tested filter is the one SKILL.md documents"
-else
-  no "the tested filter is the one SKILL.md documents" "found in SKILL.md" "not found"
-fi
-
 present() { # needle, file, name
   grep -qF "$1" "$2" 2>/dev/null && ok "$3" || no "$3" "$1" "absent"
 }
 
-# Comparison 6 says the shelf is identified by a description prefix, so the
-# marker string must appear in both places that depend on it.
-present 'startswith("Shelf:")' "$SKILL" "SKILL.md still identifies the shelf by prefix"
+# One filter, three callers. The skill sends a session to the script, the
+# pre-flight compares the script's answer against the roadmap, and the shelf is
+# identified by a description prefix in the one place that decides it.
+present 'sh .claude/skills/take-next/next.sh' "$SKILL" "SKILL.md sends a session to next.sh"
+present 'next.sh' "$PRE" "preflight.sh compares the roadmap against next.sh"
+present 'startswith("Shelf:")' "$NEXT" "next.sh identifies the shelf by prefix"
 
 # The limit is the one thing the cases above cannot check about themselves: they
 # run at a small override, so nothing there would notice the shipped default
-# dropping back under the board. Pinned in both places that carry it.
+# dropping back under the board.
 present 'PREFLIGHT_ISSUE_LIMIT:-1000' "$PRE" "preflight.sh still fetches to a limit of 1000"
-present 'gh issue list --state all --limit 1000' "$SKILL" "SKILL.md's hand-run fetch takes the same limit"
 
 echo
 if [ "$FAIL" -eq 0 ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ ls ~/.cargo/registry/src/*/ratatui-core-*/src/buffer/          # the sources, ad
 cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="ratatui-core") | .manifest_path'
 ```
 
-**Never run `find /` on Windows.** Under Git Bash `/` is the MSYS root (`C:\Program Files\Git\`), so `~/.cargo` is not under it and no match is possible; and MSYS mounts the Windows registry as directories at `/proc/registry`, `/proc/registry32` and `/proc/registry64`, so the walk enumerates the hives twice through live Win32 calls and never terminates. Six of these, left orphaned by sessions that moved on, burned 26.8 CPU-hours over five hours on 2026-08-18. Bound any exploratory scan with `timeout`, and prefer Glob or Grep pointed at an explicit path.
+**Never run `find /` on Windows.** Under Git Bash `/` is the MSYS root, which mounts the Windows registry as directories under `/proc`, so the walk never terminates, and `~/.cargo` is not under it anyway. `.claude/scripts/scan-guard.mjs` refuses the call. Bound any exploratory scan with `timeout`, and prefer Glob or Grep pointed at an explicit path.
 
 `gix` was the least-precedented dependency here (`delta` uses `git2`/libgit2 instead, likely for age reasons), so Phase 1 proved it before anything was built on top. **Proven 2026-07-30:** hunk boundaries match `git diff -U3` exactly and every Phase 1 budget holds with room. Evidence and the one constraint it came with are in `SPEC.md` §10.
 
@@ -93,7 +93,7 @@ Two tools, and picking the wrong one is the common mistake. **The test is whethe
 
 **`record_work`** files what happened **here** into the vault. Use it at the end of a real piece of work. Write it for a session that will not have your context and cannot re-read your diff, so fill every field you can: `summary`, `changes` (one line per file, what and why), `decisions` (especially where you rejected an alternative), `learned` (surprises and near-misses), `open` (unresolved threads nobody should assume are handled), `verification` (tests run and their result, failures stated honestly). `kind: "decision"` files it as a decision record; `informed_by` credits the notes you actually read.
 
-**If it is refused for tool-call markup, do NOT re-send the same shape** — it folds again. **Retry smaller in TOTAL SIZE, not merely in field count**: a call with fewer fields but a longer body has been refused where a wider, shorter one succeeded. Send the required fields with the prose trimmed, let that write land, then add the rest in a follow-up call. Two records that arrive beat one that never does. The same fold hits `remember`, so this is not a `record_work` quirk. **The mechanism is not settled** — do not repeat one. **The cost, so you choose it knowingly:** the fields you drop survive as prose in the body but stop being queryable as fields. Tracked as [breferrari/obsidian-mind#244](https://github.com/breferrari/obsidian-mind/issues/244).
+**If a write is refused for tool-call markup, retry once smaller in total size** (the required fields, prose trimmed), then file the note by hand under `projects/vigia/notes/` and comment on [breferrari/obsidian-mind#244](https://github.com/breferrari/obsidian-mind/issues/244). The same fold hits `remember`. Fields you drop survive as prose but stop being queryable.
 
 Rule of thumb: **a `gix` limitation that would bite any Rust project is a `remember`** — and note that it is `scope: "platform"` with `platforms: ["rust"]`, not `general`, which is exactly the call this section exists to get right. **"Landed the watch engine and here is what it cost" is a `record_work`.** Do both when both are true.
 
@@ -101,42 +101,15 @@ Before finishing work that changed or clarified a decision here, write it down. 
 
 ## Bias to building
 
-**The budgets have room and this section exists because that stopped being obvious.** The frame budget is 16ms and the tool runs at **2.4ms p50, 3.1ms p99**, which is five times the headroom. Refusing a feature on cost, in a tool with that much slack, needs the slack quoted alongside the cost or it is not an argument.
+**The default is build, and a refusal needs a reason that survives being checked.** `SPEC.md` §0 carries the rules for citing the record, and every reader passes it: a ruling is its reason plus a date, a reason naming an absence expires fastest, an invariant's own words have to reach the case, a budget arrives with its current headroom, and a reason that collapses reopens the question. Four rows of Phase 8 spent a session each on a decline, and one was reopened because both of its reasons were false. The frame path runs at **2.4ms p50** against a 16ms budget, so a cost cited without that headroom is a mood, not a measurement.
 
-### A cost measured in isolation is not a budget
+Three rules that are this file's rather than the spec's:
 
-**Measure the whole, not the part, and measure it before the cost is allowed to restrict anything.** A component timed on its own answers a question nobody asked. What decides whether something is affordable is the thing it sits inside, measured with and without it, interleaved, with both numbers quoted.
+- **Measure the whole, not the part, and before the cost restricts anything.** Two fixtures, the same workload with and without the thing being priced, interleaved so a loaded machine moves both. A zero from a clock is a quantum until timed across enough repetitions to clear it: `GetThreadTimes` steps at 15.625ms on Windows and read a 2.60ms burst as nothing. A cap is a feature restriction and needs the same bar as a refusal; measured in situ, a sizing cap read 17.93ms against 18.43ms unsized and was deleted.
+- **What ships is what was asked for and nothing narrower.** A bound taken from a neighbouring tool's default is that tool's decision, not a ruling here ([#272](https://github.com/breferrari/vigia/issues/272) imported `delta`'s wrap cap, and the reader had to say twice that he never asked for it). A limit nobody asked for is a refusal wearing a yes, and it is the harder kind to see.
+- **A session's own prior decision is a record of what was done, not permission withheld.** Name the reader's decisions; never cite a session's as a constraint on him.
 
-This rule exists because it was broken twice in one session, on the same 256-path burst, in opposite directions:
-
-- **Once on a wall clock.** 2.38ms p50 on a machine running four agents and a build. The feature was one edit from being capped at a quarter of its range on a number that was mostly contention.
-- **Once on a CPU clock that could not see it.** `GetThreadTimes` reports in 15.625ms steps on Windows, so the burst read **0ns** and that was taken as evidence the cost was off-CPU and therefore the host's. Timed across enough rounds to clear the quantum it is 2.60ms of genuine CPU, so the cap went back.
-
-Both readings were about the syscall alone. **Neither measured the frame the syscall sits in**, and that is the only number that decides anything. Measured properly, interleaved over thirty rounds of a hundred-file bulk rewrite, a frame costs **18.43ms sizing nothing, 17.39ms sizing sixty-four paths and 17.93ms sizing all 256**: the *unsized* run is the slowest of the three, because the status walk on the same wake has already stat'd every one of those files and the metadata is warm. The cost is unmeasurable in situ and the cap was deleted.
-
-So, before a number restricts a feature:
-
-- **A zero from a clock is a quantum until proven otherwise.** Time it across enough repetitions to clear the resolution, or you are reading the instrument rather than the code.
-- **Two fixtures, not one.** Same workload, with and without the thing being priced, interleaved so a loaded machine moves both. A single number has nothing to be compared against and will be compared against a budget instead.
-- **Quote the headroom and the whole**, not the component. "2.6ms against 16ms" is an argument about a syscall; "17.93ms against 18.43ms unsized" is an argument about the product.
-- **A cap is a feature restriction and needs the same bar as a refusal.** It draws a worse graph for the reader, permanently, on the strength of a number. Duplicated work that costs nothing measurable is an efficiency row to file, never a reason to ship less.
-
-**The tell is the shape of the work:** if the measurement's only possible use is to justify spending less, and the thing it protects has not been measured, the bias has already won.
-
-Four rows of Phase 8 spent a full session each and delivered a **decline**. One has since been reopened because *both* reasons it rested on were false: the first was an invariant whose budget could never have measured the case, and the second was an absence (*"the takeover does not enable focus reporting"*) that was one unwritten line rather than a fact about the world. Two other refusals in the same phase cited the same invariant and it did not reach either.
-
-So, when a reader asks for something:
-
-- **The default is build.** A refusal overrides the person whose product this is, so it needs a reason that survives being checked, not one that merely sounds sound.
-- **Before citing an invariant, quote the row's own words and show it reaches this case.** I1's budget is *0 wakeups while idle*; neither pointer motion nor a held button is idle. A budget cited without its current headroom is a mood, not a measurement.
-- **Check facts about the world against the world.** Read the dependency in `~/.cargo/registry`, and search the web. *"No API reports that"* is the claim most likely to be a year out of date, and it has been wrong here twice.
-- **A reason that collapses reopens the question.** It does not get replaced by a better reason for the same conclusion. That happened to [#123](https://github.com/breferrari/vigia/issues/123) and the decline outlived both of its bases.
-- **Reach a decline early or not at all.** The reason either holds under checking or it does not, and that is cheap. Hours spent after that point are spent justifying, and the tell is prose getting longer while the argument does not get stronger.
-- **Size the rigor to the surface, and do not escalate past it.** Look and feel is `/simplify` plus a screenshot; the audit loop is for the frame path and the invariants. `ROADMAP.md` has said so since Phase 8 opened and it was overridden anyway.
-- **A limit you were not asked for is a refusal wearing a yes.** Everything above covers *no*. It did not cover [#272](https://github.com/breferrari/vigia/issues/272): nobody declined to build wrapping, a session built it and imported `delta --wrap-max-lines`' default of two as a cap, and the reader had to say twice that he never asked for it. What ships is what was asked for and nothing narrower. A bound taken from a neighbouring tool's default is that tool's decision, not a ruling here.
-- **Never cite a session's own prior decision as a constraint on the reader.** Evidence, yes. Decisions he made, yes, and naming them is a service. A ruling a session wrote is a record of what was done, not permission withheld.
-
-Refusals deserve more scrutiny than builds, not less, and an unrequested limit deserves the most of all: a refusal is at least visible, while a feature delivered narrower than it was asked for leaves nothing to see.
+Size the rigor to the surface: look and feel is `/simplify` plus a screenshot, and the audit loop is for the frame path and the invariants.
 
 ## Rulings say who made them
 
@@ -179,7 +152,7 @@ Pick the level from the diff. On `0.x` a new feature **and** a breaking public A
 
 ## House rules
 
-- **No agent-session artifacts in anything that lands in the repo.** No `claude.ai/code/session_*` URL, no `Claude-Session:` trailer, no local absolute path — not in commit messages, PR or issue bodies, or files. `Co-Authored-By:` is fine and wanted.
+- **No agent-session artifacts in anything that lands in the repo.** No `claude.ai/code/session_*` URL, no `Claude-Session:` trailer, no local absolute path — not in commit messages, PR or issue bodies, or files. `Co-Authored-By:` is fine and wanted. `.claude/scripts/leak-guard.mjs` refuses a `gh` publish or a `git commit` carrying one, and `sh .claude/scripts/selftest.sh` exercises every guard offline.
 - **No em-dashes** in anything published under Brenno's name: README prose, release notes, issue and PR bodies, commit messages. Use a period, a comma, a colon, or parentheses.
 - Probe capability by behaviour, never by asking. A single green run is not evidence when the defect is non-deterministic.
 - Verify the whole artifact, not just the property you were fixing.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -332,7 +332,7 @@ Everything on the deferral shelf below has a milestone here, so shelved work is 
 | ⬜ | The take-order is derived from milestone titles, when the roadmap already holds it | [#108](https://github.com/breferrari/vigia/issues/108) |
 | ⬜ | A `core.autocrlf` or `.git/info/attributes` change is invisible to the cache guard | [#111](https://github.com/breferrari/vigia/issues/111) |
 | ✅ | A denied rustdoc lint that no job runs | [#131](https://github.com/breferrari/vigia/issues/131) |
-| ⬜ | `take-next` reads Copilot's line comments with the wrong login | [#132](https://github.com/breferrari/vigia/issues/132) |
+| ✅ | `take-next` reads Copilot's line comments with the wrong login | [#132](https://github.com/breferrari/vigia/issues/132) |
 | ⬜ | `MIN_TICKS` restates `MIN_FRAMES`, and the queue it looks like it guards is unbounded | [#114](https://github.com/breferrari/vigia/issues/114) |
 | ⬜ | 0.1.1: the crate carries no LICENSE, and Windows posture is still unstated | [#135](https://github.com/breferrari/vigia/issues/135) |
 | ⬜ | 0.1.1: trusted publishing, so the crates.io token stops existing | [#141](https://github.com/breferrari/vigia/issues/141) |
@@ -365,7 +365,7 @@ Everything on the deferral shelf below has a milestone here, so shelved work is 
 | ⬜ | The mutation harness is re-improvised every pass, and the same footgun has fired in four of them | [#299](https://github.com/breferrari/vigia/issues/299) |
 | ⬜ | A PR reached ready, mergeable and never checked, because the push and the ready raced | [#301](https://github.com/breferrari/vigia/issues/301) |
 | A draft PR shows a red `ci complete`, and a draft-era run can cancel the real one | #267, 2026-08-23 | Shelf, taken | Instrument work, and the same `cancel-in-progress` grouping #301 records from the other direction. Closed by [#274](https://github.com/breferrari/vigia/issues/274). |
-| ⬜ | take-next says a draft shows no checks, and this repo's draft shows a red one | [#293](https://github.com/breferrari/vigia/issues/293) |
+| ✅ | take-next says a draft shows no checks, and this repo's draft shows a red one | [#293](https://github.com/breferrari/vigia/issues/293) |
 | ✅ | The pre-flight read a truncated board and called it drift | [#369](https://github.com/breferrari/vigia/issues/369) |
 | ⬜ | The pre-flight's cheapest loop is its slowest | [#371](https://github.com/breferrari/vigia/issues/371) |
 | ⬜ | decision: a ledger and prose share a ceiling | [#374](https://github.com/breferrari/vigia/issues/374) |

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -1544,22 +1544,52 @@ fn the_ci_workflow_runs_the_script_the_gate_proves() {
     );
 }
 
+/// The release raises the version through the script the gate above proves.
+#[test]
+fn the_bump_workflow_runs_the_script_the_gate_proves() {
+    let bump = without_comments(&repo_file(".github/workflows/bump.yml"));
+    let step = step_block(&bump, "raise the version");
+    assert!(
+        step.contains("sh .github/scripts/raise-version.sh '${{ steps.version.outputs.next }}'"),
+        "bump.yml's raise step does not run raise-version.sh with the computed version, \
+         so the gate over the script proves nothing about the release: {step}"
+    );
+    // The gate that drives the script is Unix only, which is sound while the
+    // job that runs it stays on a Unix runner.
+    let runs_on = bump
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("runs-on:"))
+        .map(str::trim)
+        .expect("bump.yml declares a runner");
+    assert_eq!(
+        runs_on, "ubuntu-latest",
+        "the bump moved to {runs_on:?}, so the Unix-only gate over raise-version.sh \
+         no longer covers where it runs"
+    );
+}
+
 /// What each document is allowed to weigh, in bytes.
-const WRITTEN_LAYER_BUDGET: [(&str, usize); 4] = [
+///
+/// The two a session reads before anything else are in the table, because
+/// they sit in the same context window as the work: a rule stated three
+/// times in the skill costs the pass the room it needs to reason.
+const WRITTEN_LAYER_BUDGET: [(&str, usize); 6] = [
     ("SPEC.md", 387259),
     ("REVOCATIONS.md", 4393),
     ("ROADMAP.md", 95473),
     ("RULINGS.md", 94676),
+    ("CLAUDE.md", 17304),
+    (".claude/skills/take-next/SKILL.md", 25777),
 ];
 
-/// What the four together are allowed to weigh.
+/// What the documents together are allowed to weigh.
 ///
 /// A ceiling may rise only while another falls by at least as much. The per-file
 /// checks cannot see that trade; this exists to.
 ///
 /// A ledger row is the exception it cannot express: a withdrawal recorded or an
 /// issue reopened cannot be declined to fit, which is #374.
-const WRITTEN_LAYER_TOTAL: usize = 581801;
+const WRITTEN_LAYER_TOTAL: usize = 624882;
 
 /// Each document weighs no more than its budget.
 #[test]

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -1579,7 +1579,7 @@ const WRITTEN_LAYER_BUDGET: [(&str, usize); 6] = [
     ("ROADMAP.md", 95473),
     ("RULINGS.md", 94676),
     ("CLAUDE.md", 17304),
-    (".claude/skills/take-next/SKILL.md", 25777),
+    (".claude/skills/take-next/SKILL.md", 25813),
 ];
 
 /// What the documents together are allowed to weigh.
@@ -1589,7 +1589,7 @@ const WRITTEN_LAYER_BUDGET: [(&str, usize); 6] = [
 ///
 /// A ledger row is the exception it cannot express: a withdrawal recorded or an
 /// issue reopened cannot be declined to fit, which is #374.
-const WRITTEN_LAYER_TOTAL: usize = 624882;
+const WRITTEN_LAYER_TOTAL: usize = 624918;
 
 /// Each document weighs no more than its budget.
 #[test]


### PR DESCRIPTION
An evaluation of `take-next`, `CLAUDE.md` and the harness, as instructions handed to an Opus session with none of this conversation. The findings and every change they led to are in this PR.

## take-next

- **The skill is cut from 12,451 words to 4,431.** Each rule is stated once. The incidents behind them stay in git history and the vault. A pass loaded roughly 150k tokens of documents before opening its issue, and the skill applied its own "fit one fresh context" test to the work and never to its inputs.
- **Commands that had stopped being true are corrected.** The line-comment read-back filters on the login `Copilot`, which is what #382's two comments carry (#132). The draft warning describes what a draft shows today: one green `ci complete` that ran nothing (#293). Step 7 watches the run object and checks its head SHA against the PR's, because `gh pr checks --watch` has returned before the matrix started (#301). The Copilot wait has a fifteen-minute exit condition, since quota has run out before and a wait with no exit is a pass that never ends.
- **The report names the release.** Latest tag and how many merged PRs sit after it. Three PRs of `y` and drag-select work sat 22 commits behind v0.31.1 while the reader believed they had shipped.
- **A wrong command in the skill is fixed in the pass that finds it.** The shelf rule for instrument work kept #132 and #293 open for three weeks as known-wrong instructions.
- **Review agents run on Sonnet**, and the reviewer personas carry the pin in their frontmatter. The worktree bullet says how to reset `vigia.a` and `vigia.b`.
- **`next.sh` holds the step 1 query.** The skill, the pre-flight and the self-test all call it, and the needle that asserted three copies agreed is gone. The self-test gains a `--ranked` case.

## Harness

- **Three rules that were prose are hooks.** `scan-guard.mjs` refuses a `find` rooted at `/`. `leak-guard.mjs` now covers `git commit` and drops the body-file path from the inline scan, so a scratch path under the profile no longer blocks a clean body. `record-guard.mjs` is a Stop hook that refuses, once per session, to end a session whose merged pass has no vault note naming its issue. `decision-authority.mjs`'s own header is the evidence for doing it this way: the prose was correct, in context, and quoted back while being breached.
- **`.claude/scripts/selftest.sh`** drives all three guards offline with fabricated tool calls, 23 cases, including the fail-open paths.
- **`CLAUDE.md`'s Bias to building** keeps the three rules `SPEC.md` §0 does not carry and points there for the rest. The `find /` and vault-write paragraphs point at the guard and the bug.
- **The written-layer ratchet covers `CLAUDE.md` and `SKILL.md`** at their current sizes, with the total raised by exactly that, so neither can grow again without something else shrinking.
- **`bump.yml`'s raise step is gated** to call `raise-version.sh` with the computed version, which #383 left unasserted.

## Verification

- `sh .claude/skills/take-next/selftest.sh`: 24 checks pass. `sh .claude/scripts/selftest.sh`: 23 checks pass, after a harness fix where Node could not open MSYS paths and every guard failed open as designed.
- `sh .claude/skills/take-next/preflight.sh` against the live tracker: clean in 20 seconds. `next.sh` returns Phase 8 with 7 open issues.
- `cargo test -p vigia --test package --test register` under `-D warnings`: green, including the prose-wrap gate over the rewritten skill and the written-layer gate at the new ceilings. `cargo clippy` on the package tests is clean.
- Scope: `.claude/scripts`, `settings.json` and `package.rs` are code, so the suites ran.

Closes #132. Closes #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
