### PR TITLE
Repair four assertion messages, give the CPU clock gate a retry, and row the shell-harness finding

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -291,7 +291,7 @@ Everything on the deferral shelf below has a milestone here, so shelved work is 
 
 **Older issues, notes and the dated cells below cite "Phase 5", and every such citation means this shelf**: the milestone URL keeps `/5` from the name it carried until 2026-08-06, `take-next` skips it by the `Shelf:` description prefix, and a title with no phase number sorts last by that query's own fallback, so the two guards agree.
 
-**A shelf item comes off it when daily use asks for it, and the asking is the whole test.** That sentence used to live here, was deleted at some point, and survives only as a quotation in two pull-forward rows below, which is a rule that exists solely as its own citation. Restated because a filter nobody can read is not one, and because the sixty-odd rows under it are what happens when the entry trigger fires on every audit and the exit trigger fires on a judgement nobody is scheduled to make.
+**A shelf item comes off it when daily use asks for it, and the asking is the whole test.** The rows under it are what happens when the entry trigger fires on every audit and the exit fires on a judgement nobody is scheduled to make.
 
 **The occasion is the pull-forward, and the question is one line: would this be built if it were not already written down?** Ask it of an item when something reaches for it, not on a schedule nobody keeps. An item that cannot answer yes is not waiting for a phase, it is declined, and closing it as such is a result rather than a loss. Five declines in a hundred and twenty-seven closed issues is not a shelf being filtered; it is a shelf being filled.
 
