### PR TITLE
The roadmap marks #460 and #459 done

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -183,8 +183,8 @@ Milestone: [Phase 8](https://github.com/breferrari/vigia/milestone/8)
 |---|---|---|
 | ✅ | The agent's reply draws in the reader's own ink. **Reported from use** | [#451](https://github.com/breferrari/vigia/issues/451) |
 | ⬜ | The agent's reply draws code as prose | [#452](https://github.com/breferrari/vigia/issues/452) |
-| ⬜ | The note box arrives in a diff row's time, so a considered effect reads as a pop. **Reported from use** | [#460](https://github.com/breferrari/vigia/issues/460) |
-| ⬜ | A note with no reply still draws the answer's stem. **Reported from use** | [#459](https://github.com/breferrari/vigia/issues/459) |
+| ✅ | The note box arrives in a diff row's time, so a considered effect reads as a pop. **Reported from use** | [#460](https://github.com/breferrari/vigia/issues/460) |
+| ✅ | A note with no reply still draws the answer's stem. **Reported from use** | [#459](https://github.com/breferrari/vigia/issues/459) |
 | ⬜ | Remove the masthead, and revoke the ruling that kept it | [#457](https://github.com/breferrari/vigia/issues/457) |
 | ⬜ | vigia mcp finds its worktree by an agent's own variable | [#450](https://github.com/breferrari/vigia/issues/450) |
 | ✅ | The footer's transition is too quick to see, and unreadable while it runs. **Reported from use** | [#410](https://github.com/breferrari/vigia/issues/410) |


### PR DESCRIPTION
Both shipped in #461. The rows went in unstarted in that same PR, because the pre-flight found them unfiled and they could not be marked done until the issues closed.

Docs-only: the diff is two characters in `ROADMAP.md`, and the marks are three bytes each either way, so no written-layer ceiling moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
