### PR TITLE
Every voice moves on the glyph channel, and moves for long enough to see

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -166,6 +166,7 @@ Milestone: [Phase 8](https://github.com/breferrari/vigia/milestone/8)
 
 | | Task | Issue |
 |---|---|---|
+| ✅ | The footer's motions are on the channel that degrades, and too short to see. **Reported from use** | [#408](https://github.com/breferrari/vigia/issues/408) |
 | ✅ | The footer says everything in one red, and no notice arrives. **Reported from use** | [#405](https://github.com/breferrari/vigia/issues/405) |
 | ✅ | Tell the reader when a newer version exists, checked once at startup. **Ruled by the author** | [#401](https://github.com/breferrari/vigia/issues/401) |
 | ⬜ | Nothing checks a direct dependency is named in the documents that describe it | [#403](https://github.com/breferrari/vigia/issues/403) |

--- a/SPEC.md
+++ b/SPEC.md
@@ -932,11 +932,15 @@ The **hint bar is a list**, so when the footer cannot hold both halves on one li
 
 | Voice | What it is | Colour | Arrives | Leaves |
 |---|---|---|---|---|
-| Said | An act of the reader's, answering | `chrome` | swept left to right out of the hints it replaced, 120ms | swept back out |
-| Arrived | Unasked-for, nothing wrong | `note` | coalesces, 250ms | dissolves |
-| Alert | Something went wrong | `alert` | lightened and back inside its own hue, 180ms | fades to the hints' colour |
+| Said | An act of the reader's, answering | `chrome` | its characters appear left to right, 320ms | the same, reversed |
+| Arrived | Unasked-for, nothing wrong | `note` | its characters appear out of scatter, 420ms | dissolves to scatter |
+| Alert | Something went wrong | `alert` | its characters appear from both ends, closing, 360ms | opens back out |
 
-Three colours the palette already had: `note` is what this program spends on something that is not diff content, and an announcement is that. A warning is the arrival that does not move, because it must not be harder to read while arriving, and it lightens within its own hue rather than fading in from another, which would slide it through a meaning it does not have. **A spent message is still drawn while it leaves**: cleared first, its departure lands on the hints underneath and animates them arriving instead.
+Three colours the palette already had: `note` is what this program spends on something that is not diff content, and an announcement is that.
+
+**Every motion is on the glyph channel, and that is a requirement rather than a taste.** §5 puts glyphs as what survives when colour does not, and an effect that interpolates colour writes styles *after* `Theme::resolve` has quantised the palette to the depth: at `Ansi16` it asks for colours the terminal cannot draw, and at `Depth::None` it shows `NO_COLOR` the one thing it was promised. Two of the three were built on colour and reported from the pane as barely visible, which is that defect from the other end. So they differ by **pattern** over one mechanism, at 14, 20 and 15 changed frames against 6, 12 and 11.
+
+**A spent message is still drawn while it leaves**: cleared first, its departure lands on the hints underneath and animates them arriving instead.
 
 **A newer published version is one footer notice, once, and nothing else.** *Ruled 2026-09-04, reader* ([#401](https://github.com/breferrari/vigia/issues/401)). One request at startup, on a thread, so first paint never waits on it, and one `NOTICE_LINGER` notice naming the version when crates.io answers with a higher one. Already current, offline, refused, slow, unparseable, and an architecture the TLS provider will not compile on are one outcome between them: **silence**, because a network problem is not the reader's problem and a monitor that nags is a monitor that gets closed. It arms no clock of its own, which is what keeps I1 whole: the check answers once and cannot repeat, and the deadline the notice sets is the one every notice already sets. `VIGIA_UPDATE=off` declines it, and a value this does not understand is refused before the terminal is taken rather than quietly ignored.
 

--- a/crates/vigia/src/lib.rs
+++ b/crates/vigia/src/lib.rs
@@ -531,7 +531,7 @@ fn weigh(workdir: &Path, path: &str) -> Option<u64> {
 /// How long a change is drawn arriving. Under `HISTORY_SAMPLE`; see `SPEC.md` §5.1.
 pub const ARRIVING: std::time::Duration = std::time::Duration::from_millis(250);
 
-/// How long a receipt for the reader's own act takes. Shortest of the three.
+/// A receipt's arrival, shortest of the three.
 pub const SAID_ARRIVING: std::time::Duration = std::time::Duration::from_millis(320);
 
 /// How long an announcement takes. Its own rather than [`ARRIVING`], which is
@@ -551,8 +551,8 @@ pub const SCROLL_LINGER: std::time::Duration = std::time::Duration::from_millis(
 pub const NOTICE_LINGER: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// How each voice arrives: one mechanism, three patterns, all revealing the
-/// message's own characters. §5 puts the glyph channel as what survives when
-/// colour does not; which pattern means what is §11.1.
+/// message's own characters, because §5 puts glyphs as what survives when colour
+/// does not. Which pattern means what is §11.1.
 #[doc(hidden)]
 pub fn arrival(voice: Voice) -> tachyonfx::Effect {
     let timer = (
@@ -572,11 +572,12 @@ pub fn arrival(voice: Voice) -> tachyonfx::Effect {
 /// Cells the sweep's edge is soft over: a wipe rather than a bar.
 const SWEEP_GRADIENT: u16 = 10;
 
-/// Cells the alert's edge is soft over as it closes in.
+/// Cells the alert's edge is soft over.
 const ALERT_SPREAD: f32 = 8.0;
 
-/// How each voice leaves: its arrival, reversed. The message stays drawn while
-/// it runs, or the effect lands on the hints and animates those instead.
+/// How each voice leaves: its arrival reversed, which is the **same** pattern
+/// with `dissolve`, not the mirrored one, since it removes in the order coalesce
+/// added. The message stays drawn throughout, or this lands on the hints.
 #[doc(hidden)]
 pub fn departure(voice: Voice) -> tachyonfx::Effect {
     let timer = (
@@ -602,7 +603,6 @@ const fn duration_for(voice: Voice) -> std::time::Duration {
     }
 }
 
-/// The one key the footer's manager needs, since one notice is on screen at a time.
 const NOTICE_KEY: &str = "notice";
 
 /// Wakes taken in one go, so one gesture costs one paint.
@@ -626,8 +626,8 @@ struct Shell {
     app: App,
     /// Keyed by path, so a second write replaces an effect rather than stacking.
     effects: EffectManager<String>,
-    /// The footer's own: the diff's are clipped to the diff, and one manager
-    /// processed twice would advance every effect in it twice a frame.
+    /// The footer's own: the diff's are clipped to it, and one manager processed
+    /// twice advances every effect in it twice a frame.
     notice_effects: EffectManager<String>,
     /// When the previous frame painted: the elapsed time an effect is told about.
     painted: Instant,

--- a/crates/vigia/src/lib.rs
+++ b/crates/vigia/src/lib.rs
@@ -53,6 +53,7 @@ use std::time::Instant;
 
 use ratatui::crossterm::event::{Event, MouseButton, MouseEventKind};
 use ratatui::layout::Rect;
+use tachyonfx::pattern::{RadialPattern, SweepPattern};
 use tachyonfx::{EffectManager, Interpolation, fx};
 use vigia_core::{Highlighter, History, WatchOptions, Worktree};
 
@@ -530,12 +531,15 @@ fn weigh(workdir: &Path, path: &str) -> Option<u64> {
 /// How long a change is drawn arriving. Under `HISTORY_SAMPLE`; see `SPEC.md` §5.1.
 pub const ARRIVING: std::time::Duration = std::time::Duration::from_millis(250);
 
-/// How long a receipt for the reader's own act takes to land. Shortest of the
-/// three: §5.3 gives an act one frame, and this is the least an arrival can be.
-pub const SAID_ARRIVING: std::time::Duration = std::time::Duration::from_millis(120);
+/// How long a receipt for the reader's own act takes. Shortest of the three.
+pub const SAID_ARRIVING: std::time::Duration = std::time::Duration::from_millis(320);
 
-/// How long a warning takes to settle into the red it keeps.
-pub const ALERT_ARRIVING: std::time::Duration = std::time::Duration::from_millis(180);
+/// How long an announcement takes. Its own rather than [`ARRIVING`], which is
+/// the diff's and is not read the same way.
+pub const NOTICE_ARRIVING: std::time::Duration = std::time::Duration::from_millis(420);
+
+/// How long a warning takes to gather.
+pub const ALERT_ARRIVING: std::time::Duration = std::time::Duration::from_millis(360);
 
 /// How often a running effect asks for a frame. The whole price of the effect.
 pub const ARRIVING_FRAME: std::time::Duration = std::time::Duration::from_millis(16);
@@ -546,76 +550,54 @@ pub const SCROLL_LINGER: std::time::Duration = std::time::Duration::from_millis(
 /// How long the footer says what a gesture sent. One-shot, so an idle pane owns no timer.
 pub const NOTICE_LINGER: std::time::Duration = std::time::Duration::from_secs(3);
 
-/// How each voice arrives. Which motion means what is `SPEC.md` §11.1; what is
-/// here is that a warning is the one that does not move, because it must not be
-/// harder to read while it arrives.
-fn arrival(voice: Voice, theme: &Theme) -> tachyonfx::Effect {
+/// How each voice arrives: one mechanism, three patterns, all revealing the
+/// message's own characters. §5 puts the glyph channel as what survives when
+/// colour does not; which pattern means what is §11.1.
+#[doc(hidden)]
+pub fn arrival(voice: Voice) -> tachyonfx::Effect {
+    let timer = (
+        tachyonfx::Duration::from(duration_for(voice)),
+        Interpolation::QuadOut,
+    );
     match voice {
-        Voice::Said => fx::sweep_in(
-            tachyonfx::Motion::LeftToRight,
-            SWEEP_GRADIENT,
-            0,
-            theme.chrome_dim.fg.unwrap_or(ratatui::style::Color::Reset),
-            (
-                tachyonfx::Duration::from(duration_for(voice)),
-                Interpolation::QuadOut,
-            ),
-        ),
-        Voice::Arrived => {
-            fx::coalesce((tachyonfx::Duration::from(ARRIVING), Interpolation::QuadOut))
+        Voice::Said => {
+            fx::coalesce(timer).with_pattern(SweepPattern::right_to_left(SWEEP_GRADIENT))
         }
-        // Out of the hints it replaced, like the sweep above, but without
-        // moving: a warning must not be harder to read while it arrives. It
-        // fades *to* what was drawn, so it settles exactly there and stops,
-        // which a shift away and back does neither of.
-        Voice::Alert => fx::fade_from_fg(
-            theme.chrome_dim.fg.unwrap_or(ratatui::style::Color::Reset),
-            (
-                tachyonfx::Duration::from(duration_for(voice)),
-                Interpolation::QuadOut,
-            ),
-        ),
+        Voice::Arrived => fx::coalesce(timer),
+        Voice::Alert => fx::coalesce(timer)
+            .with_pattern(RadialPattern::center().with_transition_width(ALERT_SPREAD)),
     }
 }
 
 /// Cells the sweep's edge is soft over: a wipe rather than a bar.
-const SWEEP_GRADIENT: u16 = 8;
+const SWEEP_GRADIENT: u16 = 10;
 
-/// How each voice leaves: its arrival, reversed.
-///
-/// The message is still drawn while this runs, which is the whole reason it
-/// reads as leaving. Cleared first, the effect would land on the hints
-/// underneath and animate them arriving instead.
-fn departure(voice: Voice, theme: &Theme) -> tachyonfx::Effect {
+/// Cells the alert's edge is soft over as it closes in.
+const ALERT_SPREAD: f32 = 8.0;
+
+/// How each voice leaves: its arrival, reversed. The message stays drawn while
+/// it runs, or the effect lands on the hints and animates those instead.
+#[doc(hidden)]
+pub fn departure(voice: Voice) -> tachyonfx::Effect {
+    let timer = (
+        tachyonfx::Duration::from(duration_for(voice)),
+        Interpolation::QuadIn,
+    );
     match voice {
-        Voice::Said => fx::sweep_out(
-            tachyonfx::Motion::LeftToRight,
-            SWEEP_GRADIENT,
-            0,
-            theme.chrome_dim.fg.unwrap_or(ratatui::style::Color::Reset),
-            (
-                tachyonfx::Duration::from(duration_for(voice)),
-                Interpolation::QuadIn,
-            ),
-        ),
-        Voice::Arrived => {
-            fx::dissolve((tachyonfx::Duration::from(ARRIVING), Interpolation::QuadIn))
+        Voice::Said => {
+            fx::dissolve(timer).with_pattern(SweepPattern::right_to_left(SWEEP_GRADIENT))
         }
-        Voice::Alert => fx::fade_to_fg(
-            theme.chrome_dim.fg.unwrap_or(ratatui::style::Color::Reset),
-            (
-                tachyonfx::Duration::from(duration_for(voice)),
-                Interpolation::QuadIn,
-            ),
-        ),
+        Voice::Arrived => fx::dissolve(timer),
+        Voice::Alert => fx::dissolve(timer)
+            .with_pattern(RadialPattern::center().with_transition_width(ALERT_SPREAD)),
     }
 }
 
-/// How long a voice takes, arriving or leaving. One table: three copies drift.
+/// How long a voice takes, arriving or leaving. One table: copies drift.
 const fn duration_for(voice: Voice) -> std::time::Duration {
     match voice {
         Voice::Said => SAID_ARRIVING,
-        Voice::Arrived => ARRIVING,
+        Voice::Arrived => NOTICE_ARRIVING,
         Voice::Alert => ALERT_ARRIVING,
     }
 }
@@ -644,8 +626,8 @@ struct Shell {
     app: App,
     /// Keyed by path, so a second write replaces an effect rather than stacking.
     effects: EffectManager<String>,
-    /// The footer's own, because the diff's are clipped to the diff and a second
-    /// pass over one manager would advance every effect in it twice per frame.
+    /// The footer's own: the diff's are clipped to the diff, and one manager
+    /// processed twice would advance every effect in it twice a frame.
     notice_effects: EffectManager<String>,
     /// When the previous frame painted: the elapsed time an effect is told about.
     painted: Instant,
@@ -889,7 +871,7 @@ impl Shell {
         }
         if let Some(voice) = self.app.voice() {
             self.notice_effects
-                .add_unique_effect(NOTICE_KEY.to_owned(), departure(voice, &self.theme));
+                .add_unique_effect(NOTICE_KEY.to_owned(), departure(voice));
             self.leaving = Some(now + duration_for(voice));
         }
     }
@@ -901,7 +883,7 @@ impl Shell {
         self.leaving = None;
         self.app.flash(message, now + NOTICE_LINGER, voice);
         self.notice_effects
-            .add_unique_effect(NOTICE_KEY.to_owned(), arrival(voice, &self.theme));
+            .add_unique_effect(NOTICE_KEY.to_owned(), arrival(voice));
     }
 
     /// The drawable area of the terminal right now.

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -1576,7 +1576,7 @@ fn the_bump_workflow_runs_the_script_the_gate_proves() {
 const WRITTEN_LAYER_BUDGET: [(&str, usize); 6] = [
     ("SPEC.md", 389911),
     ("REVOCATIONS.md", 6560),
-    ("ROADMAP.md", 95585),
+    ("ROADMAP.md", 95751),
     ("RULINGS.md", 94676),
     ("CLAUDE.md", 17304),
     (".claude/skills/take-next/SKILL.md", 25813),
@@ -1635,7 +1635,7 @@ fn the_cpu_guard_still_mirrors_the_release_it_was_read_from() {
 ///
 /// A ledger row is the exception it cannot express: a withdrawal recorded or an
 /// issue reopened cannot be declined to fit, which is #374.
-const WRITTEN_LAYER_TOTAL: usize = 629849;
+const WRITTEN_LAYER_TOTAL: usize = 630015;
 
 /// Each document weighs no more than its budget.
 #[test]

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -1574,7 +1574,7 @@ fn the_bump_workflow_runs_the_script_the_gate_proves() {
 /// they sit in the same context window as the work: a rule stated three
 /// times in the skill costs the pass the room it needs to reason.
 const WRITTEN_LAYER_BUDGET: [(&str, usize); 6] = [
-    ("SPEC.md", 389490),
+    ("SPEC.md", 389911),
     ("REVOCATIONS.md", 6560),
     ("ROADMAP.md", 95585),
     ("RULINGS.md", 94676),
@@ -1635,7 +1635,7 @@ fn the_cpu_guard_still_mirrors_the_release_it_was_read_from() {
 ///
 /// A ledger row is the exception it cannot express: a withdrawal recorded or an
 /// issue reopened cannot be declined to fit, which is #374.
-const WRITTEN_LAYER_TOTAL: usize = 629428;
+const WRITTEN_LAYER_TOTAL: usize = 629849;
 
 /// Each document weighs no more than its budget.
 #[test]

--- a/crates/vigia/tests/voice.rs
+++ b/crates/vigia/tests/voice.rs
@@ -10,10 +10,10 @@ use std::time::Instant;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
-use tachyonfx::{Duration as FxDuration, EffectManager, Interpolation, Motion, fx};
+use tachyonfx::{Duration as FxDuration, EffectManager};
 use vigia::{
-    ALERT_ARRIVING, ARRIVING, ARRIVING_FRAME, App, Glyphs, NOTICE_LINGER, Pointing, SAID_ARRIVING,
-    Theme, View, Voice, notice_area, render,
+    ARRIVING_FRAME, App, Depth, Glyphs, NOTICE_ARRIVING, NOTICE_LINGER, Pointing, Theme, View,
+    Voice, arrival, departure, notice_area, render,
 };
 
 /// An ordinary pane.
@@ -143,7 +143,7 @@ fn every_voice_changes_the_cells_it_covers_as_it_arrives() {
         let area = area_of(&app);
         let mut buf = settled.clone();
         let mut effects: EffectManager<String> = EffectManager::default();
-        effects.add_unique_effect("notice".to_owned(), arrival_of(voice));
+        effects.add_unique_effect("notice".to_owned(), arrival(voice));
         effects.process_effects(FxDuration::from(ARRIVING_FRAME), &mut buf, area);
         assert_ne!(
             (symbols(&buf, area), styles(&buf, area)),
@@ -161,7 +161,7 @@ fn every_voice_arrives_differently() {
         let area = area_of(&app);
         let mut buf = settled.clone();
         let mut effects: EffectManager<String> = EffectManager::default();
-        effects.add_unique_effect("notice".to_owned(), arrival_of(voice));
+        effects.add_unique_effect("notice".to_owned(), arrival(voice));
         effects.process_effects(FxDuration::from(ARRIVING_FRAME), &mut buf, area);
         seen.push((symbols(&buf, area), styles(&buf, area)));
     }
@@ -185,8 +185,8 @@ fn a_settled_arrival_is_what_the_renderer_drew() {
         let area = area_of(&app);
         let mut buf = settled.clone();
         let mut effects: EffectManager<String> = EffectManager::default();
-        effects.add_unique_effect("notice".to_owned(), arrival_of(voice));
-        effects.process_effects(FxDuration::from(ARRIVING * 4), &mut buf, area);
+        effects.add_unique_effect("notice".to_owned(), arrival(voice));
+        effects.process_effects(FxDuration::from(NOTICE_ARRIVING * 4), &mut buf, area);
         assert_eq!(
             (symbols(&buf, area), styles(&buf, area)),
             (symbols(&settled, area), styles(&settled, area)),
@@ -278,6 +278,56 @@ fn a_long_message_stops_where_the_readouts_begin() {
     );
 }
 
+/// Every voice moves on the glyph channel, which is the one that survives when
+/// colour does not.
+///
+/// An effect that interpolates colour writes styles the theme was already
+/// resolved past, so at `Ansi16` it asks for colours the terminal cannot draw
+/// and at `Depth::None` it shows `NO_COLOR` the one thing it was promised it
+/// would not see. Two of these three were built that way and this is what
+/// caught it.
+#[test]
+fn no_voice_needs_colour_to_be_seen() {
+    for depth in [Depth::Truecolor, Depth::Ansi256, Depth::Ansi16, Depth::None] {
+        let theme = Theme::default().resolve(depth);
+        for voice in VOICES {
+            let mut app = App::new();
+            app.flash(
+                "sent 3 lines to the clipboard",
+                Instant::now() + NOTICE_LINGER,
+                voice,
+            );
+            let chrome = app.chrome("fixture", None, Pointing::default(), 0, "");
+            let mut settled = Buffer::empty(PANE);
+            render(
+                &mut settled,
+                PANE,
+                &View::default(),
+                &theme,
+                Glyphs::default(),
+                &chrome,
+            );
+            let area = notice_area(PANE, &chrome, &View::default()).expect("an area");
+
+            let mut buf = settled.clone();
+            let mut effects: EffectManager<String> = EffectManager::default();
+            effects.add_unique_effect("notice".to_owned(), arrival(voice));
+            effects.process_effects(FxDuration::from(ARRIVING_FRAME * 4), &mut buf, area);
+
+            assert_ne!(
+                symbols(&buf, area),
+                symbols(&settled, area),
+                "{voice:?} moved nothing at {depth:?}, so a reader there sees it appear whole"
+            );
+            assert_eq!(
+                styles(&buf, area),
+                styles(&settled, area),
+                "{voice:?} changed colour at {depth:?}, which the theme was already                  resolved past and which `NO_COLOR` was promised it would not see"
+            );
+        }
+    }
+}
+
 /// An effect that never reports itself finished pins the loop awake for the
 /// rest of the session, because `Shell::patience` asks for a frame while one is
 /// running. `ping_pong` was tried here and does exactly that: it repeats, so
@@ -288,10 +338,7 @@ fn a_long_message_stops_where_the_readouts_begin() {
 #[test]
 fn every_effect_finishes_and_stops_asking_for_frames() {
     for voice in VOICES {
-        for (what, effect) in [
-            ("arrival", arrival_of(voice)),
-            ("departure", departure_of(voice)),
-        ] {
+        for (what, effect) in [("arrival", arrival(voice)), ("departure", departure(voice))] {
             let (settled, app) = drawn(voice);
             let area = area_of(&app);
             let mut buf = settled.clone();
@@ -301,55 +348,11 @@ fn every_effect_finishes_and_stops_asking_for_frames() {
                 effects.is_running(),
                 "{voice:?}'s {what} was over before it began"
             );
-            effects.process_effects(FxDuration::from(ARRIVING * 4), &mut buf, area);
+            effects.process_effects(FxDuration::from(NOTICE_ARRIVING * 4), &mut buf, area);
             assert!(
                 !effects.is_running(),
                 "{voice:?}'s {what} still wants frames after four times its longest                  duration, so an idle pane never stops waking"
             );
         }
-    }
-}
-
-/// The departures, spelled here for `arrival_of`'s reason.
-fn departure_of(voice: Voice) -> tachyonfx::Effect {
-    let theme = Theme::default();
-    let dur = match voice {
-        Voice::Said => SAID_ARRIVING,
-        Voice::Arrived => ARRIVING,
-        Voice::Alert => ALERT_ARRIVING,
-    };
-    match voice {
-        Voice::Said => fx::sweep_out(
-            Motion::LeftToRight,
-            8,
-            0,
-            theme.chrome_dim.fg.unwrap_or(ratatui::style::Color::Reset),
-            (FxDuration::from(dur), Interpolation::QuadIn),
-        ),
-        Voice::Arrived => fx::dissolve((FxDuration::from(dur), Interpolation::QuadIn)),
-        Voice::Alert => fx::fade_to_fg(
-            theme.chrome_dim.fg.unwrap_or(ratatui::style::Color::Reset),
-            (FxDuration::from(dur), Interpolation::QuadIn),
-        ),
-    }
-}
-
-/// The arrivals, spelled here rather than reached for, so this suite fails when
-/// the shell's table changes rather than following it silently.
-fn arrival_of(voice: Voice) -> tachyonfx::Effect {
-    let theme = Theme::default();
-    match voice {
-        Voice::Said => fx::sweep_in(
-            Motion::LeftToRight,
-            8,
-            0,
-            theme.chrome_dim.fg.unwrap_or(ratatui::style::Color::Reset),
-            (FxDuration::from(SAID_ARRIVING), Interpolation::QuadOut),
-        ),
-        Voice::Arrived => fx::coalesce((FxDuration::from(ARRIVING), Interpolation::QuadOut)),
-        Voice::Alert => fx::fade_from_fg(
-            theme.chrome_dim.fg.unwrap_or(ratatui::style::Color::Reset),
-            (FxDuration::from(ALERT_ARRIVING), Interpolation::QuadOut),
-        ),
     }
 }

--- a/crates/vigia/tests/voice.rs
+++ b/crates/vigia/tests/voice.rs
@@ -190,7 +190,7 @@ fn a_settled_arrival_is_what_the_renderer_drew() {
         assert_eq!(
             (symbols(&buf, area), styles(&buf, area)),
             (symbols(&settled, area), styles(&settled, area)),
-            "{voice:?} finished somewhere other than the drawn line. A voice whose              arrival is motionless settles only in style, so comparing glyphs              alone cannot see it land on the wrong colour"
+            "{voice:?} finished somewhere other than the drawn line. A voice whose arrival is motionless settles only in style, so comparing glyphs alone cannot see it land on the wrong colour"
         );
     }
 }
@@ -273,7 +273,7 @@ fn a_long_message_stops_where_the_readouts_begin() {
 
     assert!(
         area.x + area.width <= readouts,
-        "the area runs to column {} and the readouts start at {readouts}, so the          effect animates them rather than the message",
+        "the area runs to column {} and the readouts start at {readouts}, so the effect animates them rather than the message",
         area.x + area.width
     );
 }
@@ -322,7 +322,7 @@ fn no_voice_needs_colour_to_be_seen() {
             assert_eq!(
                 styles(&buf, area),
                 styles(&settled, area),
-                "{voice:?} changed colour at {depth:?}, which the theme was already                  resolved past and which `NO_COLOR` was promised it would not see"
+                "{voice:?} changed colour at {depth:?}, which the theme was already resolved past and which `NO_COLOR` was promised it would not see"
             );
         }
     }
@@ -351,7 +351,7 @@ fn every_effect_finishes_and_stops_asking_for_frames() {
             effects.process_effects(FxDuration::from(NOTICE_ARRIVING * 4), &mut buf, area);
             assert!(
                 !effects.is_running(),
-                "{voice:?}'s {what} still wants frames after four times its longest                  duration, so an idle pane never stops waking"
+                "{voice:?}'s {what} still wants frames after four times its longest duration, so an idle pane never stops waking"
             );
         }
     }


### PR DESCRIPTION
Reported from the pane, 2026-09-04, on 0.35.0: *"the animation is so quick it almost is not visible if not visible at all."*

Measuring it found the duration was the smaller half.

## The motions were on the channel that degrades

Two of the three worked in **colour**. An effect that interpolates colour writes styles *after* `Theme::resolve` has quantised the palette to the terminal's depth, so:

- at `Ansi16` it asks for colours the terminal cannot draw,
- at `Depth::None` it puts colour in front of a reader who set `NO_COLOR`.

[#395](https://github.com/breferrari/vigia/issues/395) had already ruled on this from the other end. It chose `coalesce` precisely because a hand-rolled fade *"drew nothing at all"* at sixteen colours, and `SPEC.md` §5 puts the glyph channel as what survives when colour does not. Two of these three voices were built on the channel that ruling rejected.

Measured, changed frames out of twenty, before:

| | Truecolor | Ansi16 | None |
|---|---|---|---|
| Said (`sweep_in`) | 6 colour, 0 glyph | 6 colour, 0 glyph | 6 colour, 0 glyph |
| Arrived (`coalesce`) | 0 colour, 12 glyph | 0 colour, 11 glyph | 0 colour, 11 glyph |
| Alert (`fade_from_fg`) | 11 colour, 0 glyph | 11 colour, 0 glyph | 12 colour, 0 glyph |

The one that was reported as visible is the one on the glyph channel.

## And they were short

120ms is seven frames at 60fps, and the sweep's soft edge only touched six of them.

## What ships

One mechanism, three **patterns**, all revealing the message's own characters:

| Voice | Arrives | Leaves | Duration |
|---|---|---|---|
| Said | left to right, which reads as text being written | the same, reversed | 320ms |
| Arrived | out of scatter, the motion this repository already gives an unasked-for change | dissolves to scatter | 420ms |
| Alert | from both ends, closing on the middle | opens back out | 360ms |

The announcement gets its own constant rather than borrowing the diff's `ARRIVING`: a heading and a footer line are not read the same way, and they were only briefly the same number.

After: 14, 20 and 15 glyph-changed frames and **zero** colour-changed, identical across all four depths.

## Gates

- `no_voice_needs_colour_to_be_seen` walks `Truecolor`, `Ansi256`, `Ansi16` and `None` and demands glyphs move and styles do not. Putting a colour effect back makes it red.
- The suite stops mirroring the shell. `voice.rs` spelled its own copies of the effect tables with a comment claiming that made drift visible; it did not, and the tables had already diverged. `arrival` and `departure` are reached directly now, so there is nothing left to drift.

---

Closes #408.

## What it looks like

Rendered from the real buffer:

```
Said     + 48ms |sen  12 l                     |
         +192ms |sent 12 lines to the clipbo  d|
         +288ms |sent 12 lines to the clipboard|

Arrived  + 48ms | i       5             le|
         +192ms |vi ia 0.35.0 is av     le|
         +288ms |vig a 0.35.0 is availa le|

Alert    + 48ms |                               |
         +112ms |no  wa                     pped|
         +192ms |not watching: th    t h stopped|
         +288ms |not watching: the watch stopped|
```

## Scope of checks

Not docs-only. `crates/vigia/src/lib.rs`, `crates/vigia/tests/{voice,package}.rs`, `SPEC.md`, `ROADMAP.md`.

1179 tests pass in debug and release. `cargo clippy --all-targets` clean under `RUSTFLAGS=-D warnings`, and clean cross-linted for `aarch64-unknown-linux-gnu`, which is the arm no machine here compiles and which only the macOS leg would otherwise see.

## The written layer

`SPEC.md` §11.1 carries the table and the reason. It is **421 bytes over, raised visibly**, and the reason is worth recording: **§10's closed bullets are exhausted as funding.** Five have come out across three passes, and the four that remain each carry a measurement that exists nowhere else in the repository, so taking one would lose it. That is the second half of #374's question arriving from the prose side rather than the ledger side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
