### PR TITLE
ROADMAP.md marks #405 done

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -166,7 +166,7 @@ Milestone: [Phase 8](https://github.com/breferrari/vigia/milestone/8)
 
 | | Task | Issue |
 |---|---|---|
-| ⬜ | The footer says everything in one red, and no notice arrives. **Reported from use** | [#405](https://github.com/breferrari/vigia/issues/405) |
+| ✅ | The footer says everything in one red, and no notice arrives. **Reported from use** | [#405](https://github.com/breferrari/vigia/issues/405) |
 | ✅ | Tell the reader when a newer version exists, checked once at startup. **Ruled by the author** | [#401](https://github.com/breferrari/vigia/issues/401) |
 | ⬜ | Nothing checks a direct dependency is named in the documents that describe it | [#403](https://github.com/breferrari/vigia/issues/403) |
 | ✅ | The drag's wash outlives the gesture, and sending it needs a second key. **Reported from use** | [#386](https://github.com/breferrari/vigia/issues/386) |


### PR DESCRIPTION
The footer's three voices merged as f42be27, and the row still said otherwise. Byte-neutral: a mark, not a row.

Docs-only, so no code gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)