### PR TITLE
#401 takes the front of Phase 8

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -166,6 +166,7 @@ Milestone: [Phase 8](https://github.com/breferrari/vigia/milestone/8)
 
 | | Task | Issue |
 |---|---|---|
+| ⬜ | Tell the reader when a newer version exists, checked once at startup. **Ruled by the author** | [#401](https://github.com/breferrari/vigia/issues/401) |
 | ✅ | The drag's wash outlives the gesture, and sending it needs a second key. **Reported from use** | [#386](https://github.com/breferrari/vigia/issues/386) |
 | ✅ | A nested git repository in the work tree stops the pane from ever advancing again. **Reported from use** | [#378](https://github.com/breferrari/vigia/issues/378) |
 | ✅ | Nothing shows staged files, so an agent that stages its own work empties the pane | [#313](https://github.com/breferrari/vigia/issues/313) |

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -1576,7 +1576,7 @@ fn the_bump_workflow_runs_the_script_the_gate_proves() {
 const WRITTEN_LAYER_BUDGET: [(&str, usize); 6] = [
     ("SPEC.md", 388803),
     ("REVOCATIONS.md", 6558),
-    ("ROADMAP.md", 94565),
+    ("ROADMAP.md", 94726),
     ("RULINGS.md", 94676),
     ("CLAUDE.md", 17304),
     (".claude/skills/take-next/SKILL.md", 25813),
@@ -1589,7 +1589,7 @@ const WRITTEN_LAYER_BUDGET: [(&str, usize); 6] = [
 ///
 /// A ledger row is the exception it cannot express: a withdrawal recorded or an
 /// issue reopened cannot be declined to fit, which is #374.
-const WRITTEN_LAYER_TOTAL: usize = 627719;
+const WRITTEN_LAYER_TOTAL: usize = 627880;
 
 /// Each document weighs no more than its budget.
 #[test]


### PR DESCRIPTION
An update notice is the next thing to build, ruled by the author in #401, so its row sits at the top of Phase 8.

`take-next` step 1 takes the topmost unstarted task in the eligible phase, and `next.sh` now returns #401 first.

The ceiling rises by the row's own size. Every written-layer document sits at its own size and the total has no slack, so a filed issue has nowhere to come from — the case the budget's docblock names and #374 tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
