### PR TITLE
A note anchors to a diff line and lives in a per-worktree store

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -166,7 +166,7 @@ Milestone: [Phase 7.5](https://github.com/breferrari/vigia/milestone/9)
 | ✅ | The thumb resizes when the reader scrolls into a file that changed off screen. **Reported from use** | [#412](https://github.com/breferrari/vigia/issues/412) |
 | ✅ | The height is recounted when a moved file settles, not at the next event | [#425](https://github.com/breferrari/vigia/issues/425) |
 | ✅ | decision: a note on a diff line reaches the agent over MCP | [#414](https://github.com/breferrari/vigia/issues/414) |
-| ⬜ | A note anchors to a diff line and lives in a per-worktree store | [#415](https://github.com/breferrari/vigia/issues/415) |
+| ✅ | A note anchors to a diff line and lives in a per-worktree store | [#415](https://github.com/breferrari/vigia/issues/415) |
 | ⬜ | The line number becomes the note icon under the pointer, and the note rows draw under the line | [#416](https://github.com/breferrari/vigia/issues/416) |
 | ⬜ | `vigia mcp` serves the notes to the agent over stdio | [#417](https://github.com/breferrari/vigia/issues/417) |
 | ⬜ | The pane wakes when the agent writes to the store | [#418](https://github.com/breferrari/vigia/issues/418) |

--- a/crates/vigia-core/src/error.rs
+++ b/crates/vigia-core/src/error.rs
@@ -133,7 +133,7 @@ impl fmt::Display for Error {
                 write!(f, "the notes store failed at {}: {source}", path.display())
             }
             Error::Canonicalise { path, source } => {
-                write!(f, "{} has no canonical path: {source}", path.display())
+                write!(f, "could not canonicalise {}: {source}", path.display())
             }
         }
     }

--- a/crates/vigia-core/src/error.rs
+++ b/crates/vigia-core/src/error.rs
@@ -97,7 +97,7 @@ impl Error {
         }
     }
 
-    /// The store failed at `path`.
+    /// The store could not be used at `path`.
     pub(crate) fn store(path: &std::path::Path, source: std::io::Error) -> Self {
         Error::Store {
             path: path.to_owned(),

--- a/crates/vigia-core/src/error.rs
+++ b/crates/vigia-core/src/error.rs
@@ -28,6 +28,20 @@ pub enum Error {
     },
     /// The filter configuration git would apply could not be assembled.
     FilterSetup(Box<dyn std::error::Error + Send + Sync>),
+    /// The notes store could not be created, written, read or pruned.
+    Store {
+        /// The path the operation was on.
+        path: std::path::PathBuf,
+        /// The underlying I/O failure.
+        source: std::io::Error,
+    },
+    /// A worktree path has no canonical form, which means it does not exist.
+    Canonicalise {
+        /// The path as given.
+        path: std::path::PathBuf,
+        /// The underlying I/O failure.
+        source: std::io::Error,
+    },
     /// One file could not be normalised the way git's clean filter would.
     Filter {
         /// Repository-relative path that could not be normalised.
@@ -58,7 +72,9 @@ impl Error {
             | Error::Bare
             | Error::Status(_)
             | Error::Watch(_)
-            | Error::FilterSetup(_) => None,
+            | Error::FilterSetup(_)
+            | Error::Store { .. }
+            | Error::Canonicalise { .. } => None,
         }
     }
 
@@ -78,6 +94,14 @@ impl Error {
         Error::Filter {
             path: path.to_owned(),
             source: Box::new(source),
+        }
+    }
+
+    /// The store failed at `path`.
+    pub(crate) fn store(path: &std::path::Path, source: std::io::Error) -> Self {
+        Error::Store {
+            path: path.to_owned(),
+            source,
         }
     }
 
@@ -105,6 +129,12 @@ impl fmt::Display for Error {
             Error::Filter { path, source } => {
                 write!(f, "could not normalise {path} the way git would: {source}")
             }
+            Error::Store { path, source } => {
+                write!(f, "the notes store failed at {}: {source}", path.display())
+            }
+            Error::Canonicalise { path, source } => {
+                write!(f, "{} has no canonical path: {source}", path.display())
+            }
         }
     }
 }
@@ -114,7 +144,9 @@ impl std::error::Error for Error {
         match self {
             Error::Discover(e) => Some(e),
             Error::Status(e) | Error::Watch(e) | Error::FilterSetup(e) => Some(e.as_ref()),
-            Error::Read { source, .. } => Some(source),
+            Error::Read { source, .. }
+            | Error::Store { source, .. }
+            | Error::Canonicalise { source, .. } => Some(source),
             Error::Filter { source, .. } => Some(source.as_ref()),
             Error::Bare | Error::MissingBlob { .. } => None,
         }

--- a/crates/vigia-core/src/error.rs
+++ b/crates/vigia-core/src/error.rs
@@ -130,7 +130,11 @@ impl fmt::Display for Error {
                 write!(f, "could not normalise {path} the way git would: {source}")
             }
             Error::Store { path, source } => {
-                write!(f, "the notes store failed at {}: {source}", path.display())
+                write!(
+                    f,
+                    "could not use the notes store at {}: {source}",
+                    path.display()
+                )
             }
             Error::Canonicalise { path, source } => {
                 write!(f, "could not canonicalise {}: {source}", path.display())

--- a/crates/vigia-core/src/lib.rs
+++ b/crates/vigia-core/src/lib.rs
@@ -34,6 +34,7 @@ mod frame;
 mod highlight;
 mod history;
 mod hunk;
+mod notes;
 mod timing;
 mod watch;
 mod worktree;
@@ -51,6 +52,7 @@ pub use history::{
     HISTORY_WINDOW, History, HistoryStats, PULSE_SAMPLES, Recency, SPARK_GROUPS, scale_of,
 };
 pub use hunk::{CONTEXT, FileDiff, FileSpan, Hunk, Line, LineKind};
+pub use notes::{Listing, NEAR, Note, Placement, Side, Status, Store, key, resolve, state_root};
 pub use timing::{FrameTiming, Samples};
 pub use watch::{Stop, Tick, WatchOptions, WatchStats, Watcher};
 pub use worktree::{

--- a/crates/vigia-core/src/lib.rs
+++ b/crates/vigia-core/src/lib.rs
@@ -52,7 +52,7 @@ pub use history::{
     HISTORY_WINDOW, History, HistoryStats, PULSE_SAMPLES, Recency, SPARK_GROUPS, scale_of,
 };
 pub use hunk::{CONTEXT, FileDiff, FileSpan, Hunk, Line, LineKind};
-pub use notes::{Listing, NEAR, Note, Placement, Side, Status, Store, key, resolve, state_root};
+pub use notes::{Listing, NEAR, Note, Placement, Side, Status, Store, key, resolve};
 pub use timing::{FrameTiming, Samples};
 pub use watch::{Stop, Tick, WatchOptions, WatchStats, Watcher};
 pub use worktree::{

--- a/crates/vigia-core/src/notes.rs
+++ b/crates/vigia-core/src/notes.rs
@@ -59,9 +59,8 @@ pub enum Status {
 /// One note, pinned to a line of the diff.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Note {
-    /// Unique across processes and restarts, and the file's name: ASCII
-    /// letters, digits and dashes only, which is what [`Store`] refuses to
-    /// write or remove without.
+    /// Unique across processes and restarts, and the file's name, so
+    /// [`Store`] refuses one it could not name a file after.
     pub id: String,
     /// Repository-relative path of the file the line is in.
     pub path: String,
@@ -150,19 +149,26 @@ pub fn key(workdir: &Path) -> Result<String> {
     Ok(id.to_hex().to_string())
 }
 
-/// Whether `id` can be a file name inside the store and nothing else: on
-/// Windows a device name is a device whatever extension follows it, so those
-/// are refused on every platform and the store stays one rule.
+/// Whether `id` can be a file name inside the store and nothing else:
+/// lowercase ASCII letters, digits and dashes, so a filesystem that folds case
+/// cannot give one file two names; and not a Windows device name, which is a
+/// device whatever extension follows it, refused on every platform so the
+/// store stays one rule.
 fn is_id(id: &str) -> bool {
-    let plain = !id.is_empty()
+    !id.is_empty()
         && id.len() <= ID_MAX
-        && id.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-');
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+        && !is_device(id)
+}
+
+fn is_device(id: &str) -> bool {
     let upper = id.to_ascii_uppercase();
-    let device = matches!(upper.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+    matches!(upper.as_str(), "CON" | "PRN" | "AUX" | "NUL")
         || (upper.len() == 4
             && (upper.starts_with("COM") || upper.starts_with("LPT"))
-            && matches!(upper.as_bytes()[3], b'1'..=b'9'));
-    plain && !device
+            && matches!(upper.as_bytes()[3], b'1'..=b'9'))
 }
 
 /// The notes of one worktree, on disk.
@@ -271,15 +277,26 @@ impl Store {
         for entry in entries {
             let entry = entry.map_err(|source| Error::store(&self.dir, source))?;
             let name = entry.file_name();
-            if Path::new(&name).extension().and_then(|ext| ext.to_str()) != Some(NOTE_EXT) {
+            let file = Path::new(&name);
+            if file.extension().and_then(|ext| ext.to_str()) != Some(NOTE_EXT) {
                 continue;
             }
             let path = entry.path();
+            // A name the store would not write is not read either: on Windows a
+            // device name opens the device.
+            let Some(stem) = file
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .filter(|stem| is_id(stem))
+            else {
+                listing
+                    .skipped
+                    .push((path, "is not named by a note id".to_owned()));
+                continue;
+            };
             match fs::read(&path) {
                 Ok(bytes) => match decode(&bytes) {
-                    Ok(note) if Path::new(&name).file_stem() == Some(note.id.as_ref()) => {
-                        listing.notes.push(note);
-                    }
+                    Ok(note) if note.id == stem => listing.notes.push(note),
                     Ok(note) => {
                         let why = format!("names itself {:?}, which is not its file name", note.id);
                         listing.skipped.push((path, why));
@@ -465,7 +482,8 @@ struct Cursor<'a> {
 }
 
 impl Cursor<'_> {
-    /// The next line without its newline. A file that ends mid-line was torn.
+    /// The next line without its newline. A file that ends first, at a line's
+    /// end or inside one, was cut short.
     fn line(&mut self) -> std::result::Result<&str, String> {
         let rest = &self.bytes[self.at..];
         let end = rest.iter().position(|&b| b == b'\n').ok_or_else(|| {

--- a/crates/vigia-core/src/notes.rs
+++ b/crates/vigia-core/src/notes.rs
@@ -3,9 +3,8 @@
 //!
 //! Headless: nothing here draws, and nothing here decides which rows are on
 //! screen. The pane hands [`resolve`] the rows it drew; the store is one
-//! directory per worktree under the reader's state directory, one file per
-//! note, and every write is a temp-and-rename so a reader lists whole files
-//! or none.
+//! directory per worktree under a root the shell resolves, one file per note,
+//! and every write is a temp-and-rename so a reader lists whole files or none.
 
 use std::fmt::Write as _;
 use std::fs;
@@ -94,64 +93,29 @@ pub enum Placement {
 /// knowledge, so an adrift note is not a placement.
 #[must_use]
 pub fn resolve(note: &Note, rows: &[(u32, &str)]) -> Placement {
-    let text = note.text.as_str();
-    if rows.iter().any(|&(n, t)| n == note.line && t == text) {
-        return Placement::At(note.line);
-    }
-    let mut best: Option<(u32, u32)> = None;
+    let mut number_drawn = false;
+    let mut nearest: Option<(u32, u32)> = None;
     for &(n, t) in rows {
-        if t != text {
+        number_drawn |= n == note.line;
+        if t != note.text {
             continue;
+        }
+        if n == note.line {
+            return Placement::At(n);
         }
         let distance = n.abs_diff(note.line);
-        if distance > NEAR {
-            continue;
-        }
         // Nearest wins; on a tie the earlier line does, so a repeated line
-        // resolves the same way from any starting order of the rows.
-        let better = match best {
-            None => true,
-            Some((d, at)) => distance < d || (distance == d && n < at),
-        };
-        if better {
-            best = Some((distance, n));
+        // resolves the same way whatever order the rows arrive in.
+        let closer = nearest.is_none_or(|(d, at)| distance < d || (distance == d && n < at));
+        if distance <= NEAR && closer {
+            nearest = Some((distance, n));
         }
     }
-    if let Some((_, n)) = best {
-        return Placement::Moved(n);
+    match nearest {
+        Some((_, n)) => Placement::Moved(n),
+        None if number_drawn => Placement::Changed,
+        None => Placement::Gone,
     }
-    if rows.iter().any(|&(n, _)| n == note.line) {
-        Placement::Changed
-    } else {
-        Placement::Gone
-    }
-}
-
-/// The directory `vigia` keeps state under, or `None` when the environment
-/// names no home.
-///
-/// `XDG_STATE_HOME` when it is set, non-empty and absolute, else
-/// `~/.local/state`, which is the XDG base directory rule; `LOCALAPPDATA` on
-/// Windows, where there is no XDG and that is the per-user local root. The
-/// `windows` flag and the `lookup` closure are parameters so a test can ask
-/// about a platform and an environment it is not running in.
-#[must_use]
-pub fn state_root(windows: bool, lookup: &impl Fn(&str) -> Option<String>) -> Option<PathBuf> {
-    let set = |name: &str| {
-        lookup(name)
-            .map(|value| value.trim().to_owned())
-            .filter(|value| !value.is_empty())
-    };
-    if windows {
-        return set("LOCALAPPDATA").map(|local| Path::new(&local).join("vigia").join("state"));
-    }
-    if let Some(xdg) = set("XDG_STATE_HOME").filter(|value| Path::new(value).is_absolute()) {
-        return Some(Path::new(&xdg).join("vigia"));
-    }
-    ["HOME", "USERPROFILE"]
-        .into_iter()
-        .find_map(set)
-        .map(|home| Path::new(&home).join(".local").join("state").join("vigia"))
 }
 
 /// The store key of `workdir`: forty hex characters of the SHA-1 of its
@@ -182,7 +146,7 @@ pub struct Store {
 
 /// What a listing found: every note that read whole, and every file that did
 /// not, with why.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default)]
 pub struct Listing {
     /// Oldest first, then by id.
     pub notes: Vec<Note>,
@@ -275,12 +239,12 @@ impl Store {
             Err(source) => return Err(Error::store(&self.dir, source)),
         };
         for entry in entries {
-            let path = entry
-                .map_err(|source| Error::store(&self.dir, source))?
-                .path();
-            if path.extension().and_then(|ext| ext.to_str()) != Some(NOTE_EXT) {
+            let entry = entry.map_err(|source| Error::store(&self.dir, source))?;
+            let name = entry.file_name();
+            if Path::new(&name).extension().and_then(|ext| ext.to_str()) != Some(NOTE_EXT) {
                 continue;
             }
+            let path = entry.path();
             match fs::read(&path) {
                 Ok(bytes) => match decode(&bytes) {
                     Ok(note) => listing.notes.push(note),

--- a/crates/vigia-core/src/notes.rs
+++ b/crates/vigia-core/src/notes.rs
@@ -24,9 +24,16 @@ const VERSION_LINE: &str = "vigia note 1";
 /// never listed.
 const NOTE_EXT: &str = "note";
 
+/// The longest id the store accepts.
+const ID_MAX: usize = 64;
+
 /// How far from its stored number a line is looked for by its text, in rows on
 /// its own side, before the note is judged to have lost it.
 pub const NEAR: u32 = 8;
+
+/// One per process, so two writes in one process never share a temporary and
+/// two ids minted in one microsecond differ.
+static COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// Which side of the diff a line is on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -52,7 +59,9 @@ pub enum Status {
 /// One note, pinned to a line of the diff.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Note {
-    /// Unique across processes and restarts; the file's name.
+    /// Unique across processes and restarts, and the file's name: ASCII
+    /// letters, digits and dashes only, which is what [`Store`] refuses to
+    /// write or remove without.
     pub id: String,
     /// Repository-relative path of the file the line is in.
     pub path: String,
@@ -132,10 +141,20 @@ pub fn key(workdir: &Path) -> Result<String> {
     })?;
     let mut hasher = gix::hash::hasher(gix::hash::Kind::Sha1);
     hasher.update(canonical.to_string_lossy().as_bytes());
+    // The only failure is a detected collision attack in the bytes hashed,
+    // which are a path this process resolved; it is reported as the store
+    // failing at that path because the store is what cannot be opened.
     let id = hasher
         .try_finalize()
         .map_err(|why| Error::store(workdir, io::Error::other(why)))?;
     Ok(id.to_hex().to_string())
+}
+
+/// Whether `id` can be a file name inside the store and nothing else.
+fn is_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= ID_MAX
+        && id.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
 }
 
 /// The notes of one worktree, on disk.
@@ -178,7 +197,6 @@ impl Store {
     /// and a counter, all in hex.
     #[must_use]
     pub fn new_id() -> String {
-        static COUNTER: AtomicU32 = AtomicU32::new(0);
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or(Duration::ZERO);
@@ -195,15 +213,18 @@ impl Store {
     ///
     /// # Errors
     ///
-    /// The directory cannot be created or the file cannot be written or moved
-    /// into place; the temporary file is removed on the way out.
+    /// The id is not one the store can name a file after; the directory cannot
+    /// be created; the file cannot be written or moved into place, in which
+    /// case the temporary is removed on the way out.
     pub fn put(&self, note: &Note) -> Result<()> {
+        let done = self.path_of(&note.id)?;
         fs::create_dir_all(&self.dir).map_err(|source| Error::store(&self.dir, source))?;
-        // The process id keeps two writers of one note from sharing a temporary.
-        let tmp = self
-            .dir
-            .join(format!("{}.{:x}.tmp", note.id, std::process::id()));
-        let done = self.path_of(&note.id);
+        let tmp = self.dir.join(format!(
+            "{}.{:x}-{:x}.tmp",
+            note.id,
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
         fs::write(&tmp, encode(note)).map_err(|source| Error::store(&tmp, source))?;
         fs::rename(&tmp, &done).map_err(|source| {
             let _ = fs::remove_file(&tmp);
@@ -216,9 +237,10 @@ impl Store {
     ///
     /// # Errors
     ///
-    /// The file exists and cannot be removed.
+    /// The id is not one the store names files after, or the file exists and
+    /// cannot be removed.
     pub fn remove(&self, id: &str) -> Result<()> {
-        let path = self.path_of(id);
+        let path = self.path_of(id)?;
         match fs::remove_file(&path) {
             Ok(()) => Ok(()),
             Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(()),
@@ -261,14 +283,24 @@ impl Store {
         Ok(listing)
     }
 
-    fn path_of(&self, id: &str) -> PathBuf {
-        self.dir.join(format!("{id}.{NOTE_EXT}"))
+    /// The file of `id`, or the error a caller can show when `id` could name
+    /// something outside the store.
+    fn path_of(&self, id: &str) -> Result<PathBuf> {
+        if !is_id(id) {
+            let why = io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("{id:?} is not a note id"),
+            );
+            return Err(Error::store(&self.dir, why));
+        }
+        Ok(self.dir.join(format!("{id}.{NOTE_EXT}")))
     }
 }
 
-/// The file: a version line, one `key: value` line per single-line field, then
-/// the body and the reply each announced with its byte length, so either may
-/// hold any line at all.
+/// The file: a version line, one `key: value` line per field that cannot hold
+/// a newline, then every free-text field announced with its byte length, so
+/// no path or line of code can forge a header and a file cut short announces
+/// more bytes than follow.
 fn encode(note: &Note) -> String {
     let secs = note
         .written
@@ -279,19 +311,20 @@ fn encode(note: &Note) -> String {
     // Writing to a String cannot fail, so the results are discarded.
     let _ = writeln!(out, "{VERSION_LINE}");
     let _ = writeln!(out, "id: {}", note.id);
-    let _ = writeln!(out, "path: {}", note.path);
     let _ = writeln!(out, "side: {}", side_name(note.side));
     let _ = writeln!(out, "line: {}", note.line);
     let _ = writeln!(out, "status: {}", status_name(note.status));
     let _ = writeln!(out, "written: {secs}");
-    let _ = writeln!(out, "text: {}", note.text);
-    let _ = writeln!(out, "body {}", note.body.len());
-    out.push_str(&note.body);
-    out.push('\n');
-    if let Some(reply) = &note.reply {
-        let _ = writeln!(out, "reply {}", reply.len());
-        out.push_str(reply);
+    let mut block = |name: &str, text: &str| {
+        let _ = writeln!(out, "{name} {}", text.len());
+        out.push_str(text);
         out.push('\n');
+    };
+    block("path", &note.path);
+    block("text", &note.text);
+    block("body", &note.body);
+    if let Some(reply) = &note.reply {
+        block("reply", reply);
     }
     out
 }
@@ -311,7 +344,9 @@ fn status_name(status: Status) -> &'static str {
     }
 }
 
-/// Parse one file, or say in a sentence why it cannot be trusted.
+/// Parse one file, or say in a sentence why it cannot be trusted. Nothing in
+/// a file, however large a number it names, may panic: a corrupt note costs
+/// that note and never the process.
 fn decode(bytes: &[u8]) -> std::result::Result<Note, String> {
     let mut cursor = Cursor { bytes, at: 0 };
     let version = cursor.line()?;
@@ -321,25 +356,21 @@ fn decode(bytes: &[u8]) -> std::result::Result<Note, String> {
         ));
     }
     let mut id = None;
-    let mut path = None;
     let mut side = None;
     let mut line = None;
     let mut status = None;
     let mut written = None;
-    let mut text = None;
-    let body_len = loop {
-        let header = cursor.line()?;
-        if let Some(len) = header.strip_prefix("body ") {
-            break len
-                .parse::<usize>()
-                .map_err(|_| format!("body length {len:?} is not a number"))?;
+    loop {
+        if cursor.starts_with("path ") {
+            break;
         }
+        let header = cursor.line()?;
         let (name, value) = header
             .split_once(": ")
             .ok_or_else(|| format!("header line {header:?} is not a field"))?;
         match name {
-            "id" => id = Some(value.to_owned()),
-            "path" => path = Some(value.to_owned()),
+            "id" if is_id(value) => id = Some(value.to_owned()),
+            "id" => return Err(format!("id {value:?} is not a note id")),
             "side" => {
                 side = Some(match value {
                     "old" => Side::Old,
@@ -366,38 +397,32 @@ fn decode(bytes: &[u8]) -> std::result::Result<Note, String> {
                 let secs = value
                     .parse::<u64>()
                     .map_err(|_| format!("written {value:?} is not a number"))?;
-                written = Some(UNIX_EPOCH + Duration::from_secs(secs));
+                let at = UNIX_EPOCH
+                    .checked_add(Duration::from_secs(secs))
+                    .ok_or_else(|| format!("written {value:?} is past any time"))?;
+                written = Some(at);
             }
-            "text" => text = Some(value.to_owned()),
             other => return Err(format!("field {other:?} is not one this version writes")),
         }
-    };
-    let body = cursor.block(body_len, "body")?;
+    }
+    let path = cursor.block("path")?;
+    let text = cursor.block("text")?;
+    let body = cursor.block("body")?;
     let reply = if cursor.at_end() {
         None
     } else {
-        let header = cursor.line()?;
-        let len = header
-            .strip_prefix("reply ")
-            .ok_or_else(|| format!("after the body, {header:?} is not a reply"))?
-            .parse::<usize>()
-            .map_err(|_| format!("reply length in {header:?} is not a number"))?;
-        Some(cursor.block(len, "reply")?)
+        Some(cursor.block("reply")?)
     };
     if !cursor.at_end() {
         return Err("bytes follow the last field".to_owned());
     }
     let missing = |name: &str| format!("the {name} field is missing");
     Ok(Note {
-        id: id
-            .filter(|id| !id.is_empty())
-            .ok_or_else(|| missing("id"))?,
-        path: path
-            .filter(|p| !p.is_empty())
-            .ok_or_else(|| missing("path"))?,
+        id: id.ok_or_else(|| missing("id"))?,
+        path,
         side: side.ok_or_else(|| missing("side"))?,
         line: line.ok_or_else(|| missing("line"))?,
-        text: text.ok_or_else(|| missing("text"))?,
+        text,
         body,
         status: status.ok_or_else(|| missing("status"))?,
         reply,
@@ -425,10 +450,23 @@ impl Cursor<'_> {
         Ok(line)
     }
 
-    /// Exactly `len` bytes followed by a newline, as UTF-8.
-    fn block(&mut self, len: usize, what: &str) -> std::result::Result<String, String> {
+    /// Whether the bytes at the cursor begin with `prefix`.
+    fn starts_with(&self, prefix: &str) -> bool {
+        self.bytes[self.at..].starts_with(prefix.as_bytes())
+    }
+
+    /// A block announced as `<what> <len>` on its own line: exactly `len`
+    /// bytes, then a newline, as UTF-8.
+    fn block(&mut self, what: &str) -> std::result::Result<String, String> {
+        let header = self.line()?;
+        let len = header
+            .strip_prefix(what)
+            .and_then(|rest| rest.strip_prefix(' '))
+            .ok_or_else(|| format!("{header:?} is not the {what} block"))?
+            .parse::<usize>()
+            .map_err(|_| format!("the {what} length in {header:?} is not a number"))?;
         let rest = &self.bytes[self.at..];
-        if rest.len() < len + 1 || rest[len] != b'\n' {
+        if rest.get(len) != Some(&b'\n') {
             return Err(format!(
                 "the {what} is shorter than its {len} announced bytes"
             ));

--- a/crates/vigia-core/src/notes.rs
+++ b/crates/vigia-core/src/notes.rs
@@ -139,7 +139,7 @@ pub fn key(workdir: &Path) -> Result<String> {
         source,
     })?;
     let mut hasher = gix::hash::hasher(gix::hash::Kind::Sha1);
-    hasher.update(canonical.to_string_lossy().as_bytes());
+    hasher.update(&os_bytes(canonical.as_os_str()));
     // The only failure is a detected collision attack in the bytes hashed,
     // which are a path this process resolved; it is reported as the store
     // failing at that path because the store is what cannot be opened.
@@ -147,6 +147,20 @@ pub fn key(workdir: &Path) -> Result<String> {
         .try_finalize()
         .map_err(|why| Error::store(workdir, io::Error::other(why)))?;
     Ok(id.to_hex().to_string())
+}
+
+/// The bytes of a path as the platform holds them, so two paths that differ
+/// only where UTF-8 cannot represent them still hash apart.
+#[cfg(unix)]
+fn os_bytes(path: &std::ffi::OsStr) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt as _;
+    path.as_bytes().to_vec()
+}
+
+#[cfg(windows)]
+fn os_bytes(path: &std::ffi::OsStr) -> Vec<u8> {
+    use std::os::windows::ffi::OsStrExt as _;
+    path.encode_wide().flat_map(u16::to_le_bytes).collect()
 }
 
 /// Whether `id` can be a file name inside the store and nothing else:

--- a/crates/vigia-core/src/notes.rs
+++ b/crates/vigia-core/src/notes.rs
@@ -1,0 +1,482 @@
+//! Notes a reader pins to lines of the diff for the agent, and the store that
+//! holds them between the two processes (`SPEC.md` §11.2 B21).
+//!
+//! Headless: nothing here draws, and nothing here decides which rows are on
+//! screen. The pane hands [`resolve`] the rows it drew; the store is one
+//! directory per worktree under the reader's state directory, one file per
+//! note, and every write is a temp-and-rename so a reader lists whole files
+//! or none.
+
+use std::fmt::Write as _;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::error::{Error, Result};
+
+/// The first line of every note file. A file whose first line differs was
+/// written by a `vigia` this one does not know, and is skipped rather than
+/// guessed at.
+const VERSION_LINE: &str = "vigia note 1";
+
+/// The extension of a note file. A write in flight carries `.tmp` and is
+/// never listed.
+const NOTE_EXT: &str = "note";
+
+/// How far from its stored number a line is looked for by its text, in rows on
+/// its own side, before the note is judged to have lost it.
+pub const NEAR: u32 = 8;
+
+/// Which side of the diff a line is on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    /// The index side: a removed line, numbered by the index.
+    Old,
+    /// The worktree side: an added or context line, numbered by the file.
+    New,
+}
+
+/// Where a note stands on the ladder the agent climbs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    /// Written by the reader and not yet listed by the agent.
+    Open,
+    /// Listed by the agent at least once.
+    Seen,
+    /// Resolved by the agent with a line of its own; the pane draws the
+    /// departure and the server prunes the file.
+    Resolved,
+}
+
+/// One note, pinned to a line of the diff.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Note {
+    /// Unique across processes and restarts; the file's name.
+    pub id: String,
+    /// Repository-relative path of the file the line is in.
+    pub path: String,
+    /// Which side the line was on when the note was written.
+    pub side: Side,
+    /// The line's 1-based number on that side when the note was written.
+    pub line: u32,
+    /// The line's text when the note was written, which is what re-finds it
+    /// after an edit above moves the number.
+    pub text: String,
+    /// What the reader typed.
+    pub body: String,
+    /// Where it stands.
+    pub status: Status,
+    /// The agent's line on a resolve, shown once as the note departs.
+    pub reply: Option<String>,
+    /// When the reader pressed Enter, to the second.
+    pub written: SystemTime,
+}
+
+/// Where a note's line is among the rows in hand.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Placement {
+    /// The stored number still carries the stored text.
+    At(u32),
+    /// The stored text was found at another number within [`NEAR`] rows,
+    /// so an edit above or below moved the line.
+    Moved(u32),
+    /// The stored number is drawn with other text and the stored text is not
+    /// nearby, which is what the line looks like after the agent edits it.
+    Changed,
+    /// Neither the number nor the text is among the rows.
+    Gone,
+}
+
+/// Where the line `note` was pinned to is among `rows`, each a `(number, text)`
+/// on the note's side. Whether the file is in the diff at all is the caller's
+/// knowledge, so an adrift note is not a placement.
+#[must_use]
+pub fn resolve(note: &Note, rows: &[(u32, &str)]) -> Placement {
+    let text = note.text.as_str();
+    if rows.iter().any(|&(n, t)| n == note.line && t == text) {
+        return Placement::At(note.line);
+    }
+    let mut best: Option<(u32, u32)> = None;
+    for &(n, t) in rows {
+        if t != text {
+            continue;
+        }
+        let distance = n.abs_diff(note.line);
+        if distance > NEAR {
+            continue;
+        }
+        // Nearest wins; on a tie the earlier line does, so a repeated line
+        // resolves the same way from any starting order of the rows.
+        let better = match best {
+            None => true,
+            Some((d, at)) => distance < d || (distance == d && n < at),
+        };
+        if better {
+            best = Some((distance, n));
+        }
+    }
+    if let Some((_, n)) = best {
+        return Placement::Moved(n);
+    }
+    if rows.iter().any(|&(n, _)| n == note.line) {
+        Placement::Changed
+    } else {
+        Placement::Gone
+    }
+}
+
+/// The directory `vigia` keeps state under, or `None` when the environment
+/// names no home.
+///
+/// `XDG_STATE_HOME` when it is set, non-empty and absolute, else
+/// `~/.local/state`, which is the XDG base directory rule; `LOCALAPPDATA` on
+/// Windows, where there is no XDG and that is the per-user local root. The
+/// `windows` flag and the `lookup` closure are parameters so a test can ask
+/// about a platform and an environment it is not running in.
+#[must_use]
+pub fn state_root(windows: bool, lookup: &impl Fn(&str) -> Option<String>) -> Option<PathBuf> {
+    let set = |name: &str| {
+        lookup(name)
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+    };
+    if windows {
+        return set("LOCALAPPDATA").map(|local| Path::new(&local).join("vigia").join("state"));
+    }
+    if let Some(xdg) = set("XDG_STATE_HOME").filter(|value| Path::new(value).is_absolute()) {
+        return Some(Path::new(&xdg).join("vigia"));
+    }
+    ["HOME", "USERPROFILE"]
+        .into_iter()
+        .find_map(set)
+        .map(|home| Path::new(&home).join(".local").join("state").join("vigia"))
+}
+
+/// The store key of `workdir`: forty hex characters of the SHA-1 of its
+/// canonical path, so every process that resolves the same worktree lands on
+/// one directory whatever spelling it started from.
+///
+/// # Errors
+///
+/// The path cannot be canonicalised, which means it does not exist.
+pub fn key(workdir: &Path) -> Result<String> {
+    let canonical = fs::canonicalize(workdir).map_err(|source| Error::Canonicalise {
+        path: workdir.to_owned(),
+        source,
+    })?;
+    let mut hasher = gix::hash::hasher(gix::hash::Kind::Sha1);
+    hasher.update(canonical.to_string_lossy().as_bytes());
+    let id = hasher
+        .try_finalize()
+        .map_err(|why| Error::store(workdir, io::Error::other(why)))?;
+    Ok(id.to_hex().to_string())
+}
+
+/// The notes of one worktree, on disk.
+#[derive(Debug, Clone)]
+pub struct Store {
+    dir: PathBuf,
+}
+
+/// What a listing found: every note that read whole, and every file that did
+/// not, with why.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Listing {
+    /// Oldest first, then by id.
+    pub notes: Vec<Note>,
+    /// Files skipped, each with the reason, so the pane can say so once and
+    /// the server can report them beside the rest.
+    pub skipped: Vec<(PathBuf, String)>,
+}
+
+impl Store {
+    /// The store for `workdir` under the state `root`. Creates nothing: the
+    /// directory appears on the first [`Store::put`].
+    ///
+    /// # Errors
+    ///
+    /// `workdir` cannot be canonicalised.
+    pub fn open(root: &Path, workdir: &Path) -> Result<Self> {
+        Ok(Self {
+            dir: root.join(key(workdir)?),
+        })
+    }
+
+    /// Where the files are, whether or not it exists yet.
+    #[must_use]
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    /// An id no other process or restart produces: microseconds, the process
+    /// and a counter, all in hex.
+    #[must_use]
+    pub fn new_id() -> String {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO);
+        format!(
+            "{:x}-{:x}-{:x}",
+            now.as_micros(),
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        )
+    }
+
+    /// Write `note` whole, creating the directory on the first call. A reader
+    /// listing meanwhile sees the previous file or this one, never a part.
+    ///
+    /// # Errors
+    ///
+    /// The directory cannot be created or the file cannot be written or moved
+    /// into place; the temporary file is removed on the way out.
+    pub fn put(&self, note: &Note) -> Result<()> {
+        fs::create_dir_all(&self.dir).map_err(|source| Error::store(&self.dir, source))?;
+        // The process id keeps two writers of one note from sharing a temporary.
+        let tmp = self
+            .dir
+            .join(format!("{}.{:x}.tmp", note.id, std::process::id()));
+        let done = self.path_of(&note.id);
+        fs::write(&tmp, encode(note)).map_err(|source| Error::store(&tmp, source))?;
+        fs::rename(&tmp, &done).map_err(|source| {
+            let _ = fs::remove_file(&tmp);
+            Error::store(&done, source)
+        })
+    }
+
+    /// Delete the note `id`. A note already gone is not an error: two panes on
+    /// one worktree may both withdraw it.
+    ///
+    /// # Errors
+    ///
+    /// The file exists and cannot be removed.
+    pub fn remove(&self, id: &str) -> Result<()> {
+        let path = self.path_of(id);
+        match fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(source) => Err(Error::store(&path, source)),
+        }
+    }
+
+    /// Every note in the store. A store that does not exist yet lists nothing.
+    ///
+    /// # Errors
+    ///
+    /// The directory exists and cannot be read.
+    pub fn list(&self) -> Result<Listing> {
+        let mut listing = Listing::default();
+        let entries = match fs::read_dir(&self.dir) {
+            Ok(entries) => entries,
+            Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(listing),
+            Err(source) => return Err(Error::store(&self.dir, source)),
+        };
+        for entry in entries {
+            let path = entry
+                .map_err(|source| Error::store(&self.dir, source))?
+                .path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some(NOTE_EXT) {
+                continue;
+            }
+            match fs::read(&path) {
+                Ok(bytes) => match decode(&bytes) {
+                    Ok(note) => listing.notes.push(note),
+                    Err(why) => listing.skipped.push((path, why)),
+                },
+                // Withdrawn between the directory read and the file read.
+                Err(source) if source.kind() == io::ErrorKind::NotFound => {}
+                Err(source) => listing.skipped.push((path, source.to_string())),
+            }
+        }
+        listing
+            .notes
+            .sort_by(|a, b| a.written.cmp(&b.written).then_with(|| a.id.cmp(&b.id)));
+        Ok(listing)
+    }
+
+    fn path_of(&self, id: &str) -> PathBuf {
+        self.dir.join(format!("{id}.{NOTE_EXT}"))
+    }
+}
+
+/// The file: a version line, one `key: value` line per single-line field, then
+/// the body and the reply each announced with its byte length, so either may
+/// hold any line at all.
+fn encode(note: &Note) -> String {
+    let secs = note
+        .written
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs();
+    let mut out = String::new();
+    // Writing to a String cannot fail, so the results are discarded.
+    let _ = writeln!(out, "{VERSION_LINE}");
+    let _ = writeln!(out, "id: {}", note.id);
+    let _ = writeln!(out, "path: {}", note.path);
+    let _ = writeln!(out, "side: {}", side_name(note.side));
+    let _ = writeln!(out, "line: {}", note.line);
+    let _ = writeln!(out, "status: {}", status_name(note.status));
+    let _ = writeln!(out, "written: {secs}");
+    let _ = writeln!(out, "text: {}", note.text);
+    let _ = writeln!(out, "body {}", note.body.len());
+    out.push_str(&note.body);
+    out.push('\n');
+    if let Some(reply) = &note.reply {
+        let _ = writeln!(out, "reply {}", reply.len());
+        out.push_str(reply);
+        out.push('\n');
+    }
+    out
+}
+
+fn side_name(side: Side) -> &'static str {
+    match side {
+        Side::Old => "old",
+        Side::New => "new",
+    }
+}
+
+fn status_name(status: Status) -> &'static str {
+    match status {
+        Status::Open => "open",
+        Status::Seen => "seen",
+        Status::Resolved => "resolved",
+    }
+}
+
+/// Parse one file, or say in a sentence why it cannot be trusted.
+fn decode(bytes: &[u8]) -> std::result::Result<Note, String> {
+    let mut cursor = Cursor { bytes, at: 0 };
+    let version = cursor.line()?;
+    if version != VERSION_LINE {
+        return Err(format!(
+            "written as {version:?}, which this version does not read"
+        ));
+    }
+    let mut id = None;
+    let mut path = None;
+    let mut side = None;
+    let mut line = None;
+    let mut status = None;
+    let mut written = None;
+    let mut text = None;
+    let body_len = loop {
+        let header = cursor.line()?;
+        if let Some(len) = header.strip_prefix("body ") {
+            break len
+                .parse::<usize>()
+                .map_err(|_| format!("body length {len:?} is not a number"))?;
+        }
+        let (name, value) = header
+            .split_once(": ")
+            .ok_or_else(|| format!("header line {header:?} is not a field"))?;
+        match name {
+            "id" => id = Some(value.to_owned()),
+            "path" => path = Some(value.to_owned()),
+            "side" => {
+                side = Some(match value {
+                    "old" => Side::Old,
+                    "new" => Side::New,
+                    other => return Err(format!("side {other:?} is neither old nor new")),
+                });
+            }
+            "line" => {
+                line = Some(
+                    value
+                        .parse::<u32>()
+                        .map_err(|_| format!("line {value:?} is not a number"))?,
+                );
+            }
+            "status" => {
+                status = Some(match value {
+                    "open" => Status::Open,
+                    "seen" => Status::Seen,
+                    "resolved" => Status::Resolved,
+                    other => return Err(format!("status {other:?} is not on the ladder")),
+                });
+            }
+            "written" => {
+                let secs = value
+                    .parse::<u64>()
+                    .map_err(|_| format!("written {value:?} is not a number"))?;
+                written = Some(UNIX_EPOCH + Duration::from_secs(secs));
+            }
+            "text" => text = Some(value.to_owned()),
+            other => return Err(format!("field {other:?} is not one this version writes")),
+        }
+    };
+    let body = cursor.block(body_len, "body")?;
+    let reply = if cursor.at_end() {
+        None
+    } else {
+        let header = cursor.line()?;
+        let len = header
+            .strip_prefix("reply ")
+            .ok_or_else(|| format!("after the body, {header:?} is not a reply"))?
+            .parse::<usize>()
+            .map_err(|_| format!("reply length in {header:?} is not a number"))?;
+        Some(cursor.block(len, "reply")?)
+    };
+    if !cursor.at_end() {
+        return Err("bytes follow the last field".to_owned());
+    }
+    let missing = |name: &str| format!("the {name} field is missing");
+    Ok(Note {
+        id: id
+            .filter(|id| !id.is_empty())
+            .ok_or_else(|| missing("id"))?,
+        path: path
+            .filter(|p| !p.is_empty())
+            .ok_or_else(|| missing("path"))?,
+        side: side.ok_or_else(|| missing("side"))?,
+        line: line.ok_or_else(|| missing("line"))?,
+        text: text.ok_or_else(|| missing("text"))?,
+        body,
+        status: status.ok_or_else(|| missing("status"))?,
+        reply,
+        written: written.ok_or_else(|| missing("written"))?,
+    })
+}
+
+/// A position in the bytes being decoded.
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    at: usize,
+}
+
+impl Cursor<'_> {
+    /// The next line without its newline. A file that ends mid-line was torn.
+    fn line(&mut self) -> std::result::Result<&str, String> {
+        let rest = &self.bytes[self.at..];
+        let end = rest
+            .iter()
+            .position(|&b| b == b'\n')
+            .ok_or_else(|| "the file ends in the middle of a line".to_owned())?;
+        let line = std::str::from_utf8(&rest[..end])
+            .map_err(|_| "a header line is not UTF-8".to_owned())?;
+        self.at += end + 1;
+        Ok(line)
+    }
+
+    /// Exactly `len` bytes followed by a newline, as UTF-8.
+    fn block(&mut self, len: usize, what: &str) -> std::result::Result<String, String> {
+        let rest = &self.bytes[self.at..];
+        if rest.len() < len + 1 || rest[len] != b'\n' {
+            return Err(format!(
+                "the {what} is shorter than its {len} announced bytes"
+            ));
+        }
+        let block = std::str::from_utf8(&rest[..len])
+            .map_err(|_| format!("the {what} is not UTF-8"))?
+            .to_owned();
+        self.at += len + 1;
+        Ok(block)
+    }
+
+    fn at_end(&self) -> bool {
+        self.at == self.bytes.len()
+    }
+}

--- a/crates/vigia-core/src/notes.rs
+++ b/crates/vigia-core/src/notes.rs
@@ -150,11 +150,19 @@ pub fn key(workdir: &Path) -> Result<String> {
     Ok(id.to_hex().to_string())
 }
 
-/// Whether `id` can be a file name inside the store and nothing else.
+/// Whether `id` can be a file name inside the store and nothing else: on
+/// Windows a device name is a device whatever extension follows it, so those
+/// are refused on every platform and the store stays one rule.
 fn is_id(id: &str) -> bool {
-    !id.is_empty()
+    let plain = !id.is_empty()
         && id.len() <= ID_MAX
-        && id.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
+        && id.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-');
+    let upper = id.to_ascii_uppercase();
+    let device = matches!(upper.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+        || (upper.len() == 4
+            && (upper.starts_with("COM") || upper.starts_with("LPT"))
+            && matches!(upper.as_bytes()[3], b'1'..=b'9'));
+    plain && !device
 }
 
 /// The notes of one worktree, on disk.
@@ -269,7 +277,13 @@ impl Store {
             let path = entry.path();
             match fs::read(&path) {
                 Ok(bytes) => match decode(&bytes) {
-                    Ok(note) => listing.notes.push(note),
+                    Ok(note) if Path::new(&name).file_stem() == Some(note.id.as_ref()) => {
+                        listing.notes.push(note);
+                    }
+                    Ok(note) => {
+                        let why = format!("names itself {:?}, which is not its file name", note.id);
+                        listing.skipped.push((path, why));
+                    }
                     Err(why) => listing.skipped.push((path, why)),
                 },
                 // Withdrawn between the directory read and the file read.
@@ -368,10 +382,21 @@ fn decode(bytes: &[u8]) -> std::result::Result<Note, String> {
         let (name, value) = header
             .split_once(": ")
             .ok_or_else(|| format!("header line {header:?} is not a field"))?;
+        let twice = |taken: bool| {
+            if taken {
+                Err(format!("the {name} field appears twice"))
+            } else {
+                Ok(())
+            }
+        };
         match name {
-            "id" if is_id(value) => id = Some(value.to_owned()),
+            "id" if is_id(value) => {
+                twice(id.is_some())?;
+                id = Some(value.to_owned());
+            }
             "id" => return Err(format!("id {value:?} is not a note id")),
             "side" => {
+                twice(side.is_some())?;
                 side = Some(match value {
                     "old" => Side::Old,
                     "new" => Side::New,
@@ -379,6 +404,7 @@ fn decode(bytes: &[u8]) -> std::result::Result<Note, String> {
                 });
             }
             "line" => {
+                twice(line.is_some())?;
                 line = Some(
                     value
                         .parse::<u32>()
@@ -386,6 +412,7 @@ fn decode(bytes: &[u8]) -> std::result::Result<Note, String> {
                 );
             }
             "status" => {
+                twice(status.is_some())?;
                 status = Some(match value {
                     "open" => Status::Open,
                     "seen" => Status::Seen,
@@ -394,6 +421,7 @@ fn decode(bytes: &[u8]) -> std::result::Result<Note, String> {
                 });
             }
             "written" => {
+                twice(written.is_some())?;
                 let secs = value
                     .parse::<u64>()
                     .map_err(|_| format!("written {value:?} is not a number"))?;
@@ -440,10 +468,13 @@ impl Cursor<'_> {
     /// The next line without its newline. A file that ends mid-line was torn.
     fn line(&mut self) -> std::result::Result<&str, String> {
         let rest = &self.bytes[self.at..];
-        let end = rest
-            .iter()
-            .position(|&b| b == b'\n')
-            .ok_or_else(|| "the file ends in the middle of a line".to_owned())?;
+        let end = rest.iter().position(|&b| b == b'\n').ok_or_else(|| {
+            if rest.is_empty() {
+                "the file ends before its last field".to_owned()
+            } else {
+                "the file ends in the middle of a line".to_owned()
+            }
+        })?;
         let line = std::str::from_utf8(&rest[..end])
             .map_err(|_| "a header line is not UTF-8".to_owned())?;
         self.at += end + 1;

--- a/crates/vigia-core/tests/notes.rs
+++ b/crates/vigia-core/tests/notes.rs
@@ -1,0 +1,434 @@
+//! `SPEC.md` §11.2 B21: a note anchors to a diff line and lives in a
+//! per-worktree store.
+
+mod support;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, UNIX_EPOCH};
+
+use support::Scratch;
+use vigia_core::{
+    Error, NEAR, Note, Placement, Side, Status, Store, Worktree, key, resolve, state_root,
+};
+
+/// A directory the test owns, removed on drop, for a state root that is not
+/// the reader's.
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new(name: &str) -> Self {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "vigia-notes-{}-{}-{name}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create a temp dir");
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn note(id: &str, line: u32, text: &str, body: &str) -> Note {
+    Note {
+        id: id.to_owned(),
+        path: "src/watch.rs".to_owned(),
+        side: Side::New,
+        line,
+        text: text.to_owned(),
+        body: body.to_owned(),
+        status: Status::Open,
+        reply: None,
+        written: UNIX_EPOCH + Duration::from_secs(1_800_000_000),
+    }
+}
+
+fn files_in(dir: &Path) -> Vec<String> {
+    let mut names: Vec<String> = fs::read_dir(dir)
+        .expect("read the store directory")
+        .map(|entry| {
+            entry
+                .expect("a directory entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+#[test]
+fn the_key_is_one_value_for_one_worktree_from_any_path_inside_it() {
+    // Two processes start from two paths: the pane from wherever it was
+    // launched, the server from the project root. Both discover the same
+    // workdir and must land on one directory.
+    let scratch = Scratch::new("notes-key");
+    scratch.write("src/a.rs", "fn a() {}\n");
+    scratch.commit_all("first");
+
+    let from_root = key(Worktree::discover(scratch.root())
+        .expect("discover")
+        .workdir())
+    .expect("a key from the root");
+    let from_inside = key(Worktree::discover(scratch.path_of("src"))
+        .expect("discover from inside")
+        .workdir())
+    .expect("a key from inside");
+    assert_eq!(from_root, from_inside);
+    assert_eq!(from_root.len(), 40, "forty hex characters: {from_root}");
+    assert!(from_root.chars().all(|c| c.is_ascii_hexdigit()));
+
+    let other = Scratch::new("notes-key-other");
+    assert_ne!(from_root, key(other.root()).expect("another key"));
+}
+
+#[test]
+fn a_linked_worktree_has_its_own_key() {
+    // Its diff is its own, so its store is too: the workdir gix answers with
+    // is the linked root, not the main tree's.
+    let scratch = Scratch::new("notes-key-linked");
+    scratch.write("a.txt", "one\n");
+    scratch.commit_all("first");
+    let holder = TempDir::new("linked");
+    let linked_root = holder.path().join("tree");
+    scratch.git(&[
+        "worktree",
+        "add",
+        "-q",
+        linked_root.to_str().expect("a UTF-8 temp path"),
+        "-b",
+        "linked",
+    ]);
+
+    let linked = Worktree::discover(&linked_root).expect("discover the linked worktree");
+    assert_ne!(
+        key(scratch.root()).expect("the main key"),
+        key(linked.workdir()).expect("the linked key")
+    );
+}
+
+#[test]
+fn a_note_put_by_one_handle_is_read_whole_by_another() {
+    // The pane quitting and coming back, or the server reading what the pane
+    // wrote: a second handle on the same worktree sees every field.
+    let scratch = Scratch::new("notes-roundtrip");
+    let root = TempDir::new("state");
+    let store = Store::open(root.path(), scratch.root()).expect("open");
+    let mut written = note(
+        "a1",
+        5,
+        "    margin.checked_mul(2).unwrap_or(margin)",
+        "use saturating_mul\nand drop the unwrap_or.\n\nreply 3\nbody 0",
+    );
+    written.reply = Some("swapped for saturating_mul; the unwrap_or went with it".to_owned());
+    written.status = Status::Resolved;
+    written.side = Side::Old;
+    store.put(&written).expect("put");
+
+    let again = Store::open(root.path(), scratch.root()).expect("open again");
+    let listing = again.list().expect("list");
+    assert_eq!(listing.notes, vec![written]);
+    assert!(listing.skipped.is_empty(), "{:?}", listing.skipped);
+}
+
+#[test]
+fn the_store_creates_nothing_until_the_first_put_and_one_put_is_one_file() {
+    let scratch = Scratch::new("notes-one-file");
+    let root = TempDir::new("state");
+    let store = Store::open(root.path(), scratch.root()).expect("open");
+    assert!(
+        !store.dir().exists(),
+        "opening the store created its directory"
+    );
+    assert!(store.list().expect("list an absent store").notes.is_empty());
+
+    store.put(&note("a1", 1, "x", "first")).expect("put");
+    assert_eq!(files_in(store.dir()), vec!["a1.note".to_owned()]);
+
+    // A status change rewrites the same file rather than adding one.
+    store.put(&note("a1", 1, "x", "second")).expect("rewrite");
+    assert_eq!(files_in(store.dir()), vec!["a1.note".to_owned()]);
+    assert_eq!(store.list().expect("list").notes[0].body, "second");
+}
+
+#[test]
+fn removing_a_note_twice_is_not_an_error() {
+    // Two panes on one worktree may both withdraw it.
+    let scratch = Scratch::new("notes-remove");
+    let root = TempDir::new("state");
+    let store = Store::open(root.path(), scratch.root()).expect("open");
+    store.put(&note("a1", 1, "x", "y")).expect("put");
+    store.remove("a1").expect("remove");
+    assert!(files_in(store.dir()).is_empty());
+    store.remove("a1").expect("a second remove is a no-op");
+    store
+        .remove("never")
+        .expect("removing what was never there is a no-op");
+}
+
+#[test]
+fn a_torn_file_and_a_newer_version_are_skipped_and_the_rest_listed() {
+    let scratch = Scratch::new("notes-skipped");
+    let root = TempDir::new("state");
+    let store = Store::open(root.path(), scratch.root()).expect("open");
+    let good = note("good", 2, "fine", "kept");
+    store.put(&good).expect("put");
+    // A write cut off by a kill: the body announces more bytes than follow.
+    fs::write(
+        store.dir().join("torn.note"),
+        "vigia note 1\nid: torn\npath: p\nside: new\nline: 1\nstatus: open\nwritten: 1\ntext: x\nbody 40\nshort\n",
+    )
+    .expect("write a torn file");
+    fs::write(
+        store.dir().join("newer.note"),
+        "vigia note 2\nid: newer\nseverity: high\n",
+    )
+    .expect("write a newer file");
+    // A write in flight from another process is neither listed nor reported.
+    fs::write(store.dir().join("inflight.1f.tmp"), "vigia note 1\nid: in").expect("write a tmp");
+
+    let listing = store.list().expect("list");
+    assert_eq!(listing.notes, vec![good]);
+    let mut skipped: Vec<(String, String)> = listing
+        .skipped
+        .iter()
+        .map(|(path, why)| {
+            (
+                path.file_name()
+                    .expect("a file name")
+                    .to_string_lossy()
+                    .into_owned(),
+                why.clone(),
+            )
+        })
+        .collect();
+    skipped.sort();
+    assert_eq!(skipped.len(), 2, "{skipped:?}");
+    assert_eq!(skipped[0].0, "newer.note");
+    assert!(skipped[0].1.contains("vigia note 2"), "{}", skipped[0].1);
+    assert_eq!(skipped[1].0, "torn.note");
+    assert!(skipped[1].1.contains("shorter"), "{}", skipped[1].1);
+}
+
+#[test]
+fn an_unwritable_root_is_an_error_the_caller_can_show() {
+    // B7's rule: a monitor that dies of its own writes is worse than none, so
+    // the failure is a value the footer can say, not a panic.
+    let scratch = Scratch::new("notes-unwritable");
+    let root = TempDir::new("state");
+    let file = root.path().join("a-file");
+    fs::write(&file, "not a directory").expect("write a file where a root would be");
+    let store = Store::open(&file, scratch.root()).expect("opening needs no directory");
+
+    let err = store
+        .put(&note("a1", 1, "x", "y"))
+        .expect_err("a file is not a root");
+    assert!(matches!(err, Error::Store { .. }), "{err:?}");
+    assert!(!err.to_string().is_empty());
+    assert!(!store.dir().exists());
+}
+
+#[test]
+fn a_listing_sees_a_whole_note_while_it_is_being_rewritten() {
+    // Temp-and-rename is what makes a mid-write listing safe; a torn read
+    // would surface as a skipped file or a body that is neither version.
+    let scratch = Scratch::new("notes-atomic");
+    let root = TempDir::new("state");
+    let store = Store::open(root.path(), scratch.root()).expect("open");
+    let a = note("w", 3, "line", &"A".repeat(8192));
+    let b = note("w", 3, "line", &"B".repeat(8192));
+    store.put(&a).expect("first put");
+
+    let writer_store = store.clone();
+    let (wa, wb) = (a.clone(), b.clone());
+    let writer = std::thread::spawn(move || {
+        for round in 0..200 {
+            let next = if round % 2 == 0 { &wb } else { &wa };
+            writer_store.put(next).expect("rewrite under a reader");
+        }
+    });
+    let mut listed = 0;
+    while !writer.is_finished() {
+        let listing = store.list().expect("list under a writer");
+        assert!(
+            listing.skipped.is_empty(),
+            "a listing saw a torn note: {:?}",
+            listing.skipped
+        );
+        for found in &listing.notes {
+            assert!(
+                found == &a || found == &b,
+                "a listing saw a note that is neither version whole"
+            );
+            listed += 1;
+        }
+    }
+    writer.join().expect("the writer finished");
+    assert!(
+        listed > 0,
+        "the reader never listed anything while the writer ran"
+    );
+    assert_eq!(
+        files_in(store.dir()),
+        vec!["w.note".to_owned()],
+        "a temporary was left behind"
+    );
+}
+
+#[test]
+fn a_line_is_found_where_it_was_then_by_its_text_nearby_then_judged_changed_or_gone() {
+    let pinned = note("r", 5, "b", "");
+    // Where it was.
+    assert_eq!(
+        resolve(&pinned, &[(4, "a"), (5, "b"), (6, "c")]),
+        Placement::At(5)
+    );
+    // An edit above pushed it down one.
+    assert_eq!(
+        resolve(&pinned, &[(4, "a"), (5, "inserted"), (6, "b"), (7, "c")]),
+        Placement::Moved(6)
+    );
+    // The line itself was edited, which is what the agent doing the note asks
+    // for looks like.
+    assert_eq!(
+        resolve(&pinned, &[(4, "a"), (5, "b2"), (6, "c")]),
+        Placement::Changed
+    );
+    // Neither the number nor the text is drawn.
+    assert_eq!(resolve(&pinned, &[(1, "a"), (2, "c")]), Placement::Gone);
+    // Its text too far away does not count as a move.
+    let far = 5 + NEAR + 1;
+    assert_eq!(
+        resolve(&pinned, &[(5, "x"), (far, "b")]),
+        Placement::Changed
+    );
+    assert_eq!(resolve(&pinned, &[(far, "b")]), Placement::Gone);
+    // The nearest copy wins, and the earlier one on a tie, in either order.
+    assert_eq!(resolve(&pinned, &[(2, "b"), (6, "b")]), Placement::Moved(6));
+    assert_eq!(resolve(&pinned, &[(3, "b"), (7, "b")]), Placement::Moved(3));
+    assert_eq!(resolve(&pinned, &[(7, "b"), (3, "b")]), Placement::Moved(3));
+    // An empty line can carry a note, and an empty line is found by its number.
+    let blank = note("e", 9, "", "");
+    assert_eq!(
+        resolve(&blank, &[(8, "x"), (9, ""), (10, "")]),
+        Placement::At(9)
+    );
+}
+
+#[test]
+fn the_state_root_follows_xdg_then_home_and_localappdata_on_windows() {
+    let env = |vars: &[(&str, &str)]| {
+        let owned: Vec<(String, String)> = vars
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect();
+        move |name: &str| {
+            owned
+                .iter()
+                .find(|(k, _)| k == name)
+                .map(|(_, v)| v.clone())
+        }
+    };
+    // Absolute on every platform, which is what the XDG rule turns on.
+    let absolute = std::env::temp_dir().join("xdg-state");
+    let absolute_str = absolute.to_str().expect("a UTF-8 temp dir");
+
+    assert_eq!(
+        state_root(
+            false,
+            &env(&[("XDG_STATE_HOME", absolute_str), ("HOME", "/home/r")])
+        ),
+        Some(absolute.join("vigia"))
+    );
+    // A relative value is invalid and ignored, per the specification.
+    assert_eq!(
+        state_root(
+            false,
+            &env(&[("XDG_STATE_HOME", "state"), ("HOME", "/home/r")])
+        ),
+        Some(PathBuf::from("/home/r/.local/state/vigia"))
+    );
+    // Set but empty is unset.
+    assert_eq!(
+        state_root(
+            false,
+            &env(&[("XDG_STATE_HOME", "  "), ("HOME", "/home/r")])
+        ),
+        Some(PathBuf::from("/home/r/.local/state/vigia"))
+    );
+    assert_eq!(
+        state_root(false, &env(&[("USERPROFILE", "/u/r")])),
+        Some(PathBuf::from("/u/r/.local/state/vigia"))
+    );
+    assert_eq!(state_root(false, &env(&[])), None);
+    assert_eq!(
+        state_root(
+            true,
+            &env(&[
+                ("LOCALAPPDATA", "C:\\Users\\r\\AppData\\Local"),
+                ("HOME", "/h")
+            ])
+        ),
+        Some(PathBuf::from("C:\\Users\\r\\AppData\\Local\\vigia\\state"))
+    );
+    assert_eq!(state_root(true, &env(&[("HOME", "/h")])), None);
+}
+
+#[cfg(windows)]
+#[test]
+fn two_spellings_of_one_path_and_a_junction_derive_one_key() {
+    // The filesystem is case-insensitive and a junction is a second name, so
+    // both are one worktree and must be one store.
+    let scratch = Scratch::new("notes-key-spelling");
+    let root = scratch.root();
+    let spelled = root.to_string_lossy().into_owned();
+    let last = spelled
+        .rsplit(['\\', '/'])
+        .next()
+        .expect("a last component")
+        .to_owned();
+    let upper = PathBuf::from(format!(
+        "{}{}",
+        &spelled[..spelled.len() - last.len()],
+        last.to_uppercase()
+    ));
+    assert_ne!(
+        upper, root,
+        "the fixture name has no letter to change case on"
+    );
+    assert_eq!(
+        key(root).expect("key"),
+        key(&upper).expect("key of the other spelling")
+    );
+
+    let holder = TempDir::new("junction");
+    let link = holder.path().join("link");
+    let made = std::process::Command::new("cmd")
+        .args(["/C", "mklink", "/J"])
+        .arg(&link)
+        .arg(root)
+        .output()
+        .expect("run mklink");
+    assert!(
+        made.status.success(),
+        "mklink: {}",
+        String::from_utf8_lossy(&made.stderr)
+    );
+    assert_eq!(
+        key(root).expect("key"),
+        key(&link).expect("key through the junction")
+    );
+}

--- a/crates/vigia-core/tests/notes.rs
+++ b/crates/vigia-core/tests/notes.rs
@@ -362,6 +362,52 @@ fn a_file_whose_name_is_not_a_note_id_is_not_read() {
 }
 
 #[test]
+fn a_torn_file_and_a_newer_version_are_skipped_and_the_rest_listed() {
+    let (_scratch, _root, store) = store("notes-skipped");
+    let good = note("good", 2, "fine", "kept");
+    store.put(&good).expect("put");
+    // A write cut off by a kill: the body announces more bytes than follow.
+    fs::write(
+        store.dir().join("torn.note"),
+        "vigia note 1\nid: torn\nside: new\nline: 1\nstatus: open\nwritten: 1\npath 1\np\ntext 1\nx\nbody 40\nshort\n",
+    )
+    .expect("write a torn file");
+    fs::write(
+        store.dir().join("newer.note"),
+        "vigia note 2\nid: newer\nseverity: high\n",
+    )
+    .expect("write a newer file");
+    // A write in flight from another process is neither listed nor reported.
+    fs::write(
+        store.dir().join("inflight.1f-2.tmp"),
+        "vigia note 1\nid: in",
+    )
+    .expect("write a tmp");
+
+    let listing = store.list().expect("list");
+    assert_eq!(listing.notes, vec![good]);
+    let mut skipped: Vec<(String, String)> = listing
+        .skipped
+        .iter()
+        .map(|(path, why)| {
+            (
+                path.file_name()
+                    .expect("a file name")
+                    .to_string_lossy()
+                    .into_owned(),
+                why.clone(),
+            )
+        })
+        .collect();
+    skipped.sort();
+    assert_eq!(skipped.len(), 2, "{skipped:?}");
+    assert_eq!(skipped[0].0, "newer.note");
+    assert!(skipped[0].1.contains("vigia note 2"), "{}", skipped[0].1);
+    assert_eq!(skipped[1].0, "torn.note");
+    assert!(skipped[1].1.contains("shorter"), "{}", skipped[1].1);
+}
+
+#[test]
 fn a_number_too_large_for_the_file_is_a_skip_and_never_a_panic() {
     // A corrupt note costs that note and never the process.
     let (_scratch, _root, store) = store("notes-huge");

--- a/crates/vigia-core/tests/notes.rs
+++ b/crates/vigia-core/tests/notes.rs
@@ -211,9 +211,24 @@ fn removing_a_note_twice_is_not_an_error() {
 
 #[test]
 fn an_id_that_could_name_a_file_outside_the_store_is_refused() {
-    // The server will hand the store ids an agent typed.
+    // An id here may be one an agent typed, handed through the server.
     let (_scratch, _root, store) = store("notes-id");
-    for bad in ["../../evil", "a/b", "a\\b", "", ".", "..", "a b", "a\0b"] {
+    let long = "x".repeat(65);
+    for bad in [
+        "../../evil",
+        "a/b",
+        "a\\b",
+        "",
+        ".",
+        "..",
+        "a b",
+        "a\0b",
+        "CON",
+        "nul",
+        "COM1",
+        "lpt9",
+        long.as_str(),
+    ] {
         let err = store
             .put(&note(bad, 1, "x", "y"))
             .expect_err("an id that is not a note id");
@@ -225,6 +240,83 @@ fn an_id_that_could_name_a_file_outside_the_store_is_refused() {
     store
         .put(&note("ok-1", 1, "x", "y"))
         .expect("a plain id is fine");
+    let longest = "y".repeat(64);
+    store
+        .put(&note(&longest, 1, "x", "y"))
+        .expect("sixty-four is the longest id");
+    store
+        .put(&note("COM0", 1, "x", "y"))
+        .expect("COM0 names no device");
+}
+
+#[test]
+fn a_minted_id_is_one_the_store_accepts() {
+    let (_scratch, _root, store) = store("notes-minted");
+    let first = Store::new_id();
+    let second = Store::new_id();
+    assert_ne!(first, second, "two ids minted in a row must differ");
+    store
+        .put(&note(&first, 1, "x", "y"))
+        .expect("a minted id is a note id");
+    store
+        .put(&note(&second, 2, "x", "y"))
+        .expect("and so is the next");
+    assert_eq!(store.list().expect("list").notes.len(), 2);
+}
+
+#[test]
+fn a_file_whose_id_is_not_its_name_is_skipped() {
+    // A rogue file naming another note's id would point a later removal at
+    // the wrong file and survive every listing itself.
+    let (_scratch, _root, store) = store("notes-rogue");
+    let real = note("real", 1, "x", "kept");
+    store.put(&real).expect("put");
+    let encoded = fs::read(store.dir().join("real.note")).expect("read the note back");
+    fs::write(store.dir().join("rogue.note"), &encoded).expect("write a rogue copy");
+
+    let listing = store.list().expect("list");
+    assert_eq!(listing.notes, vec![real]);
+    assert_eq!(listing.skipped.len(), 1, "{:?}", listing.skipped);
+    assert!(
+        listing.skipped[0].1.contains("not its file name"),
+        "{}",
+        listing.skipped[0].1
+    );
+}
+
+#[test]
+fn a_repeated_field_or_trailing_bytes_are_a_skip() {
+    let (_scratch, _root, store) = store("notes-repeat");
+    store.put(&note("good", 1, "x", "kept")).expect("put");
+    let good = fs::read_to_string(store.dir().join("good.note")).expect("read it back");
+    let twice = good.replacen("side: new\n", "side: new\nside: old\n", 1);
+    assert_ne!(twice, good);
+    fs::write(store.dir().join("twice.note"), &twice).expect("write a repeated field");
+    fs::write(store.dir().join("trailing.note"), format!("{good}extra\n"))
+        .expect("write trailing bytes");
+    let reordered = good.replacen("id: good\nside: new\n", "side: new\nid: good\n", 1);
+    assert_ne!(reordered, good);
+    fs::write(store.dir().join("good.note"), &reordered).expect("write reordered fields");
+
+    let listing = store.list().expect("list");
+    assert_eq!(listing.notes.len(), 1, "{:?}", listing.skipped);
+    let mut skipped: Vec<String> = listing
+        .skipped
+        .iter()
+        .map(|(path, _)| {
+            path.file_name()
+                .expect("a name")
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    skipped.sort();
+    // Field order is not part of the format, so the note read back in another
+    // order is the same note.
+    assert_eq!(
+        skipped,
+        vec!["trailing.note".to_owned(), "twice.note".to_owned()]
+    );
 }
 
 #[test]
@@ -353,6 +445,7 @@ fn rewrite_under_a_reader(name: &str, writers: usize) {
         })
         .collect();
     let mut listed = 0;
+    let (mut saw_a, mut saw_b) = (false, false);
     while handles.iter().any(|h| !h.is_finished()) {
         let listing = store.list().expect("list under a writer");
         assert!(
@@ -365,6 +458,8 @@ fn rewrite_under_a_reader(name: &str, writers: usize) {
                 found == &a || found == &b,
                 "a listing saw a note that is neither version whole"
             );
+            saw_a |= found == &a;
+            saw_b |= found == &b;
             listed += 1;
         }
     }
@@ -374,6 +469,10 @@ fn rewrite_under_a_reader(name: &str, writers: usize) {
     assert!(
         listed > 0,
         "the reader never listed anything while the writers ran"
+    );
+    assert!(
+        saw_a && saw_b,
+        "the reader saw one version only, so nothing was rewritten under it"
     );
     assert_eq!(
         files_in(store.dir()),

--- a/crates/vigia-core/tests/notes.rs
+++ b/crates/vigia-core/tests/notes.rs
@@ -227,6 +227,8 @@ fn an_id_that_could_name_a_file_outside_the_store_is_refused() {
         "nul",
         "COM1",
         "lpt9",
+        "AB1",
+        "Ab-1",
         long.as_str(),
     ] {
         let err = store
@@ -245,8 +247,8 @@ fn an_id_that_could_name_a_file_outside_the_store_is_refused() {
         .put(&note(&longest, 1, "x", "y"))
         .expect("sixty-four is the longest id");
     store
-        .put(&note("COM0", 1, "x", "y"))
-        .expect("COM0 names no device");
+        .put(&note("com0", 1, "x", "y"))
+        .expect("com0 names no device");
 }
 
 #[test]
@@ -284,85 +286,79 @@ fn a_file_whose_id_is_not_its_name_is_skipped() {
     );
 }
 
+/// The note `good` as the store wrote it, and its file's text.
+fn good_note(store: &Store) -> (Note, String) {
+    let mut good = note("good", 1, "x", "kept");
+    good.reply = Some("done".to_owned());
+    store.put(&good).expect("put");
+    let text = fs::read_to_string(store.dir().join("good.note")).expect("read it back");
+    (good, text)
+}
+
 #[test]
-fn a_repeated_field_or_trailing_bytes_are_a_skip() {
+fn a_repeated_field_is_a_skip() {
     let (_scratch, _root, store) = store("notes-repeat");
-    store.put(&note("good", 1, "x", "kept")).expect("put");
-    let good = fs::read_to_string(store.dir().join("good.note")).expect("read it back");
-    let twice = good.replacen("side: new\n", "side: new\nside: old\n", 1);
-    assert_ne!(twice, good);
-    fs::write(store.dir().join("twice.note"), &twice).expect("write a repeated field");
-    fs::write(store.dir().join("trailing.note"), format!("{good}extra\n"))
-        .expect("write trailing bytes");
-    let reordered = good.replacen("id: good\nside: new\n", "side: new\nid: good\n", 1);
-    assert_ne!(reordered, good);
-    fs::write(store.dir().join("good.note"), &reordered).expect("write reordered fields");
+    let (good, text) = good_note(&store);
+    let twice = text.replacen("side: new\n", "side: new\nside: old\n", 1);
+    assert_ne!(twice, text);
+    fs::write(store.dir().join("good.note"), &twice).expect("write a repeated field");
 
     let listing = store.list().expect("list");
-    assert_eq!(listing.notes.len(), 1, "{:?}", listing.skipped);
-    let mut skipped: Vec<String> = listing
-        .skipped
-        .iter()
-        .map(|(path, _)| {
-            path.file_name()
-                .expect("a name")
-                .to_string_lossy()
-                .into_owned()
-        })
-        .collect();
-    skipped.sort();
-    // Field order is not part of the format, so the note read back in another
-    // order is the same note.
-    assert_eq!(
-        skipped,
-        vec!["trailing.note".to_owned(), "twice.note".to_owned()]
+    assert!(listing.notes.is_empty(), "{:?}", listing.notes);
+    assert_eq!(listing.skipped.len(), 1);
+    assert!(
+        listing.skipped[0].1.contains("twice"),
+        "{}",
+        listing.skipped[0].1
+    );
+    assert_ne!(listing.skipped[0].1, good.body);
+}
+
+#[test]
+fn trailing_bytes_are_a_skip() {
+    let (_scratch, _root, store) = store("notes-trailing");
+    let (_good, text) = good_note(&store);
+    fs::write(store.dir().join("good.note"), format!("{text}extra\n"))
+        .expect("write trailing bytes");
+
+    let listing = store.list().expect("list");
+    assert!(listing.notes.is_empty(), "{:?}", listing.notes);
+    assert_eq!(listing.skipped.len(), 1);
+    assert!(
+        listing.skipped[0].1.contains("follow"),
+        "{}",
+        listing.skipped[0].1
     );
 }
 
 #[test]
-fn a_torn_file_and_a_newer_version_are_skipped_and_the_rest_listed() {
-    let (_scratch, _root, store) = store("notes-skipped");
-    let good = note("good", 2, "fine", "kept");
-    store.put(&good).expect("put");
-    // A write cut off by a kill: the body announces more bytes than follow.
-    fs::write(
-        store.dir().join("torn.note"),
-        "vigia note 1\nid: torn\nside: new\nline: 1\nstatus: open\nwritten: 1\npath 1\np\ntext 1\nx\nbody 40\nshort\n",
-    )
-    .expect("write a torn file");
-    fs::write(
-        store.dir().join("newer.note"),
-        "vigia note 2\nid: newer\nseverity: high\n",
-    )
-    .expect("write a newer file");
-    // A write in flight from another process is neither listed nor reported.
-    fs::write(
-        store.dir().join("inflight.1f-2.tmp"),
-        "vigia note 1\nid: in",
-    )
-    .expect("write a tmp");
+fn a_note_read_back_in_another_field_order_is_the_same_note() {
+    let (_scratch, _root, store) = store("notes-reordered");
+    let (good, text) = good_note(&store);
+    let reordered = text.replacen("id: good\nside: new\n", "side: new\nid: good\n", 1);
+    assert_ne!(reordered, text);
+    fs::write(store.dir().join("good.note"), &reordered).expect("write reordered fields");
 
     let listing = store.list().expect("list");
     assert_eq!(listing.notes, vec![good]);
-    let mut skipped: Vec<(String, String)> = listing
-        .skipped
-        .iter()
-        .map(|(path, why)| {
-            (
-                path.file_name()
-                    .expect("a file name")
-                    .to_string_lossy()
-                    .into_owned(),
-                why.clone(),
-            )
-        })
-        .collect();
-    skipped.sort();
-    assert_eq!(skipped.len(), 2, "{skipped:?}");
-    assert_eq!(skipped[0].0, "newer.note");
-    assert!(skipped[0].1.contains("vigia note 2"), "{}", skipped[0].1);
-    assert_eq!(skipped[1].0, "torn.note");
-    assert!(skipped[1].1.contains("shorter"), "{}", skipped[1].1);
+    assert!(listing.skipped.is_empty(), "{:?}", listing.skipped);
+}
+
+#[test]
+fn a_file_whose_name_is_not_a_note_id_is_not_read() {
+    // The same rule that keeps a device name out of put keeps it out of read.
+    let (_scratch, _root, store) = store("notes-bad-name");
+    let (good, _text) = good_note(&store);
+    fs::write(store.dir().join("Bad Name.note"), "anything").expect("write a badly named file");
+
+    let listing = store.list().expect("list");
+    assert_eq!(listing.notes, vec![good]);
+    assert_eq!(listing.skipped.len(), 1, "{:?}", listing.skipped);
+    assert!(
+        listing.skipped[0].1.contains("not named by a note id"),
+        "{}",
+        listing.skipped[0].1
+    );
 }
 
 #[test]
@@ -404,6 +400,12 @@ fn a_number_too_large_for_the_file_is_a_skip_and_never_a_panic() {
     assert_eq!(listing.notes.len(), 1);
     assert_eq!(listing.skipped.len(), files.len(), "{:?}", listing.skipped);
     assert!(listing.skipped.iter().all(|(_, why)| !why.is_empty()));
+    let version_only = listing
+        .skipped
+        .iter()
+        .find(|(path, _)| path.ends_with("version-only.note"))
+        .expect("the version-only file was skipped");
+    assert!(version_only.1.contains("ends before"), "{}", version_only.1);
 }
 
 #[test]
@@ -427,8 +429,7 @@ fn an_unwritable_root_is_an_error_the_caller_can_show() {
 #[test]
 fn a_failed_rename_leaves_no_temporary_behind() {
     // A directory where the note's file would go makes the rename fail on
-    // every platform; what must not follow is a temporary the next listing
-    // has to step over forever.
+    // every platform.
     let (_scratch, _root, store) = store("notes-litter");
     store
         .put(&note("other", 1, "x", "y"))
@@ -447,26 +448,36 @@ fn a_failed_rename_leaves_no_temporary_behind() {
 }
 
 /// Rewrites one note between two versions from `writers` threads while the
-/// caller lists, and asserts every listing saw one version whole.
+/// caller lists, and asserts every listing saw one version whole and both
+/// versions were seen. The writers stop once the reader has seen both, or
+/// after a bounded number of rounds, so a starved reader fails on what it saw
+/// rather than on timing.
 fn rewrite_under_a_reader(name: &str, writers: usize) {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     let (_scratch, _root, store) = store(name);
     let a = note("w", 3, "line", &"A".repeat(8192));
     let b = note("w", 3, "line", &"B".repeat(8192));
     store.put(&a).expect("first put");
 
+    let seen_both = Arc::new(AtomicBool::new(false));
     let handles: Vec<_> = (0..writers)
         .map(|w| {
             let writer_store = store.clone();
             let (wa, wb) = (a.clone(), b.clone());
+            let seen_both = Arc::clone(&seen_both);
             std::thread::spawn(move || {
-                for round in 0..200 {
+                for round in 0..4000 {
+                    if seen_both.load(Ordering::Relaxed) {
+                        break;
+                    }
                     let next = if (round + w) % 2 == 0 { &wb } else { &wa };
                     writer_store.put(next).expect("rewrite under a reader");
                 }
             })
         })
         .collect();
-    let mut listed = 0;
     let (mut saw_a, mut saw_b) = (false, false);
     while handles.iter().any(|h| !h.is_finished()) {
         let listing = store.list().expect("list under a writer");
@@ -482,16 +493,15 @@ fn rewrite_under_a_reader(name: &str, writers: usize) {
             );
             saw_a |= found == &a;
             saw_b |= found == &b;
-            listed += 1;
         }
+        if saw_a && saw_b {
+            seen_both.store(true, Ordering::Relaxed);
+        }
+        std::thread::yield_now();
     }
     for handle in handles {
         handle.join().expect("a writer finished");
     }
-    assert!(
-        listed > 0,
-        "the reader never listed anything while the writers ran"
-    );
     assert!(
         saw_a && saw_b,
         "the reader saw one version only, so nothing was rewritten under it"

--- a/crates/vigia-core/tests/notes.rs
+++ b/crates/vigia-core/tests/notes.rs
@@ -4,7 +4,7 @@
 mod support;
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::{Duration, UNIX_EPOCH};
 
 use support::{Scratch, TempDir};
@@ -39,6 +39,14 @@ fn files_in(dir: &Path) -> Vec<String> {
     names
 }
 
+/// A store on a fresh state root for a fresh repository.
+fn store(name: &str) -> (Scratch, TempDir, Store) {
+    let scratch = Scratch::new(name);
+    let root = TempDir::new("state");
+    let store = Store::open(root.path(), scratch.root()).expect("open");
+    (scratch, root, store)
+}
+
 #[test]
 fn the_key_is_one_value_for_one_worktree_from_any_path_inside_it() {
     // Two processes start from two paths: the pane from wherever it was
@@ -62,6 +70,19 @@ fn the_key_is_one_value_for_one_worktree_from_any_path_inside_it() {
 
     let other = Scratch::new("notes-key-other");
     assert_ne!(from_root, key(other.root()).expect("another key"));
+}
+
+#[test]
+fn a_workdir_that_does_not_exist_has_no_key() {
+    let holder = TempDir::new("missing");
+    let missing = holder.path().join("never-made");
+    let err = key(&missing).expect_err("no key for a path that is not there");
+    assert!(matches!(err, Error::Canonicalise { .. }), "{err:?}");
+    assert!(err.to_string().contains("never-made"), "{err}");
+    assert!(
+        Store::open(holder.path(), &missing).is_err(),
+        "a store opened on a missing worktree would key nothing"
+    );
 }
 
 #[test]
@@ -89,35 +110,72 @@ fn a_linked_worktree_has_its_own_key() {
     );
 }
 
+#[cfg(unix)]
 #[test]
-fn a_note_put_by_one_handle_is_read_whole_by_another() {
-    // The pane quitting and coming back, or the server reading what the pane
-    // wrote: a second handle on the same worktree sees every field.
-    let scratch = Scratch::new("notes-roundtrip");
-    let root = TempDir::new("state");
-    let store = Store::open(root.path(), scratch.root()).expect("open");
-    let mut written = note(
-        "a1",
-        5,
-        "    margin.checked_mul(2).unwrap_or(margin)",
-        "use saturating_mul\nand drop the unwrap_or.\n\nreply 3\nbody 0",
+fn a_symlinked_worktree_root_derives_the_same_key() {
+    // A second name for one directory is one worktree, and must be one store.
+    let scratch = Scratch::new("notes-key-symlink");
+    let holder = TempDir::new("symlink");
+    let link = holder.path().join("link");
+    std::os::unix::fs::symlink(scratch.root(), &link).expect("make a symlink");
+    assert_eq!(
+        key(scratch.root()).expect("key"),
+        key(&link).expect("key through the symlink")
     );
-    written.reply = Some("swapped for saturating_mul; the unwrap_or went with it".to_owned());
-    written.status = Status::Resolved;
-    written.side = Side::Old;
-    store.put(&written).expect("put");
+}
+
+#[test]
+fn every_field_of_a_note_is_read_back_whole_by_a_second_handle() {
+    // The pane quitting and coming back, or the server reading what the pane
+    // wrote: a second handle on the same worktree sees every field, at every
+    // status and on either side, with a body that holds the format's own words.
+    let (scratch, root, store) = store("notes-roundtrip");
+    let mut notes = Vec::new();
+    for (i, (status, side)) in [
+        (Status::Open, Side::New),
+        (Status::Seen, Side::Old),
+        (Status::Resolved, Side::New),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let mut written = note(
+            &format!("n{i}"),
+            5,
+            "    margin.checked_mul(2).unwrap_or(margin)",
+            "use saturating_mul\nand drop the unwrap_or.\n\nreply 3\nbody 0\npath 1",
+        );
+        written.reply = Some(format!("swapped for saturating_mul {i}"));
+        written.status = status;
+        written.side = side;
+        written.written = UNIX_EPOCH + Duration::from_secs(1_800_000_000 + i as u64);
+        store.put(&written).expect("put");
+        notes.push(written);
+    }
 
     let again = Store::open(root.path(), scratch.root()).expect("open again");
     let listing = again.list().expect("list");
+    assert_eq!(listing.notes, notes);
+    assert!(listing.skipped.is_empty(), "{:?}", listing.skipped);
+}
+
+#[test]
+fn a_path_or_a_line_with_a_newline_in_it_cannot_forge_a_field() {
+    // A file name may hold a newline on Unix, and a line of code may hold a
+    // carriage return; neither may become a header the decoder believes.
+    let (_scratch, _root, store) = store("notes-forge");
+    let mut written = note("f1", 1, "a\rb", "body");
+    written.path = "x\nid: stolen\nbody 0".to_owned();
+    store.put(&written).expect("put");
+
+    let listing = store.list().expect("list");
     assert_eq!(listing.notes, vec![written]);
     assert!(listing.skipped.is_empty(), "{:?}", listing.skipped);
 }
 
 #[test]
-fn the_store_creates_nothing_until_the_first_put_and_one_put_is_one_file() {
-    let scratch = Scratch::new("notes-one-file");
-    let root = TempDir::new("state");
-    let store = Store::open(root.path(), scratch.root()).expect("open");
+fn the_store_creates_nothing_until_the_first_put() {
+    let (_scratch, _root, store) = store("notes-lazy");
     assert!(
         !store.dir().exists(),
         "opening the store created its directory"
@@ -126,8 +184,13 @@ fn the_store_creates_nothing_until_the_first_put_and_one_put_is_one_file() {
 
     store.put(&note("a1", 1, "x", "first")).expect("put");
     assert_eq!(files_in(store.dir()), vec!["a1.note".to_owned()]);
+}
 
+#[test]
+fn a_rewrite_reuses_the_note_file() {
     // A status change rewrites the same file rather than adding one.
+    let (_scratch, _root, store) = store("notes-rewrite");
+    store.put(&note("a1", 1, "x", "first")).expect("put");
     store.put(&note("a1", 1, "x", "second")).expect("rewrite");
     assert_eq!(files_in(store.dir()), vec!["a1.note".to_owned()]);
     assert_eq!(store.list().expect("list").notes[0].body, "second");
@@ -136,9 +199,7 @@ fn the_store_creates_nothing_until_the_first_put_and_one_put_is_one_file() {
 #[test]
 fn removing_a_note_twice_is_not_an_error() {
     // Two panes on one worktree may both withdraw it.
-    let scratch = Scratch::new("notes-remove");
-    let root = TempDir::new("state");
-    let store = Store::open(root.path(), scratch.root()).expect("open");
+    let (_scratch, _root, store) = store("notes-remove");
     store.put(&note("a1", 1, "x", "y")).expect("put");
     store.remove("a1").expect("remove");
     assert!(files_in(store.dir()).is_empty());
@@ -149,16 +210,32 @@ fn removing_a_note_twice_is_not_an_error() {
 }
 
 #[test]
+fn an_id_that_could_name_a_file_outside_the_store_is_refused() {
+    // The server will hand the store ids an agent typed.
+    let (_scratch, _root, store) = store("notes-id");
+    for bad in ["../../evil", "a/b", "a\\b", "", ".", "..", "a b", "a\0b"] {
+        let err = store
+            .put(&note(bad, 1, "x", "y"))
+            .expect_err("an id that is not a note id");
+        assert!(matches!(err, Error::Store { .. }), "{bad:?}: {err:?}");
+        assert!(err.to_string().contains("not a note id"), "{bad:?}: {err}");
+        assert!(store.remove(bad).is_err(), "{bad:?} was accepted by remove");
+    }
+    assert!(!store.dir().exists(), "a refused put created the directory");
+    store
+        .put(&note("ok-1", 1, "x", "y"))
+        .expect("a plain id is fine");
+}
+
+#[test]
 fn a_torn_file_and_a_newer_version_are_skipped_and_the_rest_listed() {
-    let scratch = Scratch::new("notes-skipped");
-    let root = TempDir::new("state");
-    let store = Store::open(root.path(), scratch.root()).expect("open");
+    let (_scratch, _root, store) = store("notes-skipped");
     let good = note("good", 2, "fine", "kept");
     store.put(&good).expect("put");
     // A write cut off by a kill: the body announces more bytes than follow.
     fs::write(
         store.dir().join("torn.note"),
-        "vigia note 1\nid: torn\npath: p\nside: new\nline: 1\nstatus: open\nwritten: 1\ntext: x\nbody 40\nshort\n",
+        "vigia note 1\nid: torn\nside: new\nline: 1\nstatus: open\nwritten: 1\npath 1\np\ntext 1\nx\nbody 40\nshort\n",
     )
     .expect("write a torn file");
     fs::write(
@@ -167,7 +244,11 @@ fn a_torn_file_and_a_newer_version_are_skipped_and_the_rest_listed() {
     )
     .expect("write a newer file");
     // A write in flight from another process is neither listed nor reported.
-    fs::write(store.dir().join("inflight.1f.tmp"), "vigia note 1\nid: in").expect("write a tmp");
+    fs::write(
+        store.dir().join("inflight.1f-2.tmp"),
+        "vigia note 1\nid: in",
+    )
+    .expect("write a tmp");
 
     let listing = store.list().expect("list");
     assert_eq!(listing.notes, vec![good]);
@@ -193,6 +274,47 @@ fn a_torn_file_and_a_newer_version_are_skipped_and_the_rest_listed() {
 }
 
 #[test]
+fn a_number_too_large_for_the_file_is_a_skip_and_never_a_panic() {
+    // A corrupt note costs that note and never the process.
+    let (_scratch, _root, store) = store("notes-huge");
+    store.put(&note("good", 1, "x", "kept")).expect("put");
+    let head = "vigia note 1\nid: h\nside: new\nline: 1\nstatus: open\n";
+    let files = [
+        (
+            "body.note",
+            format!(
+                "{head}written: 1\npath 1\np\ntext 1\nx\nbody {}\n\n",
+                usize::MAX
+            ),
+        ),
+        (
+            "reply.note",
+            format!(
+                "{head}written: 1\npath 1\np\ntext 1\nx\nbody 0\n\nreply {}\n\n",
+                usize::MAX
+            ),
+        ),
+        (
+            "time.note",
+            format!(
+                "{head}written: {}\npath 1\np\ntext 1\nx\nbody 0\n\n",
+                u64::MAX
+            ),
+        ),
+        ("empty.note", String::new()),
+        ("version-only.note", "vigia note 1\n".to_owned()),
+    ];
+    for (name, contents) in &files {
+        fs::write(store.dir().join(name), contents).expect("write a hostile file");
+    }
+
+    let listing = store.list().expect("list survives every file");
+    assert_eq!(listing.notes.len(), 1);
+    assert_eq!(listing.skipped.len(), files.len(), "{:?}", listing.skipped);
+    assert!(listing.skipped.iter().all(|(_, why)| !why.is_empty()));
+}
+
+#[test]
 fn an_unwritable_root_is_an_error_the_caller_can_show() {
     // B7's rule: a monitor that dies of its own writes is worse than none, so
     // the failure is a value the footer can say, not a panic.
@@ -210,27 +332,28 @@ fn an_unwritable_root_is_an_error_the_caller_can_show() {
     assert!(!store.dir().exists());
 }
 
-#[test]
-fn a_listing_sees_a_whole_note_while_it_is_being_rewritten() {
-    // Temp-and-rename is what makes a mid-write listing safe; a torn read
-    // would surface as a skipped file or a body that is neither version.
-    let scratch = Scratch::new("notes-atomic");
-    let root = TempDir::new("state");
-    let store = Store::open(root.path(), scratch.root()).expect("open");
+/// Rewrites one note between two versions from `writers` threads while the
+/// caller lists, and asserts every listing saw one version whole.
+fn rewrite_under_a_reader(name: &str, writers: usize) {
+    let (_scratch, _root, store) = store(name);
     let a = note("w", 3, "line", &"A".repeat(8192));
     let b = note("w", 3, "line", &"B".repeat(8192));
     store.put(&a).expect("first put");
 
-    let writer_store = store.clone();
-    let (wa, wb) = (a.clone(), b.clone());
-    let writer = std::thread::spawn(move || {
-        for round in 0..200 {
-            let next = if round % 2 == 0 { &wb } else { &wa };
-            writer_store.put(next).expect("rewrite under a reader");
-        }
-    });
+    let handles: Vec<_> = (0..writers)
+        .map(|w| {
+            let writer_store = store.clone();
+            let (wa, wb) = (a.clone(), b.clone());
+            std::thread::spawn(move || {
+                for round in 0..200 {
+                    let next = if (round + w) % 2 == 0 { &wb } else { &wa };
+                    writer_store.put(next).expect("rewrite under a reader");
+                }
+            })
+        })
+        .collect();
     let mut listed = 0;
-    while !writer.is_finished() {
+    while handles.iter().any(|h| !h.is_finished()) {
         let listing = store.list().expect("list under a writer");
         assert!(
             listing.skipped.is_empty(),
@@ -245,16 +368,31 @@ fn a_listing_sees_a_whole_note_while_it_is_being_rewritten() {
             listed += 1;
         }
     }
-    writer.join().expect("the writer finished");
+    for handle in handles {
+        handle.join().expect("a writer finished");
+    }
     assert!(
         listed > 0,
-        "the reader never listed anything while the writer ran"
+        "the reader never listed anything while the writers ran"
     );
     assert_eq!(
         files_in(store.dir()),
         vec!["w.note".to_owned()],
         "a temporary was left behind"
     );
+}
+
+#[test]
+fn a_listing_sees_a_whole_note_while_it_is_being_rewritten() {
+    // Temp-and-rename is what makes a mid-write listing safe; a torn read
+    // would surface as a skipped file or a body that is neither version.
+    rewrite_under_a_reader("notes-atomic", 1);
+}
+
+#[test]
+fn two_writers_in_one_process_never_produce_a_mixed_note() {
+    // Threads share a process id, so the temporary's name needs more than it.
+    rewrite_under_a_reader("notes-atomic-threads", 2);
 }
 
 #[test]
@@ -289,6 +427,8 @@ fn a_line_is_found_where_it_was_then_by_its_text_nearby_then_judged_changed_or_g
     assert_eq!(resolve(&pinned, &[(2, "b"), (6, "b")]), Placement::Moved(6));
     assert_eq!(resolve(&pinned, &[(3, "b"), (7, "b")]), Placement::Moved(3));
     assert_eq!(resolve(&pinned, &[(7, "b"), (3, "b")]), Placement::Moved(3));
+    // An exact match wins over a nearer duplicate that came first.
+    assert_eq!(resolve(&pinned, &[(4, "b"), (5, "b")]), Placement::At(5));
     // An empty line can carry a note, and an empty line is found by its number.
     let blank = note("e", 9, "", "");
     assert_eq!(
@@ -310,7 +450,7 @@ fn two_spellings_of_one_path_and_a_junction_derive_one_key() {
         .next()
         .expect("a last component")
         .to_owned();
-    let upper = PathBuf::from(format!(
+    let upper = std::path::PathBuf::from(format!(
         "{}{}",
         &spelled[..spelled.len() - last.len()],
         last.to_uppercase()

--- a/crates/vigia-core/tests/notes.rs
+++ b/crates/vigia-core/tests/notes.rs
@@ -424,6 +424,28 @@ fn an_unwritable_root_is_an_error_the_caller_can_show() {
     assert!(!store.dir().exists());
 }
 
+#[test]
+fn a_failed_rename_leaves_no_temporary_behind() {
+    // A directory where the note's file would go makes the rename fail on
+    // every platform; what must not follow is a temporary the next listing
+    // has to step over forever.
+    let (_scratch, _root, store) = store("notes-litter");
+    store
+        .put(&note("other", 1, "x", "y"))
+        .expect("put creates the directory");
+    fs::create_dir(store.dir().join("blocked.note")).expect("a directory in the way");
+
+    let err = store
+        .put(&note("blocked", 1, "x", "y"))
+        .expect_err("a rename onto a directory fails");
+    assert!(matches!(err, Error::Store { .. }), "{err:?}");
+    assert_eq!(
+        files_in(store.dir()),
+        vec!["blocked.note".to_owned(), "other.note".to_owned()],
+        "a temporary was left behind"
+    );
+}
+
 /// Rewrites one note between two versions from `writers` threads while the
 /// caller lists, and asserts every listing saw one version whole.
 fn rewrite_under_a_reader(name: &str, writers: usize) {

--- a/crates/vigia-core/tests/notes.rs
+++ b/crates/vigia-core/tests/notes.rs
@@ -5,41 +5,10 @@ mod support;
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, UNIX_EPOCH};
 
-use support::Scratch;
-use vigia_core::{
-    Error, NEAR, Note, Placement, Side, Status, Store, Worktree, key, resolve, state_root,
-};
-
-/// A directory the test owns, removed on drop, for a state root that is not
-/// the reader's.
-struct TempDir(PathBuf);
-
-impl TempDir {
-    fn new(name: &str) -> Self {
-        static COUNTER: AtomicU32 = AtomicU32::new(0);
-        let path = std::env::temp_dir().join(format!(
-            "vigia-notes-{}-{}-{name}",
-            std::process::id(),
-            COUNTER.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = fs::remove_dir_all(&path);
-        fs::create_dir_all(&path).expect("create a temp dir");
-        Self(path)
-    }
-
-    fn path(&self) -> &Path {
-        &self.0
-    }
-}
-
-impl Drop for TempDir {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.0);
-    }
-}
+use support::{Scratch, TempDir};
+use vigia_core::{Error, NEAR, Note, Placement, Side, Status, Store, Worktree, key, resolve};
 
 fn note(id: &str, line: u32, text: &str, body: &str) -> Note {
     Note {
@@ -326,65 +295,6 @@ fn a_line_is_found_where_it_was_then_by_its_text_nearby_then_judged_changed_or_g
         resolve(&blank, &[(8, "x"), (9, ""), (10, "")]),
         Placement::At(9)
     );
-}
-
-#[test]
-fn the_state_root_follows_xdg_then_home_and_localappdata_on_windows() {
-    let env = |vars: &[(&str, &str)]| {
-        let owned: Vec<(String, String)> = vars
-            .iter()
-            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
-            .collect();
-        move |name: &str| {
-            owned
-                .iter()
-                .find(|(k, _)| k == name)
-                .map(|(_, v)| v.clone())
-        }
-    };
-    // Absolute on every platform, which is what the XDG rule turns on.
-    let absolute = std::env::temp_dir().join("xdg-state");
-    let absolute_str = absolute.to_str().expect("a UTF-8 temp dir");
-
-    assert_eq!(
-        state_root(
-            false,
-            &env(&[("XDG_STATE_HOME", absolute_str), ("HOME", "/home/r")])
-        ),
-        Some(absolute.join("vigia"))
-    );
-    // A relative value is invalid and ignored, per the specification.
-    assert_eq!(
-        state_root(
-            false,
-            &env(&[("XDG_STATE_HOME", "state"), ("HOME", "/home/r")])
-        ),
-        Some(PathBuf::from("/home/r/.local/state/vigia"))
-    );
-    // Set but empty is unset.
-    assert_eq!(
-        state_root(
-            false,
-            &env(&[("XDG_STATE_HOME", "  "), ("HOME", "/home/r")])
-        ),
-        Some(PathBuf::from("/home/r/.local/state/vigia"))
-    );
-    assert_eq!(
-        state_root(false, &env(&[("USERPROFILE", "/u/r")])),
-        Some(PathBuf::from("/u/r/.local/state/vigia"))
-    );
-    assert_eq!(state_root(false, &env(&[])), None);
-    assert_eq!(
-        state_root(
-            true,
-            &env(&[
-                ("LOCALAPPDATA", "C:\\Users\\r\\AppData\\Local"),
-                ("HOME", "/h")
-            ])
-        ),
-        Some(PathBuf::from("C:\\Users\\r\\AppData\\Local\\vigia\\state"))
-    );
-    assert_eq!(state_root(true, &env(&[("HOME", "/h")])), None);
 }
 
 #[cfg(windows)]

--- a/crates/vigia-core/tests/support/mod.rs
+++ b/crates/vigia-core/tests/support/mod.rs
@@ -567,6 +567,44 @@ fn tree_fingerprint(root: &Path) -> Vec<(PathBuf, u64, Option<std::time::SystemT
     found
 }
 
+/// An empty directory under `parent` that no other test or process is using.
+fn unique_dir(parent: &Path, name: &str) -> PathBuf {
+    let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path = parent.join(format!(
+        "vigia-test-{}-{}-{}",
+        std::process::id(),
+        unique,
+        name
+    ));
+    let _ = std::fs::remove_dir_all(&path);
+    std::fs::create_dir_all(&path).expect("create a fixture directory");
+    path
+}
+
+/// An empty directory the test owns and removes on drop, for a fixture that is
+/// not a repository: a state root, or a holder for a linked worktree.
+pub struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    pub fn new(name: &str) -> Self {
+        Self {
+            path: unique_dir(&std::env::temp_dir(), name),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
 impl Scratch {
     /// Create an initialised repository with deterministic config.
     pub fn new(name: &str) -> Self {
@@ -575,15 +613,7 @@ impl Scratch {
 
     /// The same thing, somewhere other than the temp directory.
     pub fn in_dir(parent: &Path, name: &str) -> Self {
-        let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let path = parent.join(format!(
-            "vigia-test-{}-{}-{}",
-            std::process::id(),
-            unique,
-            name
-        ));
-        let _ = std::fs::remove_dir_all(&path);
-        std::fs::create_dir_all(&path).expect("create scratch dir");
+        let path = unique_dir(parent, name);
 
         let scratch = Scratch { path };
         scratch.git(&["init", "-q", "-b", "main"]);

--- a/crates/vigia/src/lib.rs
+++ b/crates/vigia/src/lib.rs
@@ -16,6 +16,7 @@ mod input;
 pub mod memory;
 mod render;
 mod signal;
+mod state;
 mod terminal;
 /// Public for [`memory`]'s reason: `tests/palette.rs` is an integration test and
 /// can only reach what the crate exports.
@@ -37,6 +38,7 @@ pub use render::{
     Areas, Band, Body, Chrome, HINT_SEPARATOR, Heat, LIST_SETTLED, Mode, PaintStats, body_layout,
     diff_height, notice_area, regions, render, voice_style,
 };
+pub use state::state_root;
 pub use terminal::{Background, Screen, Session, background_of};
 pub use theme::{THEME_FILE, THEME_VAR, Theme, ThemeError};
 pub use update::{UPDATE_VAR, UpdateError};

--- a/crates/vigia/src/state.rs
+++ b/crates/vigia/src/state.rs
@@ -14,7 +14,7 @@ use crate::theme::home_file;
 /// platform and the environment are parameters so a test can ask about both
 /// without touching the process environment, as every other lookup here does.
 #[must_use]
-pub fn state_root(windows: bool, lookup: &impl Fn(&str) -> Option<String>) -> Option<PathBuf> {
+pub fn state_root(windows: bool, lookup: impl Fn(&str) -> Option<String>) -> Option<PathBuf> {
     let set = |name: &str| {
         lookup(name)
             .map(|value| value.trim().to_owned())
@@ -26,5 +26,5 @@ pub fn state_root(windows: bool, lookup: &impl Fn(&str) -> Option<String>) -> Op
     if let Some(xdg) = set("XDG_STATE_HOME").filter(|value| Path::new(value).is_absolute()) {
         return Some(Path::new(&xdg).join("vigia"));
     }
-    home_file(".local/state/vigia", lookup)
+    home_file(".local/state/vigia", &lookup)
 }

--- a/crates/vigia/src/state.rs
+++ b/crates/vigia/src/state.rs
@@ -1,0 +1,30 @@
+//! Where the shell keeps what outlives a process: the notes store
+//! (`SPEC.md` §11.2 B21).
+
+use std::path::{Path, PathBuf};
+
+use crate::theme::home_file;
+
+/// The directory `vigia` keeps state under, or `None` when the environment
+/// names no home.
+///
+/// `XDG_STATE_HOME` when it is set, non-empty and absolute, else
+/// `~/.local/state`, which is the XDG base directory rule; `LOCALAPPDATA` on
+/// Windows, where there is no XDG and that is the per-user local root. The
+/// platform and the environment are parameters so a test can ask about both
+/// without touching the process environment, as every other lookup here does.
+#[must_use]
+pub fn state_root(windows: bool, lookup: &impl Fn(&str) -> Option<String>) -> Option<PathBuf> {
+    let set = |name: &str| {
+        lookup(name)
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+    };
+    if windows {
+        return set("LOCALAPPDATA").map(|local| Path::new(&local).join("vigia").join("state"));
+    }
+    if let Some(xdg) = set("XDG_STATE_HOME").filter(|value| Path::new(value).is_absolute()) {
+        return Some(Path::new(&xdg).join("vigia"));
+    }
+    home_file(".local/state/vigia", lookup)
+}

--- a/crates/vigia/src/terminal.rs
+++ b/crates/vigia/src/terminal.rs
@@ -829,7 +829,7 @@ mod tests {
     fn no_exit_path_in_the_shell_skips_the_destructors() {
         // The structural half of "the terminal is restored on every exit". What makes
         // that true is that every exit drops `Shell`, which owns the `Session`.
-        const SOURCES: [(&str, &str); 16] = [
+        const SOURCES: [(&str, &str); 17] = [
             ("lib.rs", include_str!("lib.rs")),
             ("main.rs", include_str!("main.rs")),
             ("app.rs", include_str!("app.rs")),
@@ -842,6 +842,7 @@ mod tests {
             ("memory.rs", include_str!("memory.rs")),
             ("render.rs", include_str!("render.rs")),
             ("signal.rs", include_str!("signal.rs")),
+            ("state.rs", include_str!("state.rs")),
             ("terminal.rs", include_str!("terminal.rs")),
             ("theme.rs", include_str!("theme.rs")),
             ("update.rs", include_str!("update.rs")),

--- a/crates/vigia/tests/state.rs
+++ b/crates/vigia/tests/state.rs
@@ -25,7 +25,7 @@ fn the_state_root_follows_xdg_then_home_and_localappdata_on_windows() {
     assert_eq!(
         state_root(
             false,
-            &env(&[("XDG_STATE_HOME", absolute_str), ("HOME", "/home/r")])
+            env(&[("XDG_STATE_HOME", absolute_str), ("HOME", "/home/r")])
         ),
         Some(absolute.join("vigia"))
     );
@@ -33,32 +33,29 @@ fn the_state_root_follows_xdg_then_home_and_localappdata_on_windows() {
     assert_eq!(
         state_root(
             false,
-            &env(&[("XDG_STATE_HOME", "state"), ("HOME", "/home/r")])
+            env(&[("XDG_STATE_HOME", "state"), ("HOME", "/home/r")])
         ),
         Some(PathBuf::from("/home/r/.local/state/vigia"))
     );
     // Set but empty is unset.
     assert_eq!(
-        state_root(
-            false,
-            &env(&[("XDG_STATE_HOME", "  "), ("HOME", "/home/r")])
-        ),
+        state_root(false, env(&[("XDG_STATE_HOME", "  "), ("HOME", "/home/r")])),
         Some(PathBuf::from("/home/r/.local/state/vigia"))
     );
     assert_eq!(
-        state_root(false, &env(&[("USERPROFILE", "/u/r")])),
+        state_root(false, env(&[("USERPROFILE", "/u/r")])),
         Some(PathBuf::from("/u/r/.local/state/vigia"))
     );
-    assert_eq!(state_root(false, &env(&[])), None);
+    assert_eq!(state_root(false, env(&[])), None);
     assert_eq!(
         state_root(
             true,
-            &env(&[
+            env(&[
                 ("LOCALAPPDATA", "C:\\Users\\r\\AppData\\Local"),
                 ("HOME", "/h")
             ])
         ),
         Some(PathBuf::from("C:\\Users\\r\\AppData\\Local\\vigia\\state"))
     );
-    assert_eq!(state_root(true, &env(&[("HOME", "/h")])), None);
+    assert_eq!(state_root(true, env(&[("HOME", "/h")])), None);
 }

--- a/crates/vigia/tests/state.rs
+++ b/crates/vigia/tests/state.rs
@@ -1,0 +1,64 @@
+//! `SPEC.md` §11.2 B21: where the notes store lives.
+
+use std::path::PathBuf;
+
+use vigia::state_root;
+
+#[test]
+fn the_state_root_follows_xdg_then_home_and_localappdata_on_windows() {
+    let env = |vars: &[(&str, &str)]| {
+        let owned: Vec<(String, String)> = vars
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect();
+        move |name: &str| {
+            owned
+                .iter()
+                .find(|(k, _)| k == name)
+                .map(|(_, v)| v.clone())
+        }
+    };
+    // Absolute on every platform, which is what the XDG rule turns on.
+    let absolute = std::env::temp_dir().join("xdg-state");
+    let absolute_str = absolute.to_str().expect("a UTF-8 temp dir");
+
+    assert_eq!(
+        state_root(
+            false,
+            &env(&[("XDG_STATE_HOME", absolute_str), ("HOME", "/home/r")])
+        ),
+        Some(absolute.join("vigia"))
+    );
+    // A relative value is invalid and ignored, per the specification.
+    assert_eq!(
+        state_root(
+            false,
+            &env(&[("XDG_STATE_HOME", "state"), ("HOME", "/home/r")])
+        ),
+        Some(PathBuf::from("/home/r/.local/state/vigia"))
+    );
+    // Set but empty is unset.
+    assert_eq!(
+        state_root(
+            false,
+            &env(&[("XDG_STATE_HOME", "  "), ("HOME", "/home/r")])
+        ),
+        Some(PathBuf::from("/home/r/.local/state/vigia"))
+    );
+    assert_eq!(
+        state_root(false, &env(&[("USERPROFILE", "/u/r")])),
+        Some(PathBuf::from("/u/r/.local/state/vigia"))
+    );
+    assert_eq!(state_root(false, &env(&[])), None);
+    assert_eq!(
+        state_root(
+            true,
+            &env(&[
+                ("LOCALAPPDATA", "C:\\Users\\r\\AppData\\Local"),
+                ("HOME", "/h")
+            ])
+        ),
+        Some(PathBuf::from("C:\\Users\\r\\AppData\\Local\\vigia\\state"))
+    );
+    assert_eq!(state_root(true, &env(&[("HOME", "/h")])), None);
+}

--- a/crates/vigia/tests/state.rs
+++ b/crates/vigia/tests/state.rs
@@ -1,6 +1,6 @@
 //! `SPEC.md` §11.2 B21: where the notes store lives.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use vigia::state_root;
 
@@ -61,7 +61,11 @@ fn the_state_root_follows_xdg_then_home_and_localappdata_on_windows() {
                 ("HOME", "/h")
             ])
         ),
-        Some(PathBuf::from("C:\\Users\\r\\AppData\\Local\\vigia\\state"))
+        Some(
+            Path::new("C:\\Users\\r\\AppData\\Local")
+                .join("vigia")
+                .join("state")
+        )
     );
     assert_eq!(state_root(true, env(&[("HOME", "/h")])), None);
     assert_eq!(state_root(true, env(&[("LOCALAPPDATA", " ")])), None);

--- a/crates/vigia/tests/state.rs
+++ b/crates/vigia/tests/state.rs
@@ -58,4 +58,5 @@ fn the_state_root_follows_xdg_then_home_and_localappdata_on_windows() {
         Some(PathBuf::from("C:\\Users\\r\\AppData\\Local\\vigia\\state"))
     );
     assert_eq!(state_root(true, env(&[("HOME", "/h")])), None);
+    assert_eq!(state_root(true, env(&[("LOCALAPPDATA", " ")])), None);
 }

--- a/crates/vigia/tests/state.rs
+++ b/crates/vigia/tests/state.rs
@@ -19,13 +19,19 @@ fn the_state_root_follows_xdg_then_home_and_localappdata_on_windows() {
         }
     };
     // Absolute on every platform, which is what the XDG rule turns on.
-    let absolute = std::env::temp_dir().join("xdg-state");
-    let absolute_str = absolute.to_str().expect("a UTF-8 temp dir");
+    let absolute_str = std::env::temp_dir()
+        .join("xdg-state")
+        .to_string_lossy()
+        .into_owned();
+    let absolute = PathBuf::from(&absolute_str);
 
     assert_eq!(
         state_root(
             false,
-            env(&[("XDG_STATE_HOME", absolute_str), ("HOME", "/home/r")])
+            env(&[
+                ("XDG_STATE_HOME", absolute_str.as_str()),
+                ("HOME", "/home/r")
+            ])
         ),
         Some(absolute.join("vigia"))
     );

--- a/crates/vigia/tests/writes.rs
+++ b/crates/vigia/tests/writes.rs
@@ -9,8 +9,8 @@ use std::time::SystemTime;
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
-use vigia::{Action, App, Glyphs, PaintStats, Pointing, Theme, body_layout, render};
-use vigia_core::{Frame, Highlighter, History, WARM_FILES, WatchOptions, Worktree, state_root};
+use vigia::{Action, App, Glyphs, PaintStats, Pointing, Theme, body_layout, render, state_root};
+use vigia_core::{Frame, Highlighter, History, WARM_FILES, WatchOptions, Worktree};
 
 use support::{Scratch, made_link, settle_tree};
 
@@ -312,7 +312,7 @@ fn the_monitor_writes_nothing_while_it_runs() {
         moved.join("\n")
     );
     if let Some(dir) = state.as_deref() {
-        let state_after = Some(dir).filter(|dir| dir.exists()).map(snapshot);
+        let state_after = dir.exists().then(|| snapshot(dir));
         let moved = match (&state_before, &state_after) {
             (None, None) => Vec::new(),
             (Some(before), Some(after)) => difference(before, after),

--- a/crates/vigia/tests/writes.rs
+++ b/crates/vigia/tests/writes.rs
@@ -257,7 +257,7 @@ fn the_monitor_writes_nothing_while_it_runs() {
     // The state directory B21 opens is outside the tree, so the tree's snapshot
     // cannot see a write there; it gets its own, at the root the shell would
     // resolve from this process's environment.
-    let state = state_root(cfg!(windows), &|name| std::env::var(name).ok());
+    let state = state_root(cfg!(windows), |name| std::env::var(name).ok());
     let state_before = state.as_deref().filter(|dir| dir.exists()).map(snapshot);
     if linked {
         assert!(

--- a/crates/vigia/tests/writes.rs
+++ b/crates/vigia/tests/writes.rs
@@ -10,7 +10,7 @@ use std::time::SystemTime;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use vigia::{Action, App, Glyphs, PaintStats, Pointing, Theme, body_layout, render};
-use vigia_core::{Frame, Highlighter, History, WARM_FILES, WatchOptions, Worktree};
+use vigia_core::{Frame, Highlighter, History, WARM_FILES, WatchOptions, Worktree, state_root};
 
 use support::{Scratch, made_link, settle_tree};
 
@@ -254,6 +254,11 @@ fn the_monitor_writes_nothing_while_it_runs() {
     // monitor.
     settle_tree(&root);
     let before = snapshot(&root);
+    // The state directory B21 opens is outside the tree, so the tree's snapshot
+    // cannot see a write there; it gets its own, at the root the shell would
+    // resolve from this process's environment.
+    let state = state_root(cfg!(windows), &|name| std::env::var(name).ok());
+    let state_before = state.as_deref().filter(|dir| dir.exists()).map(snapshot);
     if linked {
         assert!(
             before.contains_key(Path::new("link_to_mod_0.rs")),
@@ -306,6 +311,22 @@ fn the_monitor_writes_nothing_while_it_runs() {
         driven.events,
         moved.join("\n")
     );
+    if let Some(dir) = state.as_deref() {
+        let state_after = Some(dir).filter(|dir| dir.exists()).map(snapshot);
+        let moved = match (&state_before, &state_after) {
+            (None, None) => Vec::new(),
+            (Some(before), Some(after)) => difference(before, after),
+            (None, Some(_)) => vec![format!("{} was created", dir.display())],
+            (Some(_), None) => vec![format!("{} was removed", dir.display())],
+        };
+        assert!(
+            moved.is_empty(),
+            "SPEC.md §11.1: the monitor writes nothing of its own, and with no \
+             gesture this run moved {} entries under the state directory:\n{}",
+            moved.len(),
+            moved.join("\n")
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #415. The first build under `SPEC.md` §11.2 B21 (#414, ruled in #430): the anchor, the store and the key, headless in `vigia-core`, and the state root in the shell. Nothing on screen changes; the pane does not open the store until #416.

## What changes

- `crates/vigia-core/src/notes.rs`, new: `Note`, `Side`, `Status`, `Placement`, `resolve`, `key`, `Store` (`open`, `dir`, `new_id`, `put`, `remove`, `list`) and `Listing`. One file per note, temp-and-rename, a versioned text format: single-line fields for what cannot hold a newline (id, side, line, status, written) and a length-announced block for everything that can (path, text, body, reply), so no field can forge a header and a file cut short announces more bytes than follow. An id is lowercase ASCII letters, digits and dashes, at most 64 bytes, never a Windows device name; the store refuses to write, remove or read a file named otherwise, and a file whose id is not its name is skipped with the reason.
- `crates/vigia-core/src/error.rs`: `Error::Store { path, source }` and `Error::Canonicalise { path, source }`, with `Display` and `source`.
- `crates/vigia-core/src/lib.rs`: the module and its exports.
- `crates/vigia/src/state.rs`, new: `state_root(windows, lookup)`, the XDG rule and `LOCALAPPDATA`, beside the shell's other environment lookups and reusing its home rule. The plan had placed it in the engine; `/simplify` moved it, on CLAUDE.md's rule that `vigia-core` reads no environment, and the correctness reviewer named that an improvement over the plan rather than drift.
- `crates/vigia-core/tests/notes.rs`, new: twenty-three gates, listed below. `crates/vigia/tests/state.rs`, new: the state root's rule.
- `crates/vigia-core/tests/support/mod.rs`: `TempDir`, an empty directory a test owns, sharing `Scratch`'s naming.
- `crates/vigia/tests/writes.rs`: the snapshot extends to the state root this process's environment resolves, asserting the drive neither creates nor moves anything under it. Nothing in the pane writes yet, so this is the gate in place for #416 rather than a claim about today; #416 points it at a scratch root once the pane takes one, and adds the one-gesture-one-file sibling that needs a gesture.
- `ROADMAP.md`: #415's row flips to done. `SPEC.md` is untouched: B21 already says what this builds.

## Gates, by the issue's own list

| The issue asks | The gate |
|---|---|
| One key from the workdir, a subdirectory of it, and a different one for another worktree | `the_key_is_one_value_for_one_worktree_from_any_path_inside_it` |
| A linked worktree's own root has its own key | `a_linked_worktree_has_its_own_key`, over a real `git worktree add` |
| A write is atomic: a reader that lists mid-write sees the old file or the new one and never a torn one | `a_listing_sees_a_whole_note_while_it_is_being_rewritten` and `two_writers_in_one_process_never_produce_a_mixed_note`: writer threads rewrite one note while the test lists; every listing is one version whole, both versions are seen, nothing is skipped, no temporary is left |
| A note whose line moved, was edited, or is gone resolves as moved, changed, or gone | `a_line_is_found_where_it_was_then_by_its_text_nearby_then_judged_changed_or_gone`, including the distance bound, nearest-wins and earlier-on-a-tie in both orders, an exact match over a nearer duplicate, and an empty line |
| A torn file and a newer version are skipped and reported | `a_torn_file_and_a_newer_version_are_skipped_and_the_rest_listed`, with a write in flight neither listed nor reported |
| An unwritable store returns an error the caller can show | `an_unwritable_root_is_an_error_the_caller_can_show`; `a_workdir_that_does_not_exist_has_no_key` for the other variant |
| Two spellings of one path on Windows and a junction derive one key | `two_spellings_of_one_path_and_a_junction_derive_one_key` on Windows, `a_symlinked_worktree_root_derives_the_same_key` on Unix |
| A note written by one handle is read back whole by a second handle | `every_field_of_a_note_is_read_back_whole_by_a_second_handle`, every status and side, with a body that holds the format's own words |
| The writes gate extends to the state directory, and one put is one file | `writes.rs::the_monitor_writes_nothing_while_it_runs`, `the_store_creates_nothing_until_the_first_put`, `a_rewrite_reuses_the_note_file` |
| The state root rule | `state.rs::the_state_root_follows_xdg_then_home_and_localappdata_on_windows` |
| Found by the audit, not asked by the issue | `a_path_or_a_line_with_a_newline_in_it_cannot_forge_a_field`, `a_number_too_large_for_the_file_is_a_skip_and_never_a_panic`, `an_id_that_could_name_a_file_outside_the_store_is_refused`, `a_minted_id_is_one_the_store_accepts`, `a_file_whose_id_is_not_its_name_is_skipped`, `a_file_whose_name_is_not_a_note_id_is_not_read`, `a_repeated_field_is_a_skip`, `trailing_bytes_are_a_skip`, `a_note_read_back_in_another_field_order_is_the_same_note`, `a_failed_rename_leaves_no_temporary_behind`, `removing_a_note_twice_is_not_an_error` |

Adrift is the caller's knowledge (whether the file is in the diff at all), so it is not a `Placement`; #416 reports it from the frame's file list.

## Premises, measured or read on 2026-09-05

| Must be true | Answer |
|---|---|
| A process-stable hash is already in the graph | `gix::hash::hasher(Kind::Sha1)` in `gix-hash` 0.26.2, re-exported by `gix` 0.87.1; `std`'s `DefaultHasher` is not stable across releases |
| Two spellings and a junction canonicalise to one path on Windows | Probed: `Real Dir`, `real dir`, `REAL DIR`, a junction and `JUNCTION\.` all resolve to one `\\?\` path with disk casing, so the key folds nothing itself |
| The state directory convention | XDG Base Directory 0.8: `$XDG_STATE_HOME`, defaulting to `$HOME/.local/state` when unset or empty, for *"current state of the application that can be reused on a restart"*; a relative value is invalid and ignored |
| Temp-and-rename holds under a concurrent reader on Windows | The atomic gates are green here on Windows; `std` opens files with delete sharing, so a rename lands over a file a lister has open |
| A rename onto a directory fails on every platform | `rename(2)` refuses a file onto a directory and `MoveFileEx` with replace refuses a directory target; the litter gate rests on it and is green here |

## Scope of the checks

Code in both crates, so `cargo fmt --check`, `cargo clippy --all-targets` with `RUSTFLAGS=-D warnings`, `cargo doc --workspace --no-deps` with warnings denied, and `cargo test --workspace` all ran locally: 1,223 passed, 0 failed, on the final commit. The frame path is untouched, so the budget gates are not run.

## Decisions taken without asking

- The note file is a hand-rolled text format rather than JSON: `serde_json` sits in the shell crate for the update check and not in `vigia-core`, and the format needs length-announced blocks to hold any line, which JSON would buy at the cost of a dependency the spec names for something else.
- The id rule is lowercase only, which is what the store mints, rather than case-folded on read: one rule, no folding, and a filesystem that folds case cannot give one file two names.
- The temporary carries the process id and a per-process counter, so two writers of one note never share a temporary.
- `written` is kept to the second, which is what the departure and the ordering need.
- The nearness bound `NEAR` is eight rows, exported so the pane and the server agree.
- A size cap on what the reader typed was asked for by a reviewer and refused: a restriction with no measured cost behind it, on a store under the reader's own home.

## Harden audit

Reference PR: #344, the closest merged precedent for a core module with gates and audit rounds. Its gates, matched in spirit: a plan with premises settled before code, one gate per claim, mutations recorded as applied and killed, an honest exit reason, and an artifact in the body.

### Gates before the loop

- `/simplify` (phase 4): four agents on Sonnet, six findings fixed in c92854f (a single-pass `resolve`; the extension check before the path allocation; unused derives on `Listing`; the option chain in the writes gate; the test's temp-directory guard lifted into the shared support; `state_root` moved out of the engine into the shell beside the other environment lookups, which also removed a second copy of the home rule), one dismissed: `Error::Store` collapsing six I/O sites, because the wrapped error's kind is already programmatic and nothing has to parse a string.
- Plan-fidelity (phase 5): run by the wrapper against the plan on #415. Every promise delivered; one deviation recorded when taken: the writes gate snapshots the environment's state root rather than a scratch root the drive is pointed at, because nothing in the pane can be pointed yet. `/simplify` then moved `state_root` from `vigia-core` to the shell, which the plan had placed in the engine; the module rule in CLAUDE.md is the reason and the correctness reviewer named it an improvement over the plan rather than drift.

### Rounds

Each round: three agents on Sonnet in parallel (adversarial including concurrency, correctness and architecture, docs and conventions), fixes, gates rerun, a re-read of the round's diff.

- Round 1: 11 findings, e441a8e. Header forgery through a newline in a path or line text (every free-text field is a length-announced block now); a block length at the integer ceiling overflowing the bounds check; a `written` value at the ceiling panicking the time arithmetic; ids joined into paths unvalidated; two threads sharing a temporary; the canonicalise error's voice; `state_root` taking its lookup by reference where its siblings take it by value; two test gaps (the canonicalise error never asserted, `Seen` never round-tripped); a Unix counterpart for the Windows key gate; a bundled gate split. The writes gate's state branch was noted as vacuous today, which the body already disclosed.
- Round 2: 7 findings fixed, 2 dismissed, e25166b. Both adversarial and correctness independently found that a decoded id was never compared with its file name, so a rogue copy could point a later removal at the wrong note; Windows device names passed the id rule; repeated header fields were accepted; the store error's voice; a future-tense test comment; an empty file's misleading message; five test gaps (a minted id through the store's own rule, the longest and first-refused id lengths, a rogue copy, repeated and trailing fields, both versions observed under the concurrent writer, an empty `LOCALAPPDATA`). Dismissed: a size cap on what the reader typed, a restriction with no measured cost behind it and a store under the reader's own home; a put resurrecting a note after a remove, which is the last-write-wins the design table already states.
- Round 3: 11 items, e39cfdc, one of them a defect: on a filesystem that folds case an id differing only in case from an existing one landed on the same file and then failed the name check, orphaning the note, so ids are lowercase only (what the store mints) and a file's name passes the same rule before it is read. The rest: the concurrent gate polled `is_finished` and could fail on a starved runner (a bounded handshake now); the reordered gate compared a count rather than the note; an allocation on the rejected-id path; a `Path` built twice; and six wording items (the id docblock stating a stale character class, the cursor docblock, the litter gate's comment, the error constructor's voice, a bundled test name, an unasserted message). Eight of the eleven sat inside earlier rounds' fixes.
- Round 4: two agents, adversarial and correctness, defects only, capped: no defect found by either.

Trajectory: 6 (simplify) then 11, 9, 11, 0. Exit: dry at round 4. Round 3's count did not fall, and most of it was the loop polishing its own earlier fixes, which is the stop signal the skill names; the round was applied because one item was a defect, and round 4 was narrowed to defects only to test whether anything remained. Nothing did.

### Round closers

- Mutation: 21 applied to the store and the state root, 21 killed, over two passes. The first pass, after round two, ran 18: 16 killed, one did not apply (its anchor had moved, re-anchored and killed), and one survived, deleting the cleanup after a failed rename, because no gate drove a rename that fails; b288863 adds one, a directory where the note's file would go, and it is killed. The second pass, after round three, ran 21 with three new mutations for round three's rules (the name check before reading, the stem check, the repeated field): 20 killed and one survived that the first pass had killed, the version check. That survivor was a real defect: round three's range replacement had swallowed the torn-file and newer-version gate that sat between its anchors, so nothing drove a newer version any more. a52f73a restores it and the mutation is killed again. Producer side: the earlier in-place-write mutation (no temporary, no rename) produced the torn read the atomic gate exists for.
- Coverage-shape: n/a, no iterated or long-lived surface; the store is called per gesture and per wake.
- Rules-bite: the atomic gate, the refused-id gate, the stem gate, the repeated-field gate, the hostile-number gate and the litter gate each went red under the mutation naming them. The writes gate's state-root branch cannot go red today and says so; #416 points it at a scratch root.
- Measurement instruments: n/a, no perf gate; the frame path is untouched.

### Real bugs found

- A newline in a path forges a header, `notes.rs` encode: a note under such a path was dropped from every listing.
- A block length at `usize::MAX` indexes out of bounds, `Cursor::block`: a corrupt file crashed the lister.
- A `written` at `u64::MAX` panics the time arithmetic, decode: the same.
- An id joined into a path unvalidated, `Store::put` and `remove`: `../../evil` left the store.
- Two threads sharing one temporary, `Store::put`.
- A decoded id never checked against its file name, `Store::list`: a rogue copy pointed a removal at the wrong note.
- Windows device names accepted as ids, `is_id`.
- A failed rename leaving its temporary, `Store::put`: found by mutation, not by an agent.

### Tests

- Store gates: 11 → 23 (the Unix symlink gate compiles out on Windows and the junction gate on Unix). Shell gates: 1 (`state`) plus the writes gate's state branch.
- A defect the agents could not see and a mutation did: a gate deleted by an edit. Four rounds of reading passed over its absence; the closer found it in one run.
- Workspace: 1,210 passed before the loop, 1,223 after, 0 failed.

### Final gate

The workspace run after the loop caught one more thing no round had: the shell keeps a list of its modules for the exit-path scan and checks it against lib.rs, and the new state module was not on it. c5c7878 adds it. Recorded because it is a gate that bit as designed, on a module the audit agents read four times.

### Deferrals

- The id grammar belongs in `SPEC.md` B21 when the server that accepts agent-typed ids lands (#417); until then it is a rule the code and its gates carry.
- The one-gesture-one-file half of §11.1's gate needs a gesture, which is #416's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
