### PR TITLE
A release says what changed, and CHANGELOG.md lists every version

### DIFF
--- a/.github/scripts/changelog-entry.sh
+++ b/.github/scripts/changelog-entry.sh
@@ -59,8 +59,14 @@ fi
 # The list is tuned against the 143 subjects this repository had at 0.38.0 and
 # is a heuristic, not a rule: it will pass something internal through, and the
 # cost of that is one odd line in a release note rather than a broken release.
+#
+# `token` is bounded the long way round rather than with `\b`, which is a GNU
+# extension that POSIX ERE does not define. The release runs this on one runner
+# whose grep has it, but the test that drives the filter is `cfg(unix)` and so
+# runs wherever the suite does. Unbounded, the word would swallow `tokenizer`,
+# which in a syntax highlighter is a subject a reader can see.
 internal_prefix='^(roadmap|spec|docs?|ci|chore|deps?|take-next|skill|test|refactor|perf|style|build|process|steering|mockup|harden|release|vault writes)(\([^)]*\))?: '
-internal_subject='(roadmap|spec\.md|the spec|rulings?|revocation|withdrawn|written layer|phase [0-9]|the shelf|shelved|readme|claude\.md|clippy|cargo doc|ci complete|workflow|pre-flight|version raise|release note|the release |the bump |\btokens?\b|take-next|the skill|the harness|the record|budget table|mutation|audit|ceiling|proposal|declined|adopted|review agent|assertion|the mockup|funding|\.yml|§|^track the |^#[0-9]|^b[0-9]+[ :]|^[0-9]+\.[0-9]+,)'
+internal_subject='(roadmap|spec\.md|the spec|rulings?|revocation|withdrawn|written layer|phase [0-9]|the shelf|shelved|readme|claude\.md|clippy|cargo doc|ci complete|workflow|pre-flight|version raise|release note|the release |the bump |(^|[^a-zA-Z])tokens?([^a-zA-Z]|$)|take-next|the skill|the harness|the record|budget table|mutation|audit|ceiling|proposal|declined|adopted|review agent|assertion|the mockup|funding|\.yml|§|^track the |^#[0-9]|^b[0-9]+[ :]|^[0-9]+\.[0-9]+,)'
 
 # `|| true` on both greps, because grep exits 1 when it filters everything out
 # and `set -e` would kill the script on the assignment rather than let the

