### PR TITLE
The README's gesture tables fit the well, and the notes section reads as steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It is a live diff monitor, and that is the half you can see. The other half is a
 **1. Install it and point it at a repo.**
 
 ```sh
-cargo install vigia
+cargo install vigia                          # or brew install breferrari/tap/vigia
 vigia                                        # the tree you are in
 ```
 
@@ -55,10 +55,10 @@ Leave it in the pane beside your agent. There is nothing to configure and nothin
 
 ```
   41 +      self.deadline = Instant::now() + DEBOUNCE;
-     ✎ this races the settle margin, check against I1
+     ✎ should this reset on every event, or just the first?
 ```
 
-The note goes to the agent anchored to that file and that line. Its answer arrives on a row under yours. This needs [one registration](#-notes-to-the-agent), once, for every project you will ever open.
+The note goes to the agent anchored to that file and that line. Its answer arrives on a row under yours. This needs [one registration](#notes), once, for every project you will ever open.
 
 **4. Look back when you need to.** `B` opens a list of every place the pane can stand: the live tree, the branch point, or any commit behind it. Pick one and the whole pane, counts and all, moves there. `Esc` and you are back.
 
@@ -69,11 +69,7 @@ The note goes to the agent anchored to that file and that line. Its answer arriv
 
 <br>
 
-```sh
-brew install breferrari/tap/vigia            # macOS and Linuxbrew
-```
-
-Or a prebuilt binary, no toolchain at all:
+A prebuilt binary, with no toolchain at all:
 
 ```sh
 # macOS and Linux
@@ -239,9 +235,6 @@ All three are backgrounds, so they need 24-bit colour and they leave together be
 
 ## ⌨️ Drive it
 
-<table>
-<tr><td valign="top" width="50%">
-
 **Keys**
 
 | | |
@@ -267,8 +260,6 @@ All three are backgrounds, so they need 24-bit colour and they leave together be
 | `?` `Esc` | all of this, on screen |
 | `q` `Ctrl+C` | quit |
 
-</td><td valign="top" width="50%">
-
 **Mouse**
 
 | | |
@@ -285,9 +276,6 @@ All three are backgrounds, so they need 24-bit colour and they leave together be
 | click `✕` | close the sheet |
 | just point | it marks itself |
 | `Shift`+drag | your terminal selects text |
-
-</td></tr>
-</table>
 
 **`m` opens every setting in one box**, the ones above and the two only the config file sets, with `↑` `↓` to move and `Space` to flip. `remember between runs` keeps what you flip for next time; `reset to defaults` puts every row back. **`?` draws every gesture on this page**, a page at a time where the pane is small. Both draw over rows that are already there, and `Esc` puts either away.
 
@@ -313,49 +301,75 @@ It shows the working tree against the **index**, untracked files included, and i
 
 ---
 
+<a id="notes"></a>
+
 ## ✍️ Notes to the agent
 
-Point at a line number in the diff and it becomes a pencil `✎`. Click it, and a small box opens under the line. Type one sentence, press `Enter`, and it goes to the agent in the other pane, anchored to that file and that line.
+Point at a line number in the diff and it becomes a pencil `✎`. Click it, type one sentence, press `Enter`.
+
+```
+  41 +      self.deadline = Instant::now() + DEBOUNCE;
+     ✎ should this reset on every event, or just the first?
+```
+
+It goes to the agent in the other pane carrying the file, the line and your words. The answer comes back on a row under yours.
 
 That is the whole of it. `vigia` calls no model, summarises nothing and judges nothing. It carries your words, and the agent answers.
 
-**After you press `Enter`.** The note draws under its line with a word for where it stands: `open` until the agent has looked, `seen` once it has, `changed` and drawn dim if you edited the line underneath it, and `gone`, under the file's heading, if the line left the diff. A file that leaves the diff altogether leaves its note **adrift**, counted in the footer beside the position as `2 notes · 1 adrift` and back under its line the moment the file returns. No state loses a note. The line's number stays lit while a note is on it, and `c` hides the rows without hiding the marks. The file's own row in the list carries a mark too, `✎` while you are waiting on the agent and `↳` once it has answered, which is how you find the one note in a run of thirty files.
+### What a note says while it waits
+
+Every note draws under its line with one word for where it stands.
+
+| | |
+|---|---|
+| `open` | Sent. The agent has not looked yet |
+| `seen` | The agent has read it |
+| `changed` | You edited the line underneath, so the row draws dim |
+| `gone` | The line left the diff, and the note moved under the file's heading |
+| `adrift` | The whole file left the diff. The footer counts it beside the position as `2 notes · 1 adrift` |
+
+**No state loses a note.** An adrift one is back under its line the moment the file returns. A line's number stays lit while a note is on it, and the file's own row in the list carries `✎` while you are waiting and `↳` once the agent has answered, which is how you find one note in a run of thirty files. `c` hides the note rows without hiding those marks.
 
 **When the agent resolves one**, its answer arrives on a row under the note, holds for a minute, and the note leaves.
 
-**To take one back yourself**, point at the note's left side. The cell under your pointer becomes `✕`, and clicking it withdraws the note, whether or not the agent has answered it. Nothing is drawn there until you point, so a screen full of notes stays a screen full of notes. Emptying the box over a note and pressing `Enter` does the same thing, and a note the agent resolved in the meantime is left alone: its answer is on its way to you.
+**To take one back**, point at the note's left side. The cell under your pointer becomes `✕`, and clicking it withdraws the note whether or not the agent has answered. Emptying the box and pressing `Enter` does the same. A note the agent resolved in the meantime is left alone, because its answer is already on its way to you.
 
-**Where they live.** One directory per worktree under your own state directory: `$XDG_STATE_HOME/vigia/`, or `~/.local/state/vigia/`, and `%LOCALAPPDATA%\vigia\state\` on Windows. Never inside the worktree and never inside `.git`. A monitor that wrote where it watches would wake itself, and the pane puts nothing in that directory but the notes you make.
+**Where they live.** One directory per worktree under your own state directory: `$XDG_STATE_HOME/vigia/`, or `~/.local/state/vigia/`, and `%LOCALAPPDATA%\vigia\state\` on Windows. Never inside the worktree and never inside `.git`, because a monitor that wrote where it watches would wake itself.
 
-### Give the agent the server
+### Setting it up, in one command
 
-`vigia mcp` is an MCP server over stdio, and it belongs to **you** rather than to any one repository. Register it once:
+If you keep your Claude Code setup with [`mcs`](https://github.com/mcs-cli/mcs), the whole of the next section is a package. `techpack.yaml` at the root of this repository is what it reads:
+
+```sh
+mcs pack add breferrari/vigia
+mcs sync --global
+```
+
+That installs the binary, registers the MCP server for your user, and writes all three hooks under `~/.claude/`, so every repository you open from now on is covered. `mcs doctor` names anything missing and the command that fixes it, and running `mcs sync` again after an upgrade puts back whatever moved. macOS and Linux only: the pack installs through Homebrew and its hooks are shell scripts. [`docs/TECHPACK.md`](docs/TECHPACK.md) lists every component and what each one is.
+
+Everything below is what that pack does for you, and it is the route on Windows.
+
+### Setting it up by hand
+
+**1. Give the agent the server.** `vigia mcp` is an MCP server over stdio, and it belongs to **you** rather than to any one repository:
 
 ```sh
 claude mcp add --scope user vigia -- vigia mcp
 ```
 
-That covers every project you open from now on. Claude Code tells the server which project the session is in, so one registration finds whichever worktree you are watching, and the notes are kept per worktree, so two repositories never see each other's.
+One registration covers every project you open from now on. Claude Code tells the server which project the session is in, so it finds whichever worktree you are watching, and notes are kept per worktree, so two repositories never see each other's.
 
-If you keep your Claude Code setup with [`mcs`](https://github.com/mcs-cli/mcs), this registration and the hooks below come as a tech pack instead: [`docs/TECHPACK.md`](docs/TECHPACK.md).
+The agent gets three tools and one resource:
 
-The agent gets three tools and one resource. `notes` lists what is open, each with its line's current number, the line's text and three lines either side, and marks them `seen`. `reply` writes a line under a note and leaves it unresolved. `resolve` closes one, and its line is required, because that line is what you watch arrive. The resource is `vigia://notes`, and the server announces every change to the store, so an agent that subscribes hears about a note the moment you send it.
+| | |
+|---|---|
+| `notes` | Lists what is open, each with its line's current number, the line's text and three lines either side, and marks them `seen` |
+| `reply` | Writes a line under a note and leaves it unresolved |
+| `resolve` | Closes one. Its line is required, because that line is what you watch arrive |
 
-**`--scope project` is the other shape, and it is a decision about your team rather than about you.** It writes a `.mcp.json` at the root of the repository, and you commit it, so everyone who clones gets a `vigia` server whether or not they have `vigia` installed:
+The resource is `vigia://notes`, and the server announces every change to the store, so an agent that subscribes hears about a note the moment you send it.
 
-```json
-{
-  "mcpServers": {
-    "vigia": { "command": "vigia", "args": ["mcp"] }
-  }
-}
-```
-
-Right when the whole team watches its diffs this way, and only then. If it is just you, take the line above.
-
-### And reach the session already running
-
-With the server alone your note waits until the agent next looks. Two hooks make it arrive instead, and they go in `~/.claude/settings.json` for the same reason the server does: write them once, and every repository you open is covered.
+**2. Reach the session already running.** With the server alone your note waits until the agent next looks. Three hooks make it arrive instead, and they go in `~/.claude/settings.json` for the same reason the server does: write them once, and every repository is covered.
 
 ```json
 {
@@ -373,9 +387,28 @@ With the server alone your note waits until the agent next looks. Two hooks make
 }
 ```
 
-`vigia mcp register` records the session's own socket beside the store when it starts and clears it when it ends. `Enter` then posts the note into that session directly, and a session sitting idle starts a turn on it, so the answer can arrive while you are still looking at the line. The footer says **sent** when a socket took the line, **noted** when a session was registered and none took it, and nothing at all when none is registered. Nothing is written back, so *sent* is the honest word: it says the line went, never that it arrived.
+`vigia mcp register` records the session's own socket beside the store when it starts and clears it when it ends. `Enter` then posts the note into that session directly, and a session sitting idle starts a turn on it, so the answer can arrive while you are still looking at the line. The footer says **sent** when a socket took the line, **noted** when a session was registered and none took it, and nothing at all when none is. Nothing is written back, so *sent* is the honest word: it says the line went, never that it arrived.
 
 `vigia mcp pending` is the rung that needs no socket. It puts one line in front of your next prompt saying what your notes are waiting on: a read, a resolve, or you, once the agent has answered one with `reply` and left it with you. Nothing at all when nothing is pending.
+
+<details>
+<summary><b>Registering for a whole team instead</b></summary>
+
+<br>
+
+**`--scope project` is a decision about your team rather than about you.** It writes a `.mcp.json` at the root of the repository, and you commit it, so everyone who clones gets a `vigia` server whether or not they have `vigia` installed:
+
+```json
+{
+  "mcpServers": {
+    "vigia": { "command": "vigia", "args": ["mcp"] }
+  }
+}
+```
+
+Right when the whole team watches its diffs this way, and only then. If it is just you, take the user-scoped line above.
+
+</details>
 
 <details>
 <summary><b>The small print on the hooks</b></summary>

--- a/README.md
+++ b/README.md
@@ -336,28 +336,17 @@ Every note draws under its line with one word for where it stands.
 
 **Where they live.** One directory per worktree under your own state directory: `$XDG_STATE_HOME/vigia/`, or `~/.local/state/vigia/`, and `%LOCALAPPDATA%\vigia\state\` on Windows. Never inside the worktree and never inside `.git`, because a monitor that wrote where it watches would wake itself.
 
-### Setting it up, in one command
+### Setting it up
 
-If you keep your Claude Code setup with [`mcs`](https://github.com/mcs-cli/mcs), the whole of the next section is a package. `techpack.yaml` at the root of this repository is what it reads:
+Two pieces, and both go in your own config rather than in the repository, because `vigia` is yours and so is the pane you run it in.
 
-```sh
-mcs pack add breferrari/vigia
-mcs sync --global
-```
-
-That installs the binary, registers the MCP server for your user, and writes all three hooks under `~/.claude/`, so every repository you open from now on is covered. `mcs doctor` names anything missing and the command that fixes it, and running `mcs sync` again after an upgrade puts back whatever moved. macOS and Linux only: the pack installs through Homebrew and its hooks are shell scripts. [`docs/TECHPACK.md`](docs/TECHPACK.md) lists every component and what each one is.
-
-Everything below is what that pack does for you, and it is the route on Windows.
-
-### Setting it up by hand
-
-**1. Give the agent the server.** `vigia mcp` is an MCP server over stdio, and it belongs to **you** rather than to any one repository:
+**1. Give the agent the server.** `vigia mcp` is an MCP server over stdio:
 
 ```sh
 claude mcp add --scope user vigia -- vigia mcp
 ```
 
-One registration covers every project you open from now on. Claude Code tells the server which project the session is in, so it finds whichever worktree you are watching, and notes are kept per worktree, so two repositories never see each other's.
+`--scope user` writes `~/.claude.json`, which covers **every project you open on this machine** and stays private to you. Claude Code tells the server which project a session is in, so that one registration finds whichever worktree you are watching, and notes are kept per worktree, so two repositories never see each other's.
 
 The agent gets three tools and one resource:
 
@@ -369,7 +358,7 @@ The agent gets three tools and one resource:
 
 The resource is `vigia://notes`, and the server announces every change to the store, so an agent that subscribes hears about a note the moment you send it.
 
-**2. Reach the session already running.** With the server alone your note waits until the agent next looks. Three hooks make it arrive instead, and they go in `~/.claude/settings.json` for the same reason the server does: write them once, and every repository is covered.
+**2. Reach the session already running.** With the server alone your note waits until the agent next looks. Three hooks make it arrive instead, and they go in `~/.claude/settings.json`, which is the same scope as the line above: write them once, and every repository is covered.
 
 ```json
 {
@@ -392,11 +381,29 @@ The resource is `vigia://notes`, and the server announces every change to the st
 `vigia mcp pending` is the rung that needs no socket. It puts one line in front of your next prompt saying what your notes are waiting on: a read, a resolve, or you, once the agent has answered one with `reply` and left it with you. Nothing at all when nothing is pending.
 
 <details>
-<summary><b>Registering for a whole team instead</b></summary>
+<summary><b>Both steps in one command, if you already use <code>mcs</code></b></summary>
 
 <br>
 
-**`--scope project` is a decision about your team rather than about you.** It writes a `.mcp.json` at the root of the repository, and you commit it, so everyone who clones gets a `vigia` server whether or not they have `vigia` installed:
+[`mcs`](https://github.com/mcs-cli/mcs) is a package manager for a Claude Code setup. It is not needed for any of the above and nothing here depends on it. If you already keep your setup that way, `techpack.yaml` at the root of this repository is a pack it can install:
+
+```sh
+mcs pack add breferrari/vigia
+mcs sync --global
+```
+
+**Its `--global` is the scope both steps above already use**, under another name: machine-wide for your user, writing the server into `~/.claude.json` and the hooks into `~/.claude/settings.json`. What it adds is doing both at once, installing the binary with them, and putting back whatever moved when you run `mcs sync` again after an upgrade. `mcs doctor` names anything missing and the command that fixes it.
+
+macOS and Linux only, because the pack installs the binary through Homebrew and its hooks are shell scripts. [`docs/TECHPACK.md`](docs/TECHPACK.md) lists every component and what each one is.
+
+</details>
+
+<details>
+<summary><b>Putting the server in the repository instead</b></summary>
+
+<br>
+
+`--scope project` is the one shape here that reaches anybody but you. It writes a `.mcp.json` at the root of the repository, and you commit it, so everyone who clones gets a `vigia` server whether or not they have `vigia` installed:
 
 ```json
 {
@@ -406,7 +413,7 @@ The resource is `vigia://notes`, and the server announces every change to the st
 }
 ```
 
-Right when the whole team watches its diffs this way, and only then. If it is just you, take the user-scoped line above.
+Right when the whole team watches its diffs this way, and only then. If it is just you, the user-scoped line above is the one, and it already covers every repository on the machine.
 
 </details>
 

--- a/crates/vigia/tests/package.rs
+++ b/crates/vigia/tests/package.rs
@@ -2135,9 +2135,14 @@ fn the_config_doc_teaches_a_config_file_that_parses_and_names_every_key() {
 fn the_readme_key_table_names_every_gesture_a_config_key_reaches() {
     let readme = repo_file("README.md");
 
-    // The table lives inside a `<td>` under a bold caption, and a row's left cell
-    // is what a reader looks for. `sheet.rs::readme_gestures` reads both tables
-    // the same way; only the keyboard one can carry a config key's gesture.
+    // The table follows a bold caption and a row's left cell is what a reader
+    // looks for. `sheet.rs::readme_gestures` reads both tables the same way;
+    // only the keyboard one can carry a config key's gesture.
+    //
+    // The end is the first line that is neither blank nor a row, which is the
+    // table's own shape rather than the markup around it: these were cells of an
+    // HTML table until a nested table could not be made to fit the column, and a
+    // gate anchored on `</td>` reads to the end of the file the day that goes.
     let mut taught: Vec<String> = Vec::new();
     let mut inside = false;
     for line in readme.lines() {
@@ -2146,7 +2151,7 @@ fn the_readme_key_table_names_every_gesture_a_config_key_reaches() {
             inside = true;
             continue;
         }
-        if inside && trimmed.starts_with("</td>") {
+        if inside && !trimmed.is_empty() && !trimmed.starts_with('|') {
             break;
         }
         if !inside || !trimmed.starts_with('|') || trimmed.contains("---") {

--- a/crates/vigia/tests/register.rs
+++ b/crates/vigia/tests/register.rs
@@ -498,25 +498,51 @@ fn markdown() -> Vec<(String, String)> {
         .collect()
 }
 
-/// No prose paragraph in a tracked markdown file spans more than one line.
+/// The fragment of every `](#...)` link in `body`.
+fn in_page_targets(body: &str) -> Vec<String> {
+    body.match_indices("](#")
+        .filter_map(|(at, _)| {
+            let rest = &body[at + 3..];
+            let end = rest.find(')')?;
+            Some(rest[..end].to_owned())
+        })
+        .filter(|target| !target.is_empty())
+        .collect()
+}
+
+/// Every in-page link lands on an anchor the document writes itself.
 ///
-/// A wall rather than a ratchet, because the tree is clean and the class is
-/// mechanical: GitHub renders a single newline inside a paragraph as a real
-/// line break, so a body wrapped at eighty arrives at its reader broken
-/// mid-sentence. 811 forced breaks across sixteen of this repository's own pull
-/// requests before anyone measured it.
+/// A heading's anchor cannot be derived by reading the heading. `## ✍️ Notes
+/// to the agent` loses the writing hand and keeps the variation selector behind
+/// it, so what GitHub generates is that invisible character followed by
+/// `-notes-to-the-agent`. A link typed from the heading looks right on the page
+/// and goes nowhere, and the two spellings cannot be told apart by eye. Five
+/// headings in `README.md` carry an emoji of that shape.
 ///
-/// **Gated rather than written down, because it had been written down twice
-/// and lost twice.** An instruction cannot beat a corpus: these documents held
-/// 7,351 hard-wrapped lines, and a session reads them before it writes
-/// anything. Removing the examples is what makes the rule hold.
-///
-/// Code comments are deliberately out of scope. Nothing renders them, so a
-/// break there corrupts nothing, and they sit beside code held near a hundred
-/// columns where one long line reads worse.
-///
-/// Structure is not prose and is never counted: YAML frontmatter, fenced code,
-/// tables, list items, headings, blockquotes and thematic breaks.
+/// So the rule is the target rather than the spelling. A link to `#x` needs an
+/// `<a id="x">` in the same document, which GitHub rewrites to `user-content-x`
+/// and resolves the fragment against, the path its own heading anchors take.
+#[test]
+fn every_in_page_link_lands_on_an_anchor() {
+    let mut seen = 0usize;
+    for (name, body) in markdown() {
+        for target in in_page_targets(&body) {
+            seen += 1;
+            let written = format!("<a id=\"{target}\">");
+            assert!(
+                body.contains(&written),
+                "{name} links to #{target} and carries no {written}, so the link \
+                 is resolving against a heading slug nobody here can spell"
+            );
+        }
+    }
+    assert!(
+        seen > 0,
+        "no tracked document carries an in-page link, so this gate is passing \
+         over anything"
+    );
+}
+
 /// Every row of a markdown table has the cells its header declared.
 ///
 /// A row one cell short renders as a table with a hole in it, and nothing else
@@ -598,6 +624,25 @@ fn no_table_row_is_missing_a_cell() {
     );
 }
 
+/// No prose paragraph in a tracked markdown file spans more than one line.
+///
+/// A wall rather than a ratchet, because the tree is clean and the class is
+/// mechanical: GitHub renders a single newline inside a paragraph as a real
+/// line break, so a body wrapped at eighty arrives at its reader broken
+/// mid-sentence. 811 forced breaks across sixteen of this repository's own pull
+/// requests before anyone measured it.
+///
+/// **Gated rather than written down, because it had been written down twice
+/// and lost twice.** An instruction cannot beat a corpus: these documents held
+/// 7,351 hard-wrapped lines, and a session reads them before it writes
+/// anything. Removing the examples is what makes the rule hold.
+///
+/// Code comments are deliberately out of scope. Nothing renders them, so a
+/// break there corrupts nothing, and they sit beside code held near a hundred
+/// columns where one long line reads worse.
+///
+/// Structure is not prose and is never counted: YAML frontmatter, fenced code,
+/// tables, list items, headings, blockquotes and thematic breaks.
 #[test]
 fn no_prose_paragraph_is_hard_wrapped() {
     let files = markdown();

--- a/crates/vigia/tests/sheet.rs
+++ b/crates/vigia/tests/sheet.rs
@@ -895,8 +895,13 @@ fn readme_gestures() -> Vec<String> {
     )
     .expect("README.md is where the crate says it is");
 
-    // The two tables live inside one `<td>` each under a bold caption. A row is
-    // `| cell | cell |`, and the left cell is what a reader looks for.
+    // Each table follows a bold caption. A row is `| cell | cell |`, and the left
+    // cell is what a reader looks for.
+    //
+    // A table ends at the first line that is neither blank nor a row. That is the
+    // table's own shape rather than the markup around it: these were cells of an
+    // HTML table until a nested table could not be made to fit the column, and a
+    // gate anchored on `</td>` reads to the end of the file the day that goes.
     let mut out = Vec::new();
     let mut inside = false;
     for line in readme.lines() {
@@ -905,7 +910,7 @@ fn readme_gestures() -> Vec<String> {
             inside = true;
             continue;
         }
-        if inside && trimmed.starts_with("</td>") {
+        if inside && !trimmed.is_empty() && !trimmed.starts_with('|') {
             inside = false;
             continue;
         }


### PR DESCRIPTION
Four things reported from the rendered page, and the gate for the one that no reading catches.

## The gesture tables still ran past the well

Shortening the cells last time was the wrong fix, because the cells were never the cause. The two tables were cells of an HTML table at `width="50%"` each, and **a table cannot wrap**: its minimum width is its own content, so a nested one grows the cell it sits in rather than fitting it, whatever the cells say.

They stack now, full width each, which is also what a phone can render. Checked on the branch at a narrow viewport.

Two gates closed a table on `</td>`, which no longer exists:

- `sheet.rs::readme_gestures`
- `package.rs::the_readme_key_table_names_every_gesture_a_config_key_reaches`

Both now end a table at the first line that is neither blank nor a row, which is the table's own shape rather than the markup around it. `sheet.rs` cross-checks every parsed gesture against the pane's own sheet, so a parser reading the wrong thing fails rather than passes quietly.

## `brew` sat with the prebuilt installers

It is a package manager like `cargo install` and belongs beside it. It moves into step 1 of the tour, and the collapsed block keeps the two curl-and-powershell scripts it is actually about.

## The `one registration` link went nowhere

GitHub's slug for `## ✍️ Notes to the agent` drops the writing hand and **keeps the variation selector behind it**. Fetched from the rendered page, the heading's id is:

```
user-content-<U+FE0F>-notes-to-the-agent
```

The link was `#-notes-to-the-agent`, with no such character. On the page the two are indistinguishable.

An explicit `<a id="notes">` cannot drift that way. GitHub rewrites it to `user-content-notes` and resolves the fragment against it, which is the path its own heading anchors take, and it is now what the link points at.

**Gated, because four more headings carry an emoji of that shape** and the next link typed from one would fail the same silent way. `register.rs::every_in_page_link_lands_on_an_anchor` requires every `](#x)` in a tracked document to have an `<a id="x">` in the same file. The rule is the target rather than the spelling, which is checkable without reimplementing a slugger, and a slugger is exactly the thing that cannot be spelled from memory. Mutated by restoring the old link: red, naming the file and the anchor it wanted.

## The notes section was a wall of text

- The five words a note can carry were one dense paragraph. They are a table.
- The three MCP tools were a sentence. They are a table.
- Setting it up is numbered.
- `--scope project` moves into a fold. It is a decision about a team, and most readers are not making it.
- The setup names **two** scopes rather than three, checked against both sets of documentation. `claude mcp add --scope user` writes `~/.claude.json`, covering every project on this machine and private to your account. `mcs sync --global` is machine-wide for the same user and writes that same file plus `~/.claude/settings.json`. One destination under two names, and a reader with one account on one device has no third tier to pick from.
- **`mcs` is optional and third-party, so it does not lead.** The two steps it automates are the setup, so they come first, and mcs is a fold under them saying so in its first line and naming the two files it writes. Nothing moved out of those steps: the server, its three tools, all three hooks and both `vigia mcp` subcommands are where they were.
- The `--scope project` fold is named for the repository rather than for a team. It writes a committed `.mcp.json`, which is the one shape here that reaches anybody else, and a team is who ends up with it rather than what the flag addresses.

The tour's note example carried the jargon the mockup's did before it was changed, and now carries the same question.

## Also

`no_prose_paragraph_is_hard_wrapped` had no docblock, and its nineteen lines were sitting above `no_table_row_is_missing_a_cell`, describing a gate eighty lines away. Moved onto the gate it is about. Pre-existing, found while adding the one beside it.

## Verification

`--test package --test register --test sheet` green: 33, 7, 56. Clippy clean, fmt clean. The README render checked on GitHub, and the anchors read back out of the rendered HTML rather than guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
