### PR TITLE
The guard reads a release's notes, and stops refusing their path

### DIFF
--- a/.claude/scripts/leak-guard.mjs
+++ b/.claude/scripts/leak-guard.mjs
@@ -13,9 +13,19 @@
 //   - a --body-file whose newlines were destroyed (PowerShell array-join
 //     flattening: one giant line where a document should be)
 //
-// The path handed to --body-file, --file or -F is dropped from the inline scan
-// first: it says where the body sits and never lands in it, and a scratch
-// directory under the user's profile is exactly the shape the path class matches.
+// The path handed to --body-file, --notes-file, --file or -F is dropped from
+// the inline scan first: it says where the body sits and never lands in it, and
+// a scratch directory under the user's profile is exactly the shape the path
+// class matches.
+//
+// --notes-file is the flag `gh release create|edit` takes, and it is a separate
+// alternative rather than a suffix of --file, which it does not contain: the
+// hyphens fall as `notes-file`, so an alternation of --file never reaches it.
+// Missing it cost both halves at once. A body published that way was never read,
+// so the classes above went unchecked on the one surface a user reads most; and
+// its path stayed in the inline scan, so an ordinary Windows path under the
+// profile was blocked as a leak. A guard that skips the body and refuses the
+// path is wrong in both directions from one omission.
 
 import { readFileSync } from "node:fs";
 import { isAbsolute, resolve } from "node:path";
@@ -54,7 +64,7 @@ const block = (what, hits) => {
 	process.exit(2);
 };
 
-const m = /(?:--body-file|--file|-F)[= ]\s*(?:"([^"]+)"|'([^']+)'|(\S+))/.exec(command);
+const m = /(?:--body-file|--notes-file|--file|-F)[= ]\s*(?:"([^"]+)"|'([^']+)'|(\S+))/.exec(command);
 const bodyFile = m ? (m[1] ?? m[2] ?? m[3]) : null;
 const inline = m ? command.replace(m[0], " ") : command;
 

--- a/.claude/scripts/selftest.sh
+++ b/.claude/scripts/selftest.sh
@@ -52,6 +52,13 @@ expect leak-guard.mjs 2 "a publish whose body carries the trailer is blocked" "g
 expect leak-guard.mjs 2 "a publish whose body carries a session URL is blocked" "gh issue comment 1 --body-file $FIXW/url.md"
 expect leak-guard.mjs 2 "an inline body with a session URL is blocked" 'gh pr comment 1 --body "see https://claude.ai/code/session_01abc"'
 expect leak-guard.mjs 0 "a body-file path under the profile is not a leak" 'gh pr create --title t --body-file "C:\Users\someone\AppData\Local\Temp\x\body.md"'
+# A release takes its body through --notes-file, which is a different flag and
+# not a suffix of --file. Both directions are cases, because the omission broke
+# both: the body went unread, and its path was read as a leak.
+expect leak-guard.mjs 0 "a release with a clean notes file is allowed" "gh release edit v0.1.0 --notes-file $FIXW/clean.md"
+expect leak-guard.mjs 2 "a release whose notes carry a session URL is blocked" "gh release edit v0.1.0 --notes-file $FIXW/url.md"
+expect leak-guard.mjs 2 "a new release whose notes carry the trailer is blocked" "gh release create v0.1.0 --notes-file $FIXW/trailer.md"
+expect leak-guard.mjs 0 "a notes-file path under the profile is not a leak" 'gh release edit v0.1.0 --notes-file "C:\Users\someone\AppData\Local\Temp\x\notes.md"'
 expect leak-guard.mjs 2 "a commit message carrying the trailer is blocked" 'git commit -m "subject" -m "Claude-Session: https://claude.ai/code/session_01abc"'
 expect leak-guard.mjs 2 "a commit message file carrying the trailer is blocked" "git commit -F $FIXW/trailer.md"
 expect leak-guard.mjs 0 "a clean commit is allowed" 'git commit -m "The version raise counts only the lines it moved"'


### PR DESCRIPTION
`gh release create|edit` takes its body through `--notes-file`, and the guard's flag alternation did not carry it.

It is not a suffix of `--file` and never could be matched by one. The hyphens in `--notes-file` fall as `notes-file`, so a scan for `--file` needs two consecutive hyphens that are not there, and `-F` needs an uppercase `F`. The flag was invisible to the guard.

## One omission, wrong in both directions

**The body was never read.** With `bodyFile` null, the guard does its inline scan and exits 0 without opening the file. So neither artifact class was checked on the surface a user of the tool reads most.

**And the path was read as a leak.** The path is only dropped from the inline scan when the flag matches. Unmatched, it stayed in, where a scratch path under the user's profile is exactly the shape the local-path class matches. A correct call was refused.

A guard that skips the body and refuses the path is wrong in both directions from one missing alternative.

## How it was found

While backfilling the release notes for all fifty published versions. That is fifty `gh release edit --notes-file` calls whose bodies the guard was not reading, and which it would have refused outright had they been written with native Windows paths rather than POSIX ones.

## The cases, watched red

Four in `selftest.sh`, covering both directions plus a control. Against the unfixed guard:

```
  ok   a release with a clean notes file is allowed
  FAIL a release whose notes carry a session URL is blocked
    expected exit 2, got 0
  FAIL a new release whose notes carry the trailer is blocked
    expected exit 2, got 0
  FAIL a notes-file path under the profile is not a leak
    expected exit 0, got 2
```

The control passes either way and is there to keep the other three honest: without it, a change that made the guard block everything would turn all three green.

With the fix, the whole selftest exits 0, fourteen leak-guard cases and the scan-guard and record-guard suites unchanged.

## One thing this does not do

**Nothing runs `selftest.sh` but a person.** It is in no workflow, and no test reads it. That is how this gap survived, and it is the reason the next one will too. Left as it was rather than widened here, but it is worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