--- a/.github/scripts/changelog-entry.sh
+++ b/.github/scripts/changelog-entry.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# Writes one release's section into CHANGELOG.md, from the commit subjects of
+# the range being released.
+#
+# Lives in a file rather than inline in the workflow for the reason
+# raise-version.sh does: a filter decides what a user is told about a release,
+# and a filter nothing drives is a wish. The test feeds it fixed subjects and
+# reads back the section, so the rules below are checkable without a release.
+#
+# Subjects arrive on stdin, one per line, newest first, which is what
+# `git log --format=%s` gives and the order the section is written in.
+#
+# Usage: changelog-entry.sh <version> <date> [changelog]
+#   version   the version being released, three numeric components
+#   date      ISO date for the heading
+#   changelog the file to write into (default: ./CHANGELOG.md)
+set -eu
+
+[ "$#" -ge 2 ] || { echo "::error::usage: changelog-entry.sh <version> <date> [changelog]"; exit 1; }
+version="$1"
+date="$2"
+changelog="${3:-CHANGELOG.md}"
+
+case "$version" in
+    [0-9]*.[0-9]*.[0-9]*) ;;
+    *) echo "::error::${version} is not three numeric components"; exit 1 ;;
+esac
+
+[ -f "$changelog" ] || { echo "::error::${changelog} does not exist"; exit 1; }
+
+# A section for this version already existing means the release is being
+# re-run, or that somebody wrote it by hand. Either way, overwriting it would
+# discard the better text, so this stops instead.
+if grep -qF "## [${version}]" "$changelog"; then
+    echo "::error::${changelog} already carries a section for ${version}"
+    exit 1
+fi
+
+# **The two filters are different rules and neither subsumes the other.**
+#
+# The first drops the repository's own prefix convention: a subject beginning
+# `roadmap:` or `spec:` is work on the written layer, which a user of the binary
+# cannot observe. `feat:` and `fix:` are deliberately absent, because those
+# describe the product and predate the prose-title convention.
+#
+# The second drops the subjects that describe the same work without a prefix,
+# which is most of them: a row moving on the roadmap, a phase reordering, a
+# ruling being written, a token the release needed. It matches anywhere in the
+# subject rather than at an anchor, because the internal thing is as often the
+# object as the subject, and case-insensitively, because `ROADMAP.md` and `the
+# roadmap` are the same subject twice.
+#
+# **Scoping the range to `crates/` instead was tried and does not work here.**
+# It is the usual way to do this and it looks stricter, but this repository
+# gates its own prose from tests, so a commit that only edits ROADMAP.md still
+# touches `crates/vigia/tests/package.rs` to move a ceiling. Measured over
+# 0.34.0 to 0.38.0, the path scope kept every document commit in the range.
+#
+# The list is tuned against the 143 subjects this repository had at 0.38.0 and
+# is a heuristic, not a rule: it will pass something internal through, and the
+# cost of that is one odd line in a release note rather than a broken release.
+internal_prefix='^(roadmap|spec|docs?|ci|chore|deps?|take-next|skill|test|refactor|perf|style|build|process|steering|mockup|harden|release|vault writes)(\([^)]*\))?: '
+internal_subject='(roadmap|spec\.md|the spec|rulings?|revocation|withdrawn|written layer|phase [0-9]|the shelf|shelved|readme|claude\.md|clippy|cargo doc|ci complete|workflow|pre-flight|version raise|release note|the release |the bump |\btokens?\b|take-next|the skill|the harness|the record|budget table|mutation|audit|ceiling|proposal|declined|adopted|review agent|assertion|the mockup|funding|\.yml|§|^track the |^#[0-9]|^b[0-9]+[ :]|^[0-9]+\.[0-9]+,)'
+
+# `|| true` on both greps, because grep exits 1 when it filters everything out
+# and `set -e` would kill the script on the assignment rather than let the
+# empty case below be handled.
+kept=$(grep -Ev "$internal_prefix" || true)
+kept=$(printf '%s\n' "$kept" | grep -Eiv "$internal_subject" || true)
+
+# Trailing `(#123)` references are the tracker's, not the reader's. Stripped
+# repeatedly because a merge subject carries the issue's number and the pull
+# request's, and sometimes two issues'.
+entries=$(printf '%s\n' "$kept" \
+    | sed -E 's/[[:space:]]*\((#[0-9]+(,[[:space:]]*#[0-9]+)*)\)[[:space:]]*$//' \
+    | sed -E 's/[[:space:]]*\((#[0-9]+(,[[:space:]]*#[0-9]+)*)\)[[:space:]]*$//' \
+    | sed -E 's/[[:space:]]*\((#[0-9]+(,[[:space:]]*#[0-9]+)*)\)[[:space:]]*$//' \
+    | sed -E 's/[[:space:]]+$//' \
+    | grep -v '^$' \
+    | sed -E 's/^/- /' \
+    || true)
+
+# **An empty section is written rather than skipped, and it says so.** A version
+# with no section makes `dist` fall back to the install instructions alone, with
+# no warning anywhere, so the release that had nothing to report and the release
+# whose notes were lost look identical to a reader. This tells them apart.
+if [ -z "$entries" ]; then
+    entries="- Internal changes only. Nothing a user of the pane can see moved."
+fi
+
+# Written above the newest existing section, so the file stays newest first.
+# `awk` rather than `sed`, because the insertion is a block and the anchor is
+# the first line of many that match.
+#
+# The entries reach awk through a file rather than through `-v`, which
+# interprets backslash escapes in the value it is given: a commit subject
+# carrying one would arrive mangled, and a subject ending in one would eat the
+# line after it.
+lines="${changelog}.entries"
+printf '%s\n' "$entries" > "$lines"
+
+inserted="${changelog}.inserted"
+awk -v heading="## [${version}] - ${date}" -v lines="$lines" '
+    function emit() {
+        print heading
+        print ""
+        while ((getline entry < lines) > 0) print entry
+        close(lines)
+    }
+    !written && /^## \[/ {
+        emit()
+        print ""
+        written = 1
+    }
+    { print }
+    END { if (!written) emit() }
+' "$changelog" > "$inserted"
+mv "$inserted" "$changelog"
+rm -f "$lines"
+
+# Verify the write rather than trusting it, on raise-version.sh's rule: an awk
+# that matched nothing exits 0 and leaves the file as it was.
+if ! grep -qF "## [${version}] - ${date}" "$changelog"; then
+    echo "::error::the section for ${version} was not written to ${changelog}"
+    exit 1
+fi
+
+echo "::notice::wrote $(printf '%s\n' "$entries" | wc -l | tr -d ' ') entry line(s) for ${version}"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -81,9 +81,15 @@ jobs:
       # against a local HTTP server: with the extraheader set, both the initial
       # request and the post-401 retry sent the bot's token and the URL's was
       # never sent at all. `release.yml` already checks out this way.
