### PR TITLE
The written layer catches up with #365

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ Same shape as the theme file: one key per line, `#` for a comment, and a key it 
 | [gix](https://github.com/GitoxideLabs/gitoxide) | Pure Rust git. Diffs in process, no subprocess per change |
 | [notify](https://github.com/notify-rs/notify) | Native filesystem events, which is what "no polling timer" requires |
 | [syntect](https://github.com/trishume/syntect) | Syntax highlighting, pure Rust, so no C toolchain in CI |
+| [tachyonfx](https://github.com/ratatui/tachyonfx) | Effects over the drawn buffer, so a change can be seen arriving. It schedules nothing, which is what keeps "no polling timer" this program's own rule to keep |
 | [two-face](https://codeberg.org/CosmicHarper/two-face) | The grammars: [bat](https://github.com/sharkdp/bat)'s curated set, packaged for `syntect`. It builds the dump the binary carries and is itself absent from every shipped graph |
 
 Everything is pure Rust on purpose: a genuinely static Linux binary needs no cross toolchain, and macOS and Windows are plain tier-1 targets.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -228,7 +228,7 @@ Milestone: [Phase 8](https://github.com/breferrari/vigia/milestone/8)
 | ✅ | The masthead graph draws a flat track and one spike, and the spike does not sit in the band | [#348](https://github.com/breferrari/vigia/issues/348) |
 | ⬜ | decision: a bulk write marks every row with the pulse, so the mark says nothing on the shape an agent produces | [#362](https://github.com/breferrari/vigia/issues/362) |
 | ✅ | Turning wrap off measures a page step in the pane's height, so it walks over unseen lines. **Reported from use** | [#364](https://github.com/breferrari/vigia/issues/364) |
-| ⬜ | research: price animation on an arriving change | [#365](https://github.com/breferrari/vigia/issues/365) |
+| ✅ | a change arriving coalesces into place | [#365](https://github.com/breferrari/vigia/issues/365) |
 | ⬜ | watch.rs evicts an arbitrary path from a HashSet | [#368](https://github.com/breferrari/vigia/issues/368) |
 | ✅ | `cargo install vigia` fails on a yanked `bisync` pinned through gix 0.86 | [#349](https://github.com/breferrari/vigia/issues/349) |
 | ✅ | `cargo install vigia` fails: tinyvec 1.13.0 does not compile and a fresh resolve takes it | [#396](https://github.com/breferrari/vigia/issues/396) |

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -1576,7 +1576,7 @@ fn the_bump_workflow_runs_the_script_the_gate_proves() {
 const WRITTEN_LAYER_BUDGET: [(&str, usize); 6] = [
     ("SPEC.md", 388803),
     ("REVOCATIONS.md", 6558),
-    ("ROADMAP.md", 94574),
+    ("ROADMAP.md", 94565),
     ("RULINGS.md", 94676),
     ("CLAUDE.md", 17304),
     (".claude/skills/take-next/SKILL.md", 25813),
@@ -1589,7 +1589,7 @@ const WRITTEN_LAYER_BUDGET: [(&str, usize); 6] = [
 ///
 /// A ledger row is the exception it cannot express: a withdrawal recorded or an
 /// issue reopened cannot be declined to fit, which is #374.
-const WRITTEN_LAYER_TOTAL: usize = 627728;
+const WRITTEN_LAYER_TOTAL: usize = 627719;
 
 /// Each document weighs no more than its budget.
 #[test]


### PR DESCRIPTION
Two things went stale the moment #395 merged, and neither had a gate behind it.

**The roadmap row** was marked `⬜` and described the research rather than the result — drift of exactly the kind pre-flight comparison 3 exists to catch: a row not marked done whose issue is closed. What shipped is an effect, not a price, so the row says so.

**README's `Built with` table did not name `tachyonfx`.** That table is a curated set rather than every direct dependency — it names neither `rustix` nor the two platform FFI crates — so what belongs in it is a building block. `tachyonfx` is one. `tinyvec` is not, and stays out: it buys nothing, adds nothing to the graph, and exists only to bound a version, which is why `SPEC.md` §6 names it and this table does not.

**Nothing couples a manifest to the documents that describe it**, so both were invisible to CI, to the byte ceilings and to review. That is two instances in one day — the other being §6 not naming `tinyvec`, fixed in #399 — and it is worth a gate that neither PR builds.

The `ROADMAP.md` ceiling **falls** by nine bytes to the file's real size, since the new row is shorter than the one it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
