### PR TITLE
The pack card leads with what vigia is, so the description reads for a newcomer

### DIFF
--- a/techpack.yaml
+++ b/techpack.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 1
 identifier: vigia
 displayName: vigia
-description: The vigia notes server, and the hooks that carry a pinned note into a running session
+description: Installs vigia, a live diff monitor for the terminal, and wires its notes into your Claude Code session
 author: Brenno Ferrari
 # The release that added `ignore:`, which is what keeps a commit to the crates
 # from telling installed copies that a pack update is waiting.


### PR DESCRIPTION
## Why

The mcs registry renders `techpack.yaml`'s `description` as the card subtitle and tokenises it into keyword chips. The old line ("the vigia notes server, and the hooks that carry a pinned note into a running session") means nothing to a newcomer, and the chips it seeded were `carry`, `pinned`, `into` and `running`. The new line names the product, the class and the integration in one sentence, so the chips derive from `vigia`, `diff`, `monitor`, `terminal`, `notes`, `claude`, `code` and `session` instead.

## Test plan

- Run `mcs pack validate .` → expect `all checks passed`.
- View the pack on the mcs registry after merge → expect the new description under the pack title and product-shaped chips.