+      #
+      # **`fetch-depth: 0` is what lets the release say what changed**, and the
+      # default fails quietly rather than loudly: a shallow checkout carries no
+      # tags, so the range the notes are written from has no previous release to
+      # start at and the section comes out holding the whole history or nothing.
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
@@ -352,10 +358,42 @@ jobs:
           sh .github/scripts/raise-version.sh '${{ steps.version.outputs.next }}'
           cargo update --workspace
 
+      # **What the release tells a user it changed.** `dist` reads CHANGELOG.md,
+      # matches the section whose heading carries the version being released,
+      # and puts it above the install instructions in the release body. A
+      # version with no section is not an error there: the body falls back to
+      # the install instructions alone, with no warning anywhere, so a release
+      # that had nothing to say and a release whose notes were lost look
+      # identical to the person reading it. That is why this runs here, before
+      # the commit, rather than being left to whoever remembers.
+      #
+      # Same shape as the raise above and for the same reason: the filtering
+      # that decides what a user is told lives in a script a test can drive.
+      # `--first-parent` is insurance rather than a correction, since every
+      # merge here is squashed and the log is already one subject per pull
+      # request.
+      - name: write the changelog section
+        run: |
+          set -euo pipefail
+          previous=$(git describe --tags --abbrev=0 2>/dev/null || true)
+          if [ -z "$previous" ]; then
+            echo "::error::no tag to write the notes from; a shallow checkout is the usual cause"
+            exit 1
+          fi
+          git log --first-parent --format='%s' "${previous}..HEAD" \
+            | sh .github/scripts/changelog-entry.sh \
+                '${{ steps.version.outputs.next }}' "$(date -u +%F)"
+
       # The gate that makes the sed above safe, run before anything is pushed.
       # It compares the two strings the edit touched and fails if they disagree.
       - name: the manifests agree
         run: cargo test -p vigia --test package the_internal_dependency_tracks_the_workspace_version
+
+      # And the section landed under the version being released, which is the
+      # only thing `dist` looks at. CI cannot have checked this: the version it
+      # ran against is the one before this job moved it.
+      - name: the changelog names the version being released
+        run: cargo test -p vigia --test package the_changelog_names_the_version_the_manifest_carries
 
       # And the binary reports the new number, which is the claim a user checks.
       - name: the binary reports the new version
@@ -382,7 +420,7 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml Cargo.lock
+          git add Cargo.toml Cargo.lock CHANGELOG.md
           git commit -m "release: ${{ steps.version.outputs.next }}"
 
           # **Pushed with `RELEASE_TOKEN`, and this only works because the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,382 @@