@@ -303,6 +303,8 @@ Everything on the deferral shelf below has a milestone here, so shelved work is 
 | ✅ | A symlink diffs as its target's contents, and on Windows was never reusable | [#15](https://github.com/breferrari/vigia/issues/15) |
 | ✅ | The macOS watch suite fails three different ways under CI load, and it is blocking merges | [#337](https://github.com/breferrari/vigia/issues/337) |
 | ✅ | The height walk trusts a cached diff by path | [#390](https://github.com/breferrari/vigia/issues/390) |
+| ✅ | Four assertion messages carry a lost line continuation | [#438](https://github.com/breferrari/vigia/issues/438) |
+| ✅ | The CPU clock gate takes an absolute bound once, so a loaded suite fails it | [#439](https://github.com/breferrari/vigia/issues/439) |
 | ⬜ | Lift the tinyvec bound once a compiling release exists | [#397](https://github.com/breferrari/vigia/issues/397) |
 | ⬜ | The caret row's weight is the one modifier a theme file cannot reach | [#195](https://github.com/breferrari/vigia/issues/195) |
 | ⬜ | The sheet's tables are audited, not derived, so the keymap can still drift into them | [#312](https://github.com/breferrari/vigia/issues/312) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -291,12 +291,12 @@ Everything on the deferral shelf below has a milestone here, so shelved work is 
 
 **Older issues, notes and the dated cells below cite "Phase 5", and every such citation means this shelf**: the milestone URL keeps `/5` from the name it carried until 2026-08-06, `take-next` skips it by the `Shelf:` description prefix, and a title with no phase number sorts last by that query's own fallback, so the two guards agree.
 
-**A shelf item comes off it when daily use asks for it, and the asking is the whole test.** The rows under it are what happens when the entry trigger fires on every audit and the exit fires on a judgement nobody is scheduled to make.
+**A shelf item comes off it when daily use asks for it, and the asking is the whole test.** The rows under it are what happens when the entry fires on every audit and the exit on a judgement nobody is scheduled to make.
 
-**The occasion is the pull-forward, and the question is one line: would this be built if it were not already written down?** Ask it of an item when something reaches for it, not on a schedule nobody keeps. An item that cannot answer yes is not waiting for a phase, it is declined, and closing it as such is a result rather than a loss. Five declines in a hundred and twenty-seven closed issues is not a shelf being filtered; it is a shelf being filled.
+**The occasion is the pull-forward, and the question is one line: would this be built if it were not already written down?** Ask it of an item when something reaches for it, not on a schedule nobody keeps. An item that cannot answer yes is not waiting for a phase, it is declined, and closing it as such is a result rather than a loss. A shelf almost nothing is ever declined off is not being filtered, it is being filled.
 
 
-**If a second shelf is ever created, its milestone description must begin `Shelf:`.** Until [#83](https://github.com/breferrari/vigia/issues/83) the never-next rule lived only in this paragraph, which is prose, and `take-next` step 1 is a query: it read the milestone list, saw three peers, and offered the shelf as the next phase. The marker is what a query can read, and this paragraph is where whoever creates the next one is standing, so it is stated here rather than only in the skill. Comparison 6 of that skill's pre-flight is the check that fires when the two disagree.
+**If a second shelf is ever created, its milestone description must begin `Shelf:`.** A rule that lives only in prose is one a query cannot read, and `take-next` step 1 is a query: an unmarked shelf is offered as the next phase ([#83](https://github.com/breferrari/vigia/issues/83)). This paragraph is where whoever creates the next one is standing, so it is stated here rather than only in the skill, and comparison 6 of that pre-flight is what fires when the two disagree.
 
 | | Task | Issue |
 |---|---|---|
@@ -305,6 +305,7 @@ Everything on the deferral shelf below has a milestone here, so shelved work is 
 | ✅ | The height walk trusts a cached diff by path | [#390](https://github.com/breferrari/vigia/issues/390) |
 | ✅ | Four assertion messages carry a lost line continuation | [#438](https://github.com/breferrari/vigia/issues/438) |
 | ✅ | The CPU clock gate takes an absolute bound once, so a loaded suite fails it | [#439](https://github.com/breferrari/vigia/issues/439) |
+| ⬜ | No test can build a Shell, so a gesture's decisions must move out to be seen | [#441](https://github.com/breferrari/vigia/issues/441) |
 | ⬜ | Lift the tinyvec bound once a compiling release exists | [#397](https://github.com/breferrari/vigia/issues/397) |
 | ⬜ | The caret row's weight is the one modifier a theme file cannot reach | [#195](https://github.com/breferrari/vigia/issues/195) |
 | ⬜ | The sheet's tables are audited, not derived, so the keymap can still drift into them | [#312](https://github.com/breferrari/vigia/issues/312) |

--- a/crates/vigia-core/src/history.rs
+++ b/crates/vigia-core/src/history.rs
@@ -846,13 +846,15 @@ mod tests {
 
         assert!(
             busiest > spiked.scale() * 4,
-            "the outlier's own bucket is {busiest} against a scale of {}, so the              fixture has no outlier to speak of and this proves nothing",
+            "the outlier's own bucket is {busiest} against a scale of {}, so the \
+             fixture has no outlier to speak of and this proves nothing",
             spiked.scale()
         );
         assert_eq!(
             spiked.churn("b").unwrap()[HISTORY_BUCKETS - 1],
             1,
-            "the small path stopped being recorded, so the fixture changed rather              than the scale"
+            "the small path stopped being recorded, so the fixture changed rather \
+             than the scale"
         );
     }
 

--- a/crates/vigia-core/tests/budgets.rs
+++ b/crates/vigia-core/tests/budgets.rs
@@ -878,21 +878,40 @@ fn a_breach_with_no_cpu_clock_is_treated_as_ours() {
 fn the_cpu_clock_tells_waiting_from_working() {
     // Non-vacuity for the two gates above, and the only thing here that touches the
     // platform.
+    //
+    // The busy half is asked several times and needs one round to hold, because
+    // the claim is that this clock *can* tell the two apart rather than that a
+    // loaded machine always lets it: the whole suite's binaries run beside this
+    // one, and a thread descheduled through its own measurement reports somebody
+    // else's load as its own. A clock that cannot do it once in five is broken,
+    // which is what this exists to catch. The sleeping half needs no rounds,
+    // since load can only push CPU time down and its bound is an upper one.
     let busy = Duration::from_millis(80);
-    let (wall, cpu) = time_cpu(|| {
-        let deadline = std::time::Instant::now() + busy;
-        let mut sum = 0u64;
-        while std::time::Instant::now() < deadline {
-            for at in 0..10_000u64 {
-                sum = sum.wrapping_add(std::hint::black_box(at).wrapping_mul(2_654_435_761));
+    let mut best = Duration::ZERO;
+    let mut wall = Duration::ZERO;
+    for _ in 0..5 {
+        let (round_wall, cpu) = time_cpu(|| {
+            let deadline = std::time::Instant::now() + busy;
+            let mut sum = 0u64;
+            while std::time::Instant::now() < deadline {
+                for at in 0..10_000u64 {
+                    sum = sum.wrapping_add(std::hint::black_box(at).wrapping_mul(2_654_435_761));
+                }
             }
+            std::hint::black_box(sum);
+        });
+        if cpu > best {
+            (best, wall) = (cpu, round_wall);
         }
-        std::hint::black_box(sum);
-    });
+        if best >= busy / 2 {
+            break;
+        }
+    }
     assert!(
-        cpu >= busy / 2,
-        "the CPU clock reported {cpu:?} for {wall:?} of work that never waited for \
-         anything, so a real overshoot would read as somebody else's load"
+        best >= busy / 2,
+        "the CPU clock's best of five reported {best:?} for {wall:?} of work that \
+         never waited for anything, so a real overshoot would read as somebody \
+         else's load"
     );
 
     let (slept_wall, slept_cpu) = time_cpu(|| std::thread::sleep(Duration::from_millis(60)));

--- a/crates/vigia/src/signal.rs
+++ b/crates/vigia/src/signal.rs
@@ -448,7 +448,8 @@ mod tests {
             // from a `Reply` back to a `BOOL` uncalled.
             assert!(
                 !CAUGHT.contains(&5),
-                "5 is claimed now, so handing it to the real handler would park                  forever; pick a kind outside `CAUGHT` or drop this test"
+                "5 is claimed now, so handing it to the real handler would park \
+                 forever; pick a kind outside `CAUGHT` or drop this test"
             );
 
             // SAFETY: `on_ctrl` performs no unsafe operation. It does read `SHELL`,

--- a/crates/vigia/src/theme.rs
+++ b/crates/vigia/src/theme.rs
@@ -724,7 +724,8 @@ impl fmt::Display for ThemeError {
             ),
             Self::RepeatedBase { line } => write!(
                 f,
-                "line {line}: `base` is already set. One palette to start from, or                  the second silently discards the first"
+                "line {line}: `base` is already set. One palette to start from, or \
+                 the second silently discards the first"
             ),
             Self::LateBase { line } => write!(
                 f,


### PR DESCRIPTION
Closes #438 and #439. Both were found by #420's audit in files that issue had no business touching, so they were kept out of its diff and filed here instead.

**Fixed on arrival rather than shelved.** Each is a handful of lines, neither needed a ruling, and deferring would have cost more in ceremony than the fix does in edits. The rows are on the shelf because that is where an instrument finding goes, not because either is waiting for anything.

## Four assertion messages had lost their line continuations

`crates/vigia-core/src/history.rs:849` and `:855`, `crates/vigia/src/signal.rs:451`, `crates/vigia/src/theme.rs:727`. Each string lost the `\` that joins its two halves, so it carried the indentation of its own second line as fourteen or eighteen literal spaces and printed that way when the test failed.

Nothing catches this. `cargo fmt` does not touch string contents, clippy has no lint for it, and the text renders only on a failure, which is exactly when somebody is reading carefully. Copilot caught the same damage in a line #420 had just written; the grep for the class found the other four.

The cause will recur, so it is worth naming: a Bash heredoc eats one backslash from every doubled pair even with a quoted delimiter, so any Rust string written into a file that way loses its continuations silently and still compiles.

## The CPU clock gate took its bound once

`crates/vigia-core/tests/budgets.rs::the_cpu_clock_tells_waiting_from_working` is the non-vacuity check under the two gates that attribute a wall-clock breach to CPU time, so whether it is trustworthy decides whether those two mean anything. It asserted that 80ms of pure computation reports at least 40ms of CPU time, once, with no retry.

Every other binary in the suite runs beside it under `cargo test --workspace`, so a thread descheduled through its own measurement reports somebody else's load as its own and the gate fails for a reason that has nothing to do with the clock. It failed exactly that way once during #420 and passed alone and on every run since.

It asks five times now and needs one round to hold. That is the honest shape for this assertion, because the claim is that the clock **can** tell waiting from working rather than that a loaded machine always lets it, and a clock that cannot manage it once in five rounds is genuinely broken, which is what the gate is for.

Two fixes were considered and rejected. **Weakening the bound** would make the gate vacuous in the exact direction it exists to catch. **`support::exclusively_timed()`** cannot help: that lock is a `static` compiled separately into each test binary, so it serialises within a binary, and this contention is between them.

The sleeping half keeps its single measurement, since load can only push measured CPU time down and its bound is an upper one.

## The written layer

`ROADMAP.md` was exactly on its ceiling, so the two shelf rows are funded rather than added. What came out is a paragraph recording the history of its own correction, which this repository puts in a commit message and a tracker rather than in the document. The file lands at 93,111 bytes, exactly its unchanged ceiling.

No shelf reason paragraph accompanies the rows, because the shelf's prose carries *deferral* reasons and neither of these is deferred.

## Verification

`cargo test --workspace --no-fail-fast`: exit 0, **1,382 passed**, unchanged from `main`, since this fixes message text and a retry rather than behaviour. `cargo clippy --all-targets` under `RUSTFLAGS=-D warnings`: exit 0. `cargo fmt --all -- --check`: exit 0. `cargo doc --workspace --no-deps` under `RUSTDOCFLAGS=-D warnings`: exit 0, run this time because #420 marked ready without it and CI caught an unresolvable intra-doc link that nothing else in the local loop can see.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


## And one finding filed rather than fixed

#441 is the third thing the audit turned up outside its diff: no test can build a `Shell`, so a gesture's decisions have to move out of it to be reachable. #420 paid that twice in one issue, extracting `post::context_for` and `post::spawn` for no reason except that nothing could see them where they were. Filed rather than built, because it changes how every gesture in this repository is tested, which is far wider than the issue that found it. Its roadmap row lands here, since preflight comparison 7 fails on an issue the roadmap never mentions.

The roadmap was exactly on its ceiling for all three rows, so each is funded out of trail prose: an account of how the never-next rule was found unreadable by a query, and a count of declines that prose was holding and that has drifted since.
