### PR TITLE
tinyvec 1.13.0 does not compile, and a fresh resolve takes it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2543,6 +2543,7 @@ dependencies = [
  "libc",
  "notify",
  "syntect",
+ "tinyvec",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,14 @@ gix = { version = "0.87", default-features = false, features = [
     "max-performance-safe",
     "sha1",
 ] }
+# Not used here, and declared only to bound a version. `tinyvec 1.13.0` does not
+# compile at all: it imports `alloc::vec` as a module, which shadows the `vec!`
+# macro it then calls, and the crate is `alloc`-only so no feature avoids it.
+# `unicode-normalization` asks for `^1` under `gix-utils`, so a fresh resolve
+# takes the broken one and `cargo install vigia` fails while CI, which builds
+# through the committed lock, cannot see it. That is #349's shape exactly.
+# Lift this the moment a fixed release exists; the bound blocks 1.13.1 too.
+tinyvec = ">=1.12, <1.13"
 # Native filesystem events, which I1 requires instead of a timer. The
 # companion debouncer crate is deliberately not taken: coalesce policy lives in
 # vigia-core, which is the only place I1 is testable.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -231,6 +231,7 @@ Milestone: [Phase 8](https://github.com/breferrari/vigia/milestone/8)
 | ⬜ | research: price animation on an arriving change | [#365](https://github.com/breferrari/vigia/issues/365) |
 | ⬜ | watch.rs evicts an arbitrary path from a HashSet | [#368](https://github.com/breferrari/vigia/issues/368) |
 | ✅ | `cargo install vigia` fails on a yanked `bisync` pinned through gix 0.86 | [#349](https://github.com/breferrari/vigia/issues/349) |
+| ✅ | `cargo install vigia` fails: tinyvec 1.13.0 does not compile and a fresh resolve takes it | [#396](https://github.com/breferrari/vigia/issues/396) |
 | ✅ | A long line cannot be read to its end, and the ruling against wrapping was made without a toggle in it | [#272](https://github.com/breferrari/vigia/issues/272) |
 | ✅ | The pulse leaves the last edited file after a second, and it used to stay | [#345](https://github.com/breferrari/vigia/issues/345) |
 | ✅ | The pointer's mark is the loudest weight in the list, and the file the diff is inside has none | [#193](https://github.com/breferrari/vigia/issues/193) |

--- a/crates/vigia-core/Cargo.toml
+++ b/crates/vigia-core/Cargo.toml
@@ -25,6 +25,8 @@ categories = ["development-tools"]
 
 [dependencies]
 gix.workspace = true
+# Declared for its version bound alone; see the workspace manifest.
+tinyvec.workspace = true
 notify.workspace = true
 syntect.workspace = true
 

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -1576,7 +1576,7 @@ fn the_bump_workflow_runs_the_script_the_gate_proves() {
 const WRITTEN_LAYER_BUDGET: [(&str, usize); 6] = [
     ("SPEC.md", 387297),
     ("REVOCATIONS.md", 6558),
-    ("ROADMAP.md", 94417),
+    ("ROADMAP.md", 94574),
     ("RULINGS.md", 94676),
     ("CLAUDE.md", 17304),
     (".claude/skills/take-next/SKILL.md", 25813),
@@ -1589,7 +1589,7 @@ const WRITTEN_LAYER_BUDGET: [(&str, usize); 6] = [
 ///
 /// A ledger row is the exception it cannot express: a withdrawal recorded or an
 /// issue reopened cannot be declined to fit, which is #374.
-const WRITTEN_LAYER_TOTAL: usize = 626065;
+const WRITTEN_LAYER_TOTAL: usize = 626222;
 
 /// Each document weighs no more than its budget.
 #[test]


### PR DESCRIPTION
Closes #396.

`cargo install vigia` fails on v0.33.0. `tinyvec 1.13.0` was published today, is not yanked, and does not compile: it imports `alloc::vec` as a module, shadowing the `vec!` macro it then calls. The crate is `alloc`-only with no `std` feature, so no feature combination avoids it, and every dependent that turns `alloc` on gets a crate that will not build.

It reaches us through `gix-utils` -> `unicode-normalization`, which asks for `tinyvec = "1"`. On `^1` the resolver takes the newest.

CI could not see it. CI and `cargo publish` resolve through the committed lock, which pins 1.12.0. `cargo install` resolves fresh unless given `--locked`, and says so: `Locking 231 packages to latest compatible versions`. That is #349's shape exactly, and the failure is reachable only by the command README.md tells a reader to run.

#349 was fixed by bumping a direct dependency past the broken transitive. Not available here: no range this workspace controls reaches `tinyvec`. So the workspace declares it for its version bound alone, intersecting `^1` down to a release that compiles. It adds no crate to the graph.

**Proven the way `cargo install` behaves, not through the lock**: with `Cargo.lock` deleted outright and the workspace re-resolved from nothing, the resolver selects `tinyvec 1.12.0`. The committed lock moves by one line, the new edge, and the version it pins is unchanged.

The bound blocks the fix as well as the break, since `<1.13` excludes 1.13.1. Lifting it is #397.

**One ceiling was raised rather than funded.** The roadmap row costs 157 bytes; all six written-layer documents already sat at their exact ceilings and the cross-file total had no slack, so a ledger row had nowhere to come from. That is the case the budget's own docblock names and #374 tracks. Raised by exactly 157, visibly, rather than by deleting prose that is still true.

Verification: 1139 tests pass across 51 targets, clippy clean under `RUSTFLAGS=-D warnings`, fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