+# Changelog
+
+Every released version of `vigia`, newest first. The date is the day the release was cut.
+
+Before 1.0, a minor release can change behaviour. Anything that moves a key, a gesture or the default look is called out here.
+
+## [0.38.0] - 2026-09-07
+
+### Changed
+
+- Notes draw in six inks of their own, so a note reads as a note rather than as diff.
+- The prompt line says what each note is waiting on.
+
+## [0.37.0] - 2026-09-07
+
+### Added
+
+- Notes on a diff line. The line number becomes a note icon under the pointer, and the note draws in a bordered box under its line.
+- `vigia mcp` serves those notes to a coding agent over stdio, from a store kept per worktree.
+- Enter posts a note straight into the running session's socket.
+- The pane wakes on its own when the agent writes to the note store.
+
+### Fixed
+
+- A file changed in both the staged and the unstaged run takes one note placement, not one per run.
+
+## [0.36.0] - 2026-09-04
+
+### Fixed
+
+- A file's height is recounted when it settles rather than at the next event, so the scrollbar stops sizing itself against a file still being written.
+- The scrollbar a wrapped diff draws when it is shorter than its region is now reachable by the pointer.
+
+## [0.35.2] - 2026-09-04
+
+### Changed
+
+- The footer's text crossfades, eased at both ends and long enough to watch.
+
+## [0.35.1] - 2026-09-04
+
+### Changed
+
+- Every footer voice moves on the glyph channel, and moves for long enough to see.
+
+## [0.35.0] - 2026-09-04
+
+### Added
+
+- The pane says so when a newer version of `vigia` has been published.
+
+### Changed
+
+- The footer gets three voices, and each arrives and leaves in its own way.
+
+## [0.34.0] - 2026-09-04
+
+### Changed
+
+- A change arrives by coalescing rather than appearing all at once.
+
+## [0.33.1] - 2026-09-03
+
+### Fixed
+
+- A fresh dependency resolve no longer picks up tinyvec 1.13.0, which does not compile.
+
+## [0.33.0] - 2026-09-03
+
+### Changed
+
+- Letting go of a drag sends the selected rows, so the separate `y` step is gone.
+- `Esc` closes the gestures sheet.
+
+### Fixed
+
+- A page step and the scrollbar thumb count rows of the diff rather than rows of the pane.
+- One entry that cannot be read is one entry, not a broken frame.
+
+## [0.32.0] - 2026-09-03
+
+### Added
+
+- Drag over the diff to select rows, and `y` sends their real text rather than what the terminal happens to have on screen.
+- `y` copies the caret file's path.
+- The gestures sheet says that text can be selected, which had been true and undocumented.
+
+### Fixed
+
+- The masthead graph's spike no longer sits inside the band.
+
+## [0.31.1] - 2026-08-26
+
+### Fixed
+
+- The caret mark stays on the last edited file.
+- gix 0.87, off the version that needed a yanked crate.
+
+## [0.31.0] - 2026-08-26
+
+### Added
+
+- `w` wraps a long line so it can be read to its end, capped at two rows.
+
+## [0.30.3] - 2026-08-26
+
+### Fixed
+
+- A list that is entirely staged says so, and reads as staged.
+
+## [0.30.2] - 2026-08-26
+
+### Fixed
+
+- A file is never drawn without the label of the run it belongs to.
+
+## [0.30.1] - 2026-08-26
+
+### Fixed
+
+- The pane stops showing what is no longer there.
+
+## [0.30.0] - 2026-08-26
+
+### Added
+
+- Theming. A theme file decides what the pane is allowed to look like, and every theme key has a documented row.
+- File paths are clickable links in terminals that support OSC 8.
+
+### Changed
+
+- The showcase look becomes the default.
+- Colour ramps interpolate in Oklab, so their steps read evenly.
+- Block glyphs use octants on terminals known to draw them, chosen by terminal version.
+- The diff colours follow the delta formula.
+
+## [0.29.1] - 2026-08-25
+
+### Changed
+
+- The staged mark moves onto the kind letter, which gives a column back to the path.
+
+## [0.29.0] - 2026-08-25
+
+### Added
+
+- `a` draws the staged run beside the unstaged one.
+
+## [0.28.0] - 2026-08-25
+
+### Added
+
+- The pane starts in the view the reader configured rather than in the built-in default.
+
+### Fixed
+
+- The gestures sheet names the two gestures it had been leaving out.
+
+## [0.27.0] - 2026-08-25
+
+### Added
+
+- `s` pins the diff to one file.
+- `←` and `→` move between changed files.
+
+### Fixed
+
+- The gestures sheet swallows the key press that closes it, so the press no longer reaches the pane behind.
+
+## [0.26.0] - 2026-08-24
+
+### Added
+
+- `r` toggles the left rail.
+
+## [0.25.1] - 2026-08-24
+
+### Fixed
+
+- The gestures sheet pages, so a small pane stops dropping gestures in silence.
+
+## [0.25.0] - 2026-08-24
+
+### Changed
+
+- The file list becomes a left rail beside the diff.
+
+### Fixed
+
+- The gestures sheet spends the width it has, so a short pane stops dropping the mouse group.
+
+## [0.24.0] - 2026-08-22
+
+### Fixed
+
+- The churn band's yardstick stops being set by one loud burst, and the braille rung comes back with it.
+
+## [0.23.0] - 2026-08-22
+
+### Changed
+
+- Follow lands on the change itself rather than on the filename above it.
+- Under a level, the churn band draws at the block rung.
+
+### Fixed
+
+- A screenful of prose stops costing 100ms a frame.
+
+## [0.22.0] - 2026-08-21
+
+### Fixed
+
+- The frame path stops parsing under a grammar nothing has compiled, so the first Markdown file in a session no longer costs half a second on the frame that draws it.
+
+## [0.21.0] - 2026-08-21
+
+### Changed
+
+- The file list deepens on a tall pane.
+- The sparkline's bucket count follows the pane width.
+
+## [0.20.1] - 2026-08-19
+
+### Fixed
+
+- The vendored grammars ship their licence texts, not just their names.
+
+## [0.20.0] - 2026-08-19
+
+### Changed
+
+- The grammar set becomes one vetted dump covering every modern language.
+
+## [0.19.0] - 2026-08-18
+
+### Changed
+
+- The churn band runs under the scrollbar, and the track moves with it.
+- The glance elements draw a level.
+
+### Fixed
+
+- The published crate carries the licence text.
+
+## [0.18.0] - 2026-08-18
+
+### Changed
+
+- The glance elements become a graph.
+
+## [0.17.0] - 2026-08-18
+
+### Changed
+
+- The sparkline draws twelve buckets of ten seconds.
+- The churn band draws in columns rather than in cells.
+
+## [0.16.0] - 2026-08-18
+
+### Added
+
+- A braille rung above the block ramp for the sparkline.
+
+## [0.15.0] - 2026-08-17
+
+### Changed
+
+- The churn band gets its left bar and reaches the bar's own column.
+- The header gets air, and the sigil gets a column of its own.
+
+## [0.14.0] - 2026-08-17
+
+### Changed
+
+- The gestures sheet is opaque.
+
+## [0.13.0] - 2026-08-17
+
+### Changed
+
+- The bottom bar keeps `q`, `f` and `?` and nothing else.
+
+## [0.12.0] - 2026-08-17
+
+### Added
+
+- `?` opens a sheet of every gesture, over the pane.
+
+## [0.11.1] - 2026-08-17
+
+- Internal changes only. Nothing a user of the pane can see moved.
+
+## [0.11.0] - 2026-08-17
+
+### Changed
+
+- The churn band starts hidden, and `m` is how it arrives.
+
+## [0.10.0] - 2026-08-16
+
+### Added
+
+- The worktree churn band, in a masthead that names the branch.
+- The glance row gets slices and a colour ramp.
+
+## [0.9.0] - 2026-08-16
+
+### Changed
+
+- The pointer takes the bar's colour, and the caret's row takes the bold.
+
+## [0.8.0] - 2026-08-16
+
+### Added
+
+- The scrollbar thumb and every listed file take a hover mark.
+
+## [0.7.0] - 2026-08-16
+
+### Added
+
+- A hover mark on the scrollbars, and the takeover asks the terminal for focus events.
+
+## [0.6.0] - 2026-08-16
+
+### Changed
+
+- A scroll lights one arrow on one bar.
+
+## [0.5.0] - 2026-08-16
+
+### Fixed
+
+- A drag keeps the bar it started on, and a gesture in progress is lit.
+- The scrollbar's track and its buttons were invisible, at 1.24:1 contrast.
+
+## [0.4.0] - 2026-08-15
+
+### Added
+
+- The scrollbar grows a step button at each end, and one click is one step.
+
+## [0.3.0] - 2026-08-15
+
+### Changed
+
+- A blank row closes every file's block but the last.
+- The sigil stands off its line.
+- The counters take the diff's green and red, and a zero keeps the grey.
+
+## [0.2.1] - 2026-08-15
+
+### Fixed
+
+- The file list draws the rank the digit keys address.
+
+## [0.2.0] - 2026-08-14
+
+### Added
+
+- `n` and `p` step a file, and the digit keys name a drawn row.
+- `d` and `u` are the half page.
+
+### Changed
+
+- The pane stands back from its own edge, and its furniture does not.
+
+## [0.1.0] - 2026-08-09
+
+First public release. `vigia` shows the working tree diff in a terminal pane and redraws it as the tree changes.
+
+### Added
+
+- The working tree diff, fullscreen, redrawn on filesystem events rather than on a timer.
+- Follow mode, on by default, so the newest change is scrolled to without being asked.
+- Syntax highlighting, with the first frame drawn plain so startup stays imperceptible.
+- A per-file heat strip and a sparkline, over a churn history bounded to 256 paths and 120 seconds.
+- Keyboard and mouse scrolling, and a scrollbar.
+- 256-colour and monochrome degradation paths.
+- The terminal restored on every exit the process can observe, including an external kill.
+- Legible at 40 columns.
+- Prebuilt binaries for Linux, macOS and Windows, `cargo install vigia`, and a Homebrew tap.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ These are the ones a first PR is most likely to trip on.
 - **Pure Rust.** Any dependency pulling `cc`, `cmake` or `bindgen` breaks static Linux builds and Windows, and CI fails the build if one appears.
 - **Do not hard-wrap prose.** Commit message bodies wrap at 72; markdown and PR bodies do not wrap at all, because GitHub renders a single newline as a line break.
 - **Titles say what is broken or what to build.** One clause, no "because" — the explanation goes in the body.
