### PR TITLE
The mockup's total joins the counts column the file rows use

### DIFF
--- a/assets/preview.svg
+++ b/assets/preview.svg
@@ -21,7 +21,13 @@
     <circle cx="74" cy="31" r="6" fill="#3fb950"/>
     <text class="m fg" x="102" y="36" font-size="14" font-weight="700">vigia</text>
     <text class="m fg" x="152" y="36" font-size="14" font-weight="700">&#183; main &#183; current &#9662; &#183; 3 changed</text>
-    <text class="m" x="866" y="36" font-size="13" text-anchor="end"><tspan class="grn">+55</tspan><tspan class="dim">&#160;&#160;&#160;</tspan><tspan class="red">&#8722;10</tspan></text>
+    <!-- The total joins the file rows' counts column rather than the status
+         bar's right edge. `render.rs::counts_edge` is one derivation read by the
+         header and by a row, and its own comment says why: two counts of the same
+         quantity a few rows apart, ending at different columns, is a worse glance
+         than either alone. Anchored at the same two x as every row below. -->
+    <text class="m grn" x="826.1" y="36" font-size="13.5" text-anchor="end">+55</text>
+    <text class="m red" x="874.7" y="36" font-size="13.5" text-anchor="end">&#8722;10</text>
 
     <!-- file rows -->
     <g font-size="13.5">


### PR DESCRIPTION
Reported from the picture: the header's total was not in the column it totals.

`+55 −10` was a single text run right-anchored at x=866, which is where the status bar's readouts end. Every file row draws `+N` end-anchored at 826.1 and `−N` at 874.7, so the total sat about a character to the left of the counts under it and read as a stray number rather than as the sum of that column.

## The pane does not allow this, by construction

`render.rs::counts_edge` exists for exactly this and says so:

> The columns between the chrome's right edge and the one a file row's counts cell ends at, read off `planning_width` so the two cannot drift apart.

The header's right side appends `edge` spaces after the minus for the same reason, so in a running pane the total and the file rows end at one column. The mockup had drifted from that.

## What changed

One text run becomes two, end-anchored at 826.1 and 874.7, which are the two columns every file row already uses, and set at the rows' 13.5 rather than 13 so the total is in the type of the column it heads.

Rendered and read at 5x before and after. The `−10` is one character wider than the `−7` below it and eats into the gap rather than pushing the column, which is what the pane's fixed-width minus cell does.

## Scope

Asset only. No gate reads `assets/preview.svg`: every mention in `crates/` is a comment pointing at it, so this is judged by eye, which is the rule for look and feel here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
