### PR TITLE
A roadmap row is checked against the issue in its own cell

### DIFF
--- a/.claude/skills/take-next/preflight.sh
+++ b/.claude/skills/take-next/preflight.sh
@@ -127,7 +127,13 @@ done < "$tmp/issue-invariants.txt"
 say "3. state — roadmap marks vs issue state:"
 found=0
 grep -oE '^\| *(✅|🔨|⬜) *\|.*\[#[0-9]+\]' "$tmp/roadmap.md" | while IFS= read -r row; do
-  n=$(printf '%s' "$row" | grep -oE '\[#[0-9]+\]' | head -1 | tr -dc '0-9')
+  # The row's own issue is the one in its last cell, not the first link in it.
+  # Six rows cite a second issue in their task prose (`Revoked by`, `Closed by`,
+  # `Deferred by`), and reading the first link checked those rows against the
+  # wrong issue. Five of the six agreed by luck, both being closed; the sixth is
+  # a shelf row whose deferral cites a closed issue while its own is open, and
+  # that one reported drift on a roadmap that was correct.
+  n=$(printf '%s' "$row" | grep -oE '\[#[0-9]+\]' | tail -1 | tr -dc '0-9')
   state=$(awk -F'\t' -v n="$n" '$1 == n { print $2 }' "$tmp/issues.tsv")
   # A row citing an issue the board does not have used to `continue`, which is the
   # same silence #369 was about and not the same cause: truncation is one way to

--- a/.claude/skills/take-next/selftest.sh
+++ b/.claude/skills/take-next/selftest.sh
@@ -213,6 +213,27 @@ case "$line" in
        "DRIFT row cites #9, which the tracker does not have" "$line" ;;
 esac
 
+# A row's issue is the one in its last cell. Six live rows cite a second issue in
+# their task prose (`Revoked by`, `Closed by`, `Deferred by`), and reading the
+# first link checked those rows against the wrong issue: five agreed by luck,
+# both being closed, and the sixth reported drift on a roadmap that was correct.
+#
+# Its own fixture, because the shared one above is read by two cases that would
+# see this row's second link as a board it lacks.
+cat > "$FIX/roadmap.md" <<'ROW'
+## Phase 8 - look
+| | Task | Issue |
+|---|---|---|
+| ⬜ | deferred by [#1](https://example.invalid/1) | [#2](https://example.invalid/2) |
+ROW
+jq -n '[{number: 1, state: "CLOSED", milestone: {title: "Phase 8 - look"}, title: "I1: the first"},
+        {number: 2, state: "OPEN", milestone: {title: "Phase 8 - look"}, title: "issue 2"}]'   > "$FIX/issues.json"
+line=$(PREFLIGHT_SPEC_FILE="$FIX/spec.md"   PREFLIGHT_ROADMAP_FILE="$FIX/roadmap.md"   PREFLIGHT_ISSUES_FILE="$FIX/issues.json"   PREFLIGHT_ISSUE_LIMIT=10     sh "$PRE" 2>&1 | awk '/row (not marked done|marked done|cites)/ { $1 = $1; print }')
+case "$line" in
+  "") ok "a row is checked against the issue in its own cell" ;;
+  *)  no "a row is checked against the issue in its own cell" "no drift" "$line" ;;
+esac
+
 echo "drift:"
 
 present() { # needle, file, name


### PR DESCRIPTION
Pre-flight comparison 3 took the first `[#N]` in a roadmap row. A row's issue is the one in its **last** cell.

Six live rows cite a second issue in their task prose, under `Revoked by`, `Closed by` or `Deferred by`, so all six were checked against the wrong issue. Five of them agreed by luck, because both issues were closed and the row was `✅`. The sixth is #501's shelf row, whose deferral cites the now-closed #495 while its own issue is open, and it reported drift on a roadmap that was correct. That is what surfaced it.

`tail -1` instead of `head -1`, and the comment says why, so the next reader does not undo it.

**The selftest had no comparison-3 case for the row-to-issue mapping at all.** The case ships with the fix, on a fixture of its own: the shared roadmap above it is read by two cases that would see this row's second link as an issue the board lacks. Checked both ways, which is the only thing that makes it a gate.

```
  FAIL a row is checked against the issue in its own cell     (head -1)
  ok   a row is checked against the issue in its own cell     (tail -1)
```

`sh .claude/skills/take-next/selftest.sh` passes in full, offline, in about three seconds.

Docs-only by the scope rule? No. The skill's shell scripts are never docs, and this changes one. There is no cargo surface in the diff, so no test suite or budget gate applies; the selftest is the gate this change has.

Found by the pre-flight of the next take-next pass and fixed in it, which is step 1's own rule for a command in that file that no longer does what it says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