+- **A pull request title becomes a release note.** The release writes its notes from the titles in it, so a title is read by people who will never open the diff.
 
 ## Running things
 

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ Everything is pure Rust on purpose: a genuinely static Linux binary needs no cro
 
 There is no Phase 5 in that table: the shelf, where deferred work waits with the dated reason it was deferred for, was numbered as one until August and kept its milestone.
 
-Built in the open, spec first. [`SPEC.md`](SPEC.md) is the source of truth and is written *before* the code, so it is the honest place to see where this is going and to argue with it. [`ROADMAP.md`](ROADMAP.md) is the live state, issue linked.
+Built in the open, spec first. [`SPEC.md`](SPEC.md) is the source of truth and is written *before* the code, so it is the honest place to see where this is going and to argue with it. [`ROADMAP.md`](ROADMAP.md) is the live state, issue linked. [`CHANGELOG.md`](CHANGELOG.md) is every released version and what moved in it.
 
 <details>
 <summary><b>🖼️ About that picture at the top</b></summary>
@@ -578,7 +578,7 @@ It is also the verb, third person. So `vigia .` reads as a sentence.
 
 <div align="center">
 
-**MIT** · Built in the open · [SPEC](SPEC.md) · [ROADMAP](ROADMAP.md) · [Issues](https://github.com/breferrari/vigia/issues)
+**MIT** · Built in the open · [SPEC](SPEC.md) · [ROADMAP](ROADMAP.md) · [CHANGELOG](CHANGELOG.md) · [Issues](https://github.com/breferrari/vigia/issues)
 
 </div>
 

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -1568,6 +1568,241 @@ fn the_bump_workflow_runs_the_script_the_gate_proves() {
     );
 }
 
+/// Every release section's heading, newest first, as `(version, date)`.
+///
+/// A line match rather than a parse, because the heading is the whole of what
+/// has to be right: `dist` finds the section by the version inside it and
+/// reads nothing else to decide which one to publish.
+fn changelog_headings() -> Vec<(String, String)> {
+    repo_file("CHANGELOG.md")
+        .lines()
+        .filter_map(|line| line.strip_prefix("## ["))
+        .map(|rest| {
+            let (version, date) = rest.split_once("] - ").unwrap_or_else(|| {
+                panic!("a changelog heading reads `## [{rest}`, which carries no version and date")
+            });
+            (version.to_owned(), date.trim().to_owned())
+        })
+        .collect()
+}
+
+/// The notes the release publishes are the ones for the version it ships.
+///
+/// `dist` reads CHANGELOG.md, matches the section whose heading carries the
+/// version being released, and puts it above the install instructions in the
+/// body. **A version it finds no section for is not an error there**: the body
+/// falls back to the install instructions alone and nothing warns, in the log
+/// or on the release, so a release that had nothing to say and a release whose
+/// notes went missing are the same release to whoever reads it. This is what
+/// tells them apart, and the bump runs it between writing the section and
+/// committing it, which is before anything irreversible.
+#[test]
+fn the_changelog_names_the_version_the_manifest_carries() {
+    let manifest = repo_file("Cargo.toml");
+    let version = manifest
+        .lines()
+        .find_map(|line| line.strip_prefix("version = \""))
+        .and_then(|rest| rest.split('"').next())
+        .expect("the workspace manifest carries a version");
+
+    let headings = changelog_headings();
+    let (newest, date) = headings
+        .first()
+        .expect("CHANGELOG.md carries at least one release section");
+    assert_eq!(
+        newest, version,
+        "the manifest is at {version} and the newest section in CHANGELOG.md is \
+         {newest}. dist matches the section by version and falls back to the \
+         install instructions when it finds none, so this release would ship \
+         telling nobody what changed"
+    );
+    assert!(
+        date.len() == 10 && date.starts_with("20") && date.split('-').count() == 3,
+        "the newest changelog heading dates the release {date:?}, which is not an \
+         ISO date"
+    );
+}
+
+/// The file reads newest first, which is the order a new section is written in.
+///
+/// The generator inserts above the first heading it finds rather than sorting,
+/// so a file that is out of order stays out of order and puts the next release
+/// in the middle of the list.
+#[test]
+fn the_changelog_runs_newest_first() {
+    let semver = |version: &str| -> (u64, u64, u64) {
+        let mut parts = version.split('.').map(|part| {
+            part.parse::<u64>()
+                .unwrap_or_else(|_| panic!("{version} is not three numbers"))
+        });
+        let mut next = || parts.next().unwrap_or_else(|| panic!("{version} is short"));
+        (next(), next(), next())
+    };
+
+    let headings = changelog_headings();
+    assert!(
+        headings.len() > 1,
+        "CHANGELOG.md holds {} section(s), so this gate is passing on nothing",
+        headings.len()
+    );
+
+    let out_of_order: Vec<String> = headings
+        .windows(2)
+        .filter(|pair| semver(&pair[0].0) <= semver(&pair[1].0))
+        .map(|pair| format!("  {} sits above {}", pair[0].0, pair[1].0))
+        .collect();
+    assert!(
+        out_of_order.is_empty(),
+        "CHANGELOG.md is not in descending version order, so the next release is \
+         written into the middle of it:\n{}",
+        out_of_order.join("\n")
+    );
+}
+
+/// The release writes the section it publishes, and commits it.
+///
+/// Four claims, and none implies the others. That the notes come from the
+/// script the gate below drives. That the range starts at the previous
+/// release. That the checkout is deep enough for that range to resolve, since
+/// a shallow one carries no tags and would leave the section holding the whole
+/// history or nothing. And that the file reaches the commit: a release that
+/// writes the section and leaves it behind publishes the notes once and loses
+/// them, so the next release starts from a file that never saw this one.
+#[test]
+fn the_bump_writes_the_changelog_it_publishes() {
+    let bump = without_comments(&repo_file(".github/workflows/bump.yml"));
+    let step = step_block(&bump, "write the changelog section");
+    assert!(
+        step.contains("sh .github/scripts/changelog-entry.sh"),
+        "bump.yml's changelog step does not run changelog-entry.sh, so the gate \
+         over the script proves nothing about the release: {step}"
+    );
+    assert!(
+        step.contains("git describe --tags --abbrev=0"),
+        "bump.yml's changelog step does not start the range at the previous \
+         release: {step}"
+    );
+    assert!(
+        bump.contains("fetch-depth: 0"),
+        "bump.yml checks out without `fetch-depth: 0`, so it holds no tags and \
+         the range the notes are written from cannot reach the previous release"
+    );
+
+    // A step that can be skipped is a release that can ship without notes, and
+    // the fallback that follows is silent.
+    assert_step_always_runs(&bump, "write the changelog section");
+    assert_precedes(
+        &bump,
+        "name: write the changelog section",
+        "name: commit the bump",
+        "bump.yml commits before it writes the changelog section, so the section \
+         is written into a tree nothing commits",
+    );
+
+    let commit = step_block(&bump, "commit the bump");
+    assert!(
+        commit.contains("git add Cargo.toml Cargo.lock CHANGELOG.md"),
+        "the bump commits without CHANGELOG.md, so the section it just wrote \
+         reaches the release body and never reaches the default branch: {commit}"
+    );
+}
+
+/// Drives the generator against fixed subjects, in a scratch directory of its
+/// own. Returns whether it passed and the file it left behind.
+#[cfg(unix)]
+fn changelog_entry(case: &str, version: &str, subjects: &str, changelog: &str) -> (bool, String) {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let script = repo_root().join(".github/scripts/changelog-entry.sh");
+    let dir = std::env::temp_dir().join(format!("vigia-changelog-{}-{case}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap_or_else(|e| panic!("create {}: {e}", dir.display()));
+    let path = dir.join("CHANGELOG.md");
+    std::fs::write(&path, changelog).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+
+    let mut child = Command::new("sh")
+        .arg(&script)
+        .arg(version)
+        .arg("2026-01-01")
+        .arg(&path)
+        .stdin(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|e| panic!("run {}: {e}", script.display()));
+    child
+        .stdin
+        .take()
+        .expect("the child's stdin is a pipe")
+        .write_all(subjects.as_bytes())
+        .expect("the subjects reach the script");
+    let passed = child.wait().expect("the script exits").success();
+
+    let left = read(&path);
+    let _ = std::fs::remove_dir_all(&dir);
+    (passed, left)
+}
+
+/// The generator keeps what a reader of the pane can see and drops the rest.
+///
+/// The filter is the only part of the release that decides what a user is
+/// told, and it is a heuristic over commit subjects, so it is driven here
+/// rather than trusted. One subject of each class it sorts on: prefixed
+/// internal work, unprefixed internal work naming a document, and two changes
+/// a reader can observe, whose trailing references belong to the tracker and
+/// come off.
+#[cfg(unix)]
+#[test]
+fn the_changelog_entry_keeps_what_a_reader_can_see() {
+    const BEFORE: &str = "# Changelog\n\n## [0.1.0] - 2026-01-01\n\n- First.\n";
+
+    let subjects = "roadmap: a row moves\n\
+                    The roadmap marks a row done (#449)\n\
+                    `w` wraps a long line, capped at two (#272) (#344)\n\
+                    The pane stops showing what is no longer there (#340) (#341)\n";
+    let (passed, left) = changelog_entry("mixed", "0.2.0", subjects, BEFORE);
+    assert!(
+        passed,
+        "the generator refused a section it can write:\n{left}"
+    );
+
+    let written: Vec<&str> = left
+        .lines()
+        .skip_while(|line| !line.starts_with("## [0.2.0]"))
+        .take_while(|line| !line.starts_with("## [0.1.0]"))
+        .filter(|line| line.starts_with("- "))
+        .collect();
+    assert_eq!(
+        written,
+        [
+            "- `w` wraps a long line, capped at two",
+            "- The pane stops showing what is no longer there",
+        ],
+        "the generator kept the wrong subjects:\n{left}"
+    );
+
+    // Nothing a reader can see is not the same as no section at all, and the
+    // difference is the whole reason this writes one: a missing section makes
+    // dist fall back to the install instructions without saying so.
+    let (passed, left) = changelog_entry("internal", "0.3.0", "roadmap: a row moves\n", BEFORE);
+    assert!(
+        passed,
+        "the generator refused an all-internal range:\n{left}"
+    );
+    assert!(
+        left.contains("## [0.3.0]") && left.contains("Internal changes only"),
+        "an all-internal range left no section, so the release would fall back to \
+         the install instructions in silence:\n{left}"
+    );
+
+    // A section already written is the better text, so it is not overwritten.
+    // A re-run of a release reaches this, and so does a section written by
+    // hand.
+    let (passed, left) = changelog_entry("existing", "0.1.0", "A change (#1)\n", BEFORE);
+    assert!(
+        !passed && left == BEFORE,
+        "the generator overwrote a section that was already written:\n{left}"
+    );
+}
+
 /// What each document is allowed to weigh, in bytes.
 ///
 /// The two a session reads before anything else are in the table, because


### PR DESCRIPTION
Thirty-eight releases have shipped install instructions and nothing else. The tool now has users who did not write it, and the one question a release has to answer has had no answer anywhere in the repository.

## What `dist` already does, probed rather than read

`dist` 0.32 is installed on this machine, so this was checked against this workspace rather than taken from documentation:

- a root `CHANGELOG.md` **is** found, for a workspace whose package lives under `crates/`
- the section whose heading carries the version being released **is** matched
- its body lands as `## Release Notes`, **above** the install block
- the archives now carry `CHANGELOG.md` beside `README` and `LICENSE`, for free

No change to `release.yml`, `Cargo.toml` or the `dist` metadata was needed.

One consequence worth flagging: the release **title** becomes the changelog heading, so `v0.39.0` will read `0.39.0 - 2026-09-08`. That is `dist`'s behaviour when a section exists, not a choice made here.

## The failure mode is the reason for the gates

A version `dist` finds no section for is **not an error** there. The body falls back to the install instructions alone, with no warning in the log or on the release. So a release that had nothing to say and a release whose notes went missing read identically to whoever opens it.

`the_changelog_names_the_version_the_manifest_carries` is what tells them apart, and the bump runs it between writing the section and committing it, which is before anything irreversible. CI cannot have covered it: the version CI ran against is the one before the bump moved it.

## The retrofit

Every version from 0.1.0, hand written from the git history, in plain language for someone who just installed the binary rather than in the commit titles' voice. Internal work on the written layer is left out. All 50 tags have a section.

## Going forward

`bump.yml` generates the section from the subjects of the range being released, so nothing has to be remembered at release time.

`changelog-entry.sh` carries the filter, in a file rather than inline on `raise-version.sh`'s rule: it decides what a user is told, and a filter nothing drives is a wish.

**Scoping the range to `crates/` instead was tried and does not work here.** It is the usual way to do this and it looks stricter, but this repository gates its own prose from tests, so a commit that only edits `ROADMAP.md` still touches `package.rs` to move a ceiling. Measured over 0.34.0 to 0.38.0, the path scope kept every document commit in the range. The title filter is tuned against all 143 subjects the repository had at 0.38.0, and it is a heuristic rather than a rule: it will let something internal through, and that costs one odd line in a release note rather than a broken release.

## Gates

| Gate | What it catches |
|---|---|
| `the_changelog_names_the_version_the_manifest_carries` | a release that would ship the silent install-only fallback |
| `the_changelog_runs_newest_first` | a file out of order, which puts the next section in the middle of it |
| `the_bump_writes_the_changelog_it_publishes` | the step going missing, becoming skippable, losing `fetch-depth: 0`, or the file not reaching the commit |
| `the_changelog_entry_keeps_what_a_reader_can_see` | the filter keeping the wrong subjects, an all-internal range leaving no section, an existing section being overwritten |

## Verification

`cargo fmt`, `cargo clippy --all-targets` and `cargo test --workspace` under `RUSTFLAGS=-D warnings`.

The script gate is `cfg(unix)`, on the same rule `raise-version.sh`'s is and covered by the same assertion that the bump runs on `ubuntu-latest`. Its three contracts were additionally driven straight at the script here, because the Windows canonical path defeats Git Bash's `sh`: the mixed range keeps exactly the two observable subjects and strips their trailing references, an all-internal range writes a section saying so, and a section that already exists is refused with the file untouched.

## Left open

`SPEC.md` section 9 describes the release and does not yet name this step. It sits at its exact byte ceiling, so saying so has to be funded by prose coming out, and that is its own commit rather than this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